### PR TITLE
fix(history): persist captured output

### DIFF
--- a/crates/sivtr-core/src/history/mod.rs
+++ b/crates/sivtr-core/src/history/mod.rs
@@ -2,4 +2,4 @@ pub mod query;
 pub mod schema;
 pub mod store;
 
-pub use store::HistoryStore;
+pub use store::{CaptureSource, HistoryStore};

--- a/crates/sivtr-core/src/history/query.rs
+++ b/crates/sivtr-core/src/history/query.rs
@@ -28,6 +28,7 @@ impl HistoryStore {
 
     /// Full-text search across history content and commands.
     pub fn search(&self, query: &str, limit: usize) -> Result<Vec<HistoryEntry>> {
+        let fts_query = build_fts_query(query);
         let mut stmt = self.conn.prepare(
             "SELECT h.id, h.content, h.command, h.timestamp, h.hostname, h.session_id, h.source
              FROM history h
@@ -38,7 +39,7 @@ impl HistoryStore {
         )?;
 
         let entries = stmt
-            .query_map(rusqlite::params![query, limit], |row| {
+            .query_map(rusqlite::params![fts_query, limit], |row| {
                 Ok(HistoryEntry {
                     id: row.get(0)?,
                     content: row.get(1)?,
@@ -78,6 +79,38 @@ impl HistoryStore {
             Some(Err(e)) => Err(e.into()),
             None => Ok(None),
         }
+    }
+
+    /// Keep only the most recent `max_entries` entries.
+    /// `0` means unlimited retention.
+    pub fn trim_to_max_entries(&self, max_entries: usize) -> Result<()> {
+        if max_entries == 0 {
+            return Ok(());
+        }
+
+        self.conn.execute(
+            "DELETE FROM history
+             WHERE id NOT IN (
+               SELECT id FROM history ORDER BY id DESC LIMIT ?1
+             )",
+            rusqlite::params![max_entries],
+        )?;
+
+        Ok(())
+    }
+}
+
+fn build_fts_query(query: &str) -> String {
+    let terms: Vec<String> = query
+        .split_whitespace()
+        .filter(|term| !term.is_empty())
+        .map(|term| format!("\"{}\"", term.replace('"', "\"\"")))
+        .collect();
+
+    if terms.is_empty() {
+        "\"\"".to_string()
+    } else {
+        terms.join(" ")
     }
 }
 
@@ -126,6 +159,22 @@ mod tests {
     }
 
     #[test]
+    fn test_fts_search_handles_hyphenated_terms() {
+        let store = HistoryStore::open_memory().unwrap();
+        store
+            .insert(
+                "pipe-history-ok output",
+                Some("echo pipe-history-ok"),
+                CaptureSource::Run,
+            )
+            .unwrap();
+
+        let results = store.search("pipe-history-ok", 10).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].content.contains("pipe-history-ok"));
+    }
+
+    #[test]
     fn test_get_by_id() {
         let store = HistoryStore::open_memory().unwrap();
         let id = store
@@ -135,5 +184,22 @@ mod tests {
         let entry = store.get_by_id(id).unwrap().unwrap();
         assert_eq!(entry.content, "some output");
         assert_eq!(entry.source, "pipe");
+    }
+
+    #[test]
+    fn test_trim_to_max_entries_keeps_newest_rows() {
+        let store = HistoryStore::open_memory().unwrap();
+        store
+            .insert("old output", Some("echo old"), CaptureSource::Run)
+            .unwrap();
+        store
+            .insert("new output", Some("echo new"), CaptureSource::Run)
+            .unwrap();
+
+        store.trim_to_max_entries(1).unwrap();
+
+        let entries = store.list_recent(10).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].content, "new output");
     }
 }

--- a/src/commands/capture_history.rs
+++ b/src/commands/capture_history.rs
@@ -1,0 +1,102 @@
+use anyhow::Result;
+use sivtr_core::config::SivtrConfig;
+use sivtr_core::history::{CaptureSource, HistoryStore};
+
+pub fn maybe_save_default(
+    config: &SivtrConfig,
+    content: &str,
+    command: Option<&str>,
+    source: CaptureSource,
+) -> Result<()> {
+    let store = HistoryStore::open_default()?;
+    maybe_save(&store, config, content, command, source)
+}
+
+fn maybe_save(
+    store: &HistoryStore,
+    config: &SivtrConfig,
+    content: &str,
+    command: Option<&str>,
+    source: CaptureSource,
+) -> Result<()> {
+    if !config.history.auto_save || content.trim().is_empty() {
+        return Ok(());
+    }
+
+    store.insert(content, command, source)?;
+    store.trim_to_max_entries(config.history.max_entries)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn saves_capture_when_auto_save_is_enabled() {
+        let store = HistoryStore::open_memory().unwrap();
+        let config = SivtrConfig::default();
+
+        maybe_save(
+            &store,
+            &config,
+            "captured output",
+            Some("echo captured"),
+            CaptureSource::Run,
+        )
+        .unwrap();
+
+        let entries = store.list_recent(10).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].command.as_deref(), Some("echo captured"));
+        assert_eq!(entries[0].source, "run");
+    }
+
+    #[test]
+    fn skips_save_when_auto_save_is_disabled() {
+        let store = HistoryStore::open_memory().unwrap();
+        let mut config = SivtrConfig::default();
+        config.history.auto_save = false;
+
+        maybe_save(
+            &store,
+            &config,
+            "captured output",
+            Some("echo captured"),
+            CaptureSource::Run,
+        )
+        .unwrap();
+
+        let entries = store.list_recent(10).unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn trims_history_to_configured_limit() {
+        let store = HistoryStore::open_memory().unwrap();
+        let mut config = SivtrConfig::default();
+        config.history.max_entries = 1;
+
+        maybe_save(
+            &store,
+            &config,
+            "first output",
+            Some("echo first"),
+            CaptureSource::Run,
+        )
+        .unwrap();
+        maybe_save(
+            &store,
+            &config,
+            "second output",
+            Some("echo second"),
+            CaptureSource::Pipe,
+        )
+        .unwrap();
+
+        let entries = store.list_recent(10).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].content, "second output");
+        assert_eq!(entries[0].source, "pipe");
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod browse;
+pub mod capture_history;
 pub mod clear;
 pub mod command_block_selector;
 pub mod config;

--- a/src/commands/pipe.rs
+++ b/src/commands/pipe.rs
@@ -3,9 +3,10 @@ use sivtr_core::buffer::Buffer;
 use sivtr_core::capture::pipe::read_stdin;
 use sivtr_core::config::{OpenMode, SivtrConfig};
 use sivtr_core::export::editor;
+use sivtr_core::history::CaptureSource;
 use sivtr_core::parse;
 
-use super::browse;
+use super::{browse, capture_history};
 use crate::app::App;
 
 /// Execute pipe mode: read from stdin, then open based on config.
@@ -18,6 +19,11 @@ pub fn execute() -> Result<()> {
     }
 
     let config = SivtrConfig::load().unwrap_or_default();
+    if let Err(error) =
+        capture_history::maybe_save_default(&config, &raw, None, CaptureSource::Pipe)
+    {
+        eprintln!("sivtr: failed to save history: {error:#}");
+    }
 
     match config.general.open_mode {
         OpenMode::Editor => {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -3,9 +3,10 @@ use sivtr_core::buffer::Buffer;
 use sivtr_core::capture::subprocess;
 use sivtr_core::config::{OpenMode, SivtrConfig};
 use sivtr_core::export::editor;
+use sivtr_core::history::CaptureSource;
 use sivtr_core::parse;
 
-use super::browse;
+use super::{browse, capture_history};
 use crate::app::App;
 
 /// Execute a command, capture its output, then open based on config.
@@ -26,6 +27,15 @@ pub fn execute(command: &str, args: &[String]) -> Result<()> {
     }
 
     let config = SivtrConfig::load().unwrap_or_default();
+    let command_line = render_command_line(command, args);
+    if let Err(error) = capture_history::maybe_save_default(
+        &config,
+        &result.combined,
+        Some(command_line.as_str()),
+        CaptureSource::Run,
+    ) {
+        eprintln!("sivtr: failed to save history: {error:#}");
+    }
 
     match config.general.open_mode {
         OpenMode::Editor => {
@@ -41,5 +51,13 @@ pub fn execute(command: &str, args: &[String]) -> Result<()> {
             app.config = config;
             browse::run_tui(&mut app, false)
         }
+    }
+}
+
+fn render_command_line(command: &str, args: &[String]) -> String {
+    if args.is_empty() {
+        command.to_string()
+    } else {
+        format!("{command} {}", args.join(" "))
     }
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -11,7 +11,8 @@ use crate::app::App;
 
 /// Execute a command, capture its output, then open based on config.
 pub fn execute(command: &str, args: &[String]) -> Result<()> {
-    eprintln!("sivtr: running `{} {}`", command, args.join(" "));
+    let command_line = render_command_line(command, args);
+    eprintln!("sivtr: running `{command_line}`");
 
     let result = subprocess::run_and_capture(command, args)?;
 
@@ -27,7 +28,6 @@ pub fn execute(command: &str, args: &[String]) -> Result<()> {
     }
 
     let config = SivtrConfig::load().unwrap_or_default();
-    let command_line = render_command_line(command, args);
     if let Err(error) = capture_history::maybe_save_default(
         &config,
         &result.combined,
@@ -55,9 +55,56 @@ pub fn execute(command: &str, args: &[String]) -> Result<()> {
 }
 
 fn render_command_line(command: &str, args: &[String]) -> String {
-    if args.is_empty() {
-        command.to_string()
-    } else {
-        format!("{command} {}", args.join(" "))
+    std::iter::once(command)
+        .chain(args.iter().map(String::as_str))
+        .map(quote_shell_token)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn quote_shell_token(value: &str) -> String {
+    if !value.is_empty() && value.chars().all(is_shell_safe_char) {
+        return value.to_string();
+    }
+
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn is_shell_safe_char(ch: char) -> bool {
+    matches!(
+        ch,
+        'A'..='Z'
+            | 'a'..='z'
+            | '0'..='9'
+            | '_'
+            | '.'
+            | '/'
+            | ':'
+            | '@'
+            | '%'
+            | '+'
+            | '='
+            | ','
+            | '-'
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::render_command_line;
+
+    #[test]
+    fn quotes_arguments_with_spaces() {
+        let rendered =
+            render_command_line("echo", &["hello world".to_string(), "plain".to_string()]);
+
+        assert_eq!(rendered, "echo 'hello world' plain");
+    }
+
+    #[test]
+    fn escapes_single_quotes_inside_arguments() {
+        let rendered = render_command_line("printf", &["it's fine".to_string()]);
+
+        assert_eq!(rendered, "printf 'it'\\''s fine'");
     }
 }


### PR DESCRIPTION
## Title: Fix: persist captured output to history

### 1. Context & Motivation (Context)
- **Issue:** N/A (no existing issue found)
- **Problem:** `sivtr run` and pipe mode exposed history/config documentation, but captured output was never written to the SQLite history store. That made `history list/search/show`, `history.auto_save`, and `history.max_entries` ineffective in real CLI flows.
- **Trade-offs:** This persists captures at the `run`/`pipe` command boundary instead of hiding it inside the storage layer. That keeps the source and original command context available with minimal control-flow changes, at the cost of one small helper module and one extra database write per saved capture.

### 2. Implementation Details (Implementation)
- Added a dedicated `capture_history` helper and wired it into `run` and `pipe`, so successful captures can be stored with the correct `CaptureSource` and command text.
- Added `trim_to_max_entries` to enforce `history.max_entries` immediately after inserts, and kept `auto_save = false` as a hard opt-out path.
- Hardened history FTS queries by quoting user terms before `MATCH`, so values like `pipe-history-ok` behave as plain search input instead of SQLite FTS syntax.
- **Note:** This PR intentionally does not include the unrelated `run` parser fix for leading hyphen arguments or the non-Windows clippy cleanup; those were split into separate branches to keep the diff atomic.

### 3. Testing Strategies (Validation)
- [x] Added Unit Tests for `capture_history::maybe_save` and `HistoryStore` query/retention helpers (covering `auto_save`, `max_entries`, and hyphenated search terms)
- [x] Ran Integration Test Suite against the workspace with `cargo test --workspace`
- [x] Verified backward compatibility with existing history commands by smoke-testing `run -> history list -> history search` using editor mode to avoid interactive TUI dependency
- [x] Benchmark not applicable (no hot-path algorithmic change or new dependency)
