### PR TITLE
fix(cli): accept hyphenated run args

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -177,7 +177,7 @@ pub enum Commands {
         /// The command to run
         command: String,
         /// Arguments to pass to the command
-        #[arg(trailing_var_arg = true)]
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
 
@@ -575,6 +575,19 @@ mod tests {
         match cli.command {
             Some(Commands::HotkeyPickCodex(args)) => assert_eq!(args.cwd, PathBuf::from(".")),
             _ => panic!("expected hotkey-pick-codex command"),
+        }
+    }
+
+    #[test]
+    fn run_accepts_hyphen_prefixed_child_args_without_separator() {
+        let cli = Cli::try_parse_from(["sivtr", "run", "bash", "-lc", "printf ok"]).unwrap();
+
+        match cli.command {
+            Some(Commands::Run { command, args }) => {
+                assert_eq!(command, "bash");
+                assert_eq!(args, vec!["-lc".to_string(), "printf ok".to_string()]);
+            }
+            _ => panic!("expected run command"),
         }
     }
 }


### PR DESCRIPTION
## Title: Fix: accept hyphenated child args in run

### 1. Context & Motivation (Context)
- **Issue:** N/A (no existing issue found)
- **Problem:** `sivtr run` rejected child-command arguments like `-lc` because Clap treated them as top-level `sivtr` flags. That forced users to insert an extra `--` even for common shell invocations.
- **Trade-offs:** This relaxes parsing only for the `run` subcommand's trailing argv. It preserves existing CLI structure while improving shell ergonomics, at the cost of allowing hyphen-prefixed values in that one trailing argument vector.

### 2. Implementation Details (Implementation)
- Enabled `allow_hyphen_values` for `Commands::Run.args`, while keeping `trailing_var_arg = true` so ownership stays constrained to the child command argv.
- Added a parser regression test that covers `sivtr run bash -lc 'printf ok'` without requiring an extra separator.
- **Note:** This PR intentionally avoids the unrelated history persistence fix and non-Windows clippy cleanup to keep reviewer focus on one CLI parsing change.

### 3. Testing Strategies (Validation)
- [x] Added Unit Tests for `Commands::Run` parsing (covering hyphen-prefixed child args)
- [x] Ran Integration Test Suite against the workspace with `cargo test --workspace`
- [x] Verified backward compatibility with existing `run` behavior by smoke-testing `cargo run -- run bash -lc 'printf ...'` in editor mode
- [x] Benchmark not applicable (parser-only change, no hot-path runtime impact)
