### PR TITLE
ci(clippy): silence non-windows warnings

### DIFF
--- a/src/commands/flush.rs
+++ b/src/commands/flush.rs
@@ -1,7 +1,11 @@
 use anyhow::Result;
+
+#[cfg(windows)]
 use std::env;
 
+#[cfg(windows)]
 use sivtr_core::capture::scrollback;
+#[cfg(windows)]
 use sivtr_core::session::{self, SessionEntry, SessionState};
 
 /// Flush: read console buffer, append new content to session.log.

--- a/src/commands/hotkey.rs
+++ b/src/commands/hotkey.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use sivtr_core::config::SivtrConfig;
 use std::path::{Path, PathBuf};
+#[cfg(windows)]
 use std::process::Command;
 
 use crate::cli::{
@@ -257,6 +258,7 @@ fn read_state() -> Result<Option<HotkeyState>> {
     Ok(Some(state))
 }
 
+#[cfg(windows)]
 fn write_state(state: &HotkeyState) -> Result<()> {
     let path = state_path()?;
     if let Some(parent) = path.parent() {


### PR DESCRIPTION
## Title: CI: silence non-Windows clippy warnings

### 1. Context & Motivation (Context)
- **Issue:** N/A (no existing issue found)
- **Problem:** Non-Windows builds flagged Windows-only imports and helpers in `flush` and `hotkey` as unused, which breaks `cargo clippy --workspace --all-targets -- -D warnings` on Linux.
- **Trade-offs:** This uses `#[cfg(windows)]` at the import/helper boundary instead of blanket `allow` attributes. That keeps the warning surface honest and avoids changing runtime behavior, at the cost of a few extra conditional annotations.

### 2. Implementation Details (Implementation)
- Guarded Windows-only imports in `flush.rs` and `hotkey.rs` so non-Windows builds stop compiling obviously-unused symbols into those targets.
- Guarded `write_state` with `#[cfg(windows)]` because its only call path lives inside the Windows hotkey daemon flow.
- **Note:** This PR intentionally excludes history persistence and CLI parser behavior changes; those were split into separate branches to avoid drive-by fixes.

### 3. Testing Strategies (Validation)
- [x] Added Unit Tests for `N/A` (behavior unchanged; existing suite covers affected modules)
- [x] Ran Integration Test Suite against the workspace with `cargo test --workspace`
- [x] Verified backward compatibility with Windows-only code paths by preserving all existing `cfg(windows)` call sites and running `cargo clippy --workspace --all-targets -- -D warnings` on non-Windows
- [x] Benchmark not applicable (no runtime-path change)
