### PR TITLE
feat(codex): add shared read-only session mirroring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,6 +1286,7 @@ dependencies = [
  "serde_json",
  "similar",
  "sivtr-core",
+ "tempfile",
  "tokio",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,6 @@ serde_json = "1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["fileapi", "handleapi", "processenv", "processthreadsapi", "winbase", "winnt", "winuser", "windef", "minwindef"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ sivtr copy out --lines 10:40
 
 ### Reuse Codex Sessions
 
-`sivtr copy codex` reads Codex rollout JSONL files from `~/.codex/sessions` and chooses the newest session whose `cwd` matches your current directory.
+`sivtr copy codex` reads Codex rollout JSONL files from `~/.codex/sessions`. When an active Codex shell exports `CODEX_THREAD_ID`, `sivtr` prefers that exact local session first. Otherwise it chooses the newest local session whose `cwd` matches your current directory.
+
+For shared read-only access to another account's Codex sessions, mirror them into a separate directory and add that directory to `[codex].session_dirs` instead of running `sivtr` with elevated privileges. Shared/mirrored trees only participate in explicit browsing through `--pick`.
 
 ```bash
 sivtr copy codex        # latest completed user + assistant turn
@@ -157,9 +159,23 @@ sivtr copy codex out    # latest assistant reply
 sivtr copy codex in     # latest user message
 sivtr copy codex tool   # latest tool output
 sivtr copy codex all    # parsed session
+sivtr copy codex --pick # browse local and mirrored sessions
 ```
 
 Progress commentary is filtered by default, so `sivtr copy codex out` returns the final assistant reply instead of intermediate status updates.
+
+Mirror the current account's sessions into a shared tree:
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex --watch
+```
+
+Then point another account at that mirrored tree:
+
+```toml
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+```
 
 ### VS Code Shortcut
 
@@ -197,6 +213,7 @@ The default shortcut is `alt+y`.
 | `sivtr run <command>` | Execute a command, capture output, then browse it. |
 | `sivtr copy` | Copy recent command blocks. |
 | `sivtr copy codex` | Copy useful content from the current Codex session. |
+| `sivtr codex export --dest <path>` | Mirror local Codex sessions into a shared read-only tree. |
 | `sivtr diff <left> <right>` | Compare recent command blocks. |
 | `sivtr history` | List, search, and show captured output history. |
 | `sivtr config` | Manage the TOML config file. |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -149,7 +149,9 @@ sivtr copy out --lines 10:40
 
 ### 复用 Codex 会话
 
-`sivtr copy codex` 会读取 `~/.codex/sessions` 下的 Codex rollout JSONL 文件，并优先选择 `cwd` 与当前目录匹配的最新会话。
+`sivtr copy codex` 会读取 `~/.codex/sessions` 下的 Codex rollout JSONL 文件。如果当前 Codex shell 暴露了 `CODEX_THREAD_ID`，`sivtr` 会优先匹配这个本地精确会话；否则会优先选择 `cwd` 与当前目录匹配的最新本地会话。
+
+如果要只读共享另一个账号的 Codex 会话，推荐先把它们镜像到独立目录，再通过 `[codex].session_dirs` 读取，而不是用提权方式运行 `sivtr`。共享/镜像目录只参与 `--pick` 这类显式浏览，不会抢占当前本地会话解析。
 
 ```bash
 sivtr copy codex        # 最近一轮用户消息 + 助手回复
@@ -157,9 +159,23 @@ sivtr copy codex out    # 最近助手回复
 sivtr copy codex in     # 最近用户消息
 sivtr copy codex tool   # 最近工具输出
 sivtr copy codex all    # 整个解析后的会话
+sivtr copy codex --pick # 浏览本地和共享镜像会话
 ```
 
 默认会过滤过程性 commentary，所以 `sivtr copy codex out` 更倾向返回最终助手回复，而不是中间状态更新。
+
+先把当前账号的会话持续镜像成共享树：
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex --watch
+```
+
+再让另一个账号在配置里引用镜像目录：
+
+```toml
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+```
 
 ### VS Code 快捷键
 
@@ -197,6 +213,7 @@ sivtr hotkey stop
 | `sivtr run <command>` | 执行命令、捕获输出并浏览。 |
 | `sivtr copy` | 复制最近命令块。 |
 | `sivtr copy codex` | 复制当前 Codex 会话中的有用内容。 |
+| `sivtr codex export --dest <path>` | 把本地 Codex 会话镜像成共享只读目录树。 |
 | `sivtr diff <left> <right>` | 对比最近命令输出。 |
 | `sivtr history` | 列出、搜索、查看输出历史。 |
 | `sivtr config` | 管理 TOML 配置。 |

--- a/crates/sivtr-core/src/ai.rs
+++ b/crates/sivtr-core/src/ai.rs
@@ -233,13 +233,19 @@ pub fn parse_jsonl_session(
             continue;
         }
 
-        let value: Value = serde_json::from_str(&line).with_context(|| {
-            format!(
-                "Failed to parse {provider_name} session line {} as JSON: {}",
-                idx + 1,
-                path.display()
-            )
-        })?;
+        let value: Value = match serde_json::from_str(&line) {
+            Ok(value) => value,
+            Err(error) if idx > 0 && is_trailing_partial_json_line(&error) => break,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "Failed to parse {provider_name} session line {} as JSON: {}",
+                        idx + 1,
+                        path.display()
+                    )
+                });
+            }
+        };
         apply_event(&mut session, &value);
     }
 
@@ -372,6 +378,10 @@ fn normalize_path_for_match(path: &Path) -> String {
         .to_string_lossy()
         .replace('/', "\\")
         .to_lowercase()
+}
+
+fn is_trailing_partial_json_line(error: &serde_json::Error) -> bool {
+    matches!(error.classify(), serde_json::error::Category::Eof)
 }
 
 pub fn select_blocks(session: &AgentSession, selection: AgentSelection) -> Vec<AgentBlock> {

--- a/crates/sivtr-core/src/codex.rs
+++ b/crates/sivtr-core/src/codex.rs
@@ -1,12 +1,14 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde_json::Value;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 use crate::ai::{
     extract_content_text, list_recent_jsonl_sessions, parse_jsonl_meta, parse_jsonl_session,
     pretty_json_string, pretty_json_value, push_block, AgentBlockKind, AgentProvider, AgentSession,
     AgentSessionInfo, AgentSessionMeta, AgentSessionProvider,
 };
+use crate::config::SivtrConfig;
 
 const PROVIDER_NAME: &str = "Codex";
 
@@ -19,11 +21,74 @@ impl AgentSessionProvider for CodexProvider {
     }
 
     fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
-        list_recent_jsonl_sessions(&codex_home().join("sessions"), cwd, parse_session_meta)
+        let wanted = cwd.map(normalize_path_for_match);
+        let mut sessions = Vec::new();
+
+        for root in configured_codex_session_dirs() {
+            for path in jsonl_files(&root)? {
+                let meta = parse_session_meta(&path)?;
+                if let Some(wanted) = wanted.as_deref() {
+                    let matches_cwd = meta
+                        .cwd
+                        .as_deref()
+                        .map(|cwd| normalize_path_for_match(Path::new(cwd)) == wanted)
+                        .unwrap_or(false);
+                    if !matches_cwd {
+                        continue;
+                    }
+                }
+
+                sessions.push(AgentSessionInfo {
+                    modified: std::fs::metadata(&path)
+                        .and_then(|meta| meta.modified())
+                        .unwrap_or(SystemTime::UNIX_EPOCH),
+                    path,
+                    id: meta.id,
+                    cwd: meta.cwd,
+                });
+            }
+        }
+
+        sessions.sort_by_key(|session| session.modified);
+        sessions.reverse();
+        Ok(sessions)
     }
 
     fn parse_session_file(&self, path: &Path) -> Result<AgentSession> {
         parse_jsonl_session(path, PROVIDER_NAME, apply_event)
+    }
+
+    fn find_session_by_id(&self, id: &str) -> Result<Option<PathBuf>> {
+        for path in local_session_files()? {
+            if path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.contains(id))
+            {
+                return Ok(Some(path));
+            }
+
+            if parse_session_meta(&path)?.id.as_deref() == Some(id) {
+                return Ok(Some(path));
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn find_current_session(&self, cwd: &Path) -> Result<Option<PathBuf>> {
+        if let Some(path) = find_current_thread_session()? {
+            return Ok(Some(path));
+        }
+
+        if let Some(session) = list_recent_local_sessions(Some(cwd))?.into_iter().next() {
+            return Ok(Some(session.path));
+        }
+
+        Ok(list_recent_local_sessions(None)?
+            .into_iter()
+            .next()
+            .map(|session| session.path))
     }
 }
 
@@ -35,6 +100,29 @@ pub fn codex_home() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".codex")
+}
+
+pub fn local_codex_sessions_dir() -> PathBuf {
+    codex_home().join("sessions")
+}
+
+pub fn configured_codex_session_dirs() -> Vec<PathBuf> {
+    let mut dirs = vec![local_codex_sessions_dir()];
+
+    if let Ok(extra) = std::env::var("SIVTR_CODEX_SESSION_DIRS") {
+        let separator = if cfg!(windows) { ';' } else { ':' };
+        dirs.extend(
+            extra
+                .split(separator)
+                .map(str::trim)
+                .filter(|entry| !entry.is_empty())
+                .map(PathBuf::from),
+        );
+    } else if let Ok(config) = SivtrConfig::load() {
+        dirs.extend(config.codex.session_dirs);
+    }
+
+    dedup_paths(dirs)
 }
 
 fn parse_session_meta(path: &Path) -> Result<AgentSessionMeta> {
@@ -128,12 +216,79 @@ fn extract_tool_call_text(payload: &Value) -> String {
     }
 }
 
+fn local_session_files() -> Result<Vec<PathBuf>> {
+    jsonl_files(&local_codex_sessions_dir())
+}
+
+fn list_recent_local_sessions(cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+    list_recent_jsonl_sessions(&local_codex_sessions_dir(), cwd, parse_session_meta)
+}
+
+fn find_current_thread_session() -> Result<Option<PathBuf>> {
+    let Ok(thread_id) = std::env::var("CODEX_THREAD_ID") else {
+        return Ok(None);
+    };
+
+    let thread_id = thread_id.trim();
+    if thread_id.is_empty() {
+        return Ok(None);
+    }
+
+    CodexProvider.find_session_by_id(thread_id)
+}
+
+fn dedup_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut deduped = Vec::new();
+    for path in paths {
+        if deduped.iter().any(|existing| existing == &path) {
+            continue;
+        }
+        deduped.push(path);
+    }
+    deduped
+}
+
+fn jsonl_files(root: &Path) -> Result<Vec<PathBuf>> {
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut files = Vec::new();
+    collect_jsonl_files(root, &mut files)?;
+    Ok(files)
+}
+
+fn collect_jsonl_files(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in
+        std::fs::read_dir(dir).with_context(|| format!("Failed to read {}", dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_jsonl_files(&path, files)?;
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("jsonl") {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn normalize_path_for_match(path: &Path) -> String {
+    path.canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .replace('/', "\\")
+        .to_lowercase()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::CodexProvider;
+    use super::{configured_codex_session_dirs, CodexProvider};
     use crate::ai::{
         format_blocks, select_blocks, AgentBlockKind, AgentSelection, AgentSessionProvider,
     };
+    use serde_json::json;
+    use std::{env, path::PathBuf, time::Duration};
 
     #[test]
     fn parses_codex_rollout_messages_and_tools() {
@@ -208,5 +363,179 @@ mod tests {
 
         assert_eq!(session.blocks.len(), 2);
         assert_eq!(blocks[0].text, "real answer");
+    }
+
+    #[test]
+    fn find_current_session_prefers_codex_thread_id_over_cwd_match() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_home = temp.path().join("codex-home");
+        let sessions_dir = codex_home
+            .join("sessions")
+            .join("2026")
+            .join("05")
+            .join("07");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+
+        let cwd_match = temp.path().join("cwd-match");
+        let thread_match = temp.path().join("thread-match");
+        std::fs::create_dir_all(&cwd_match).unwrap();
+        std::fs::create_dir_all(&thread_match).unwrap();
+
+        let cwd_session = sessions_dir.join("rollout-cwd.jsonl");
+        std::fs::write(
+            &cwd_session,
+            format!(
+                "{}\n",
+                serde_json::to_string(&json!({
+                    "type": "session_meta",
+                    "payload": { "id": "cwd-session", "cwd": cwd_match }
+                }))
+                .unwrap()
+            ),
+        )
+        .unwrap();
+        std::thread::sleep(Duration::from_millis(5));
+
+        let thread_session = sessions_dir.join("rollout-thread.jsonl");
+        std::fs::write(
+            &thread_session,
+            format!(
+                "{}\n",
+                serde_json::to_string(&json!({
+                    "type": "session_meta",
+                    "payload": { "id": "thread-session", "cwd": thread_match }
+                }))
+                .unwrap()
+            ),
+        )
+        .unwrap();
+
+        let previous_codex_home = env::var_os("CODEX_HOME");
+        let previous_thread_id = env::var_os("CODEX_THREAD_ID");
+        env::set_var("CODEX_HOME", &codex_home);
+        env::set_var("CODEX_THREAD_ID", "thread-session");
+
+        let resolved = CodexProvider.find_current_session(&cwd_match).unwrap();
+
+        match previous_codex_home {
+            Some(value) => env::set_var("CODEX_HOME", value),
+            None => env::remove_var("CODEX_HOME"),
+        }
+        match previous_thread_id {
+            Some(value) => env::set_var("CODEX_THREAD_ID", value),
+            None => env::remove_var("CODEX_THREAD_ID"),
+        }
+
+        assert_eq!(resolved, Some(thread_session));
+    }
+
+    #[test]
+    fn configured_codex_session_dirs_reads_env_override_once() {
+        let previous = env::var_os("SIVTR_CODEX_SESSION_DIRS");
+        env::set_var("SIVTR_CODEX_SESSION_DIRS", "/tmp/a:/tmp/b:/tmp/a");
+
+        let dirs = configured_codex_session_dirs();
+
+        match previous {
+            Some(value) => env::set_var("SIVTR_CODEX_SESSION_DIRS", value),
+            None => env::remove_var("SIVTR_CODEX_SESSION_DIRS"),
+        }
+
+        assert!(dirs.contains(&PathBuf::from("/tmp/a")));
+        assert!(dirs.contains(&PathBuf::from("/tmp/b")));
+        assert_eq!(
+            dirs.iter()
+                .filter(|path| *path == &PathBuf::from("/tmp/a"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn list_recent_sessions_includes_exported_session_dirs() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_home = temp.path().join("codex-home");
+        let local_sessions = codex_home
+            .join("sessions")
+            .join("2026")
+            .join("05")
+            .join("07");
+        let exported_root = temp.path().join("shared-export");
+        let exported_sessions = exported_root
+            .join("sessions")
+            .join("2026")
+            .join("05")
+            .join("06");
+        std::fs::create_dir_all(&local_sessions).unwrap();
+        std::fs::create_dir_all(&exported_sessions).unwrap();
+
+        let local_path = local_sessions.join("rollout-local.jsonl");
+        std::fs::write(
+            &local_path,
+            serde_json::to_string(&json!({
+                "type": "session_meta",
+                "payload": { "id": "local-session", "cwd": "/tmp/local" }
+            }))
+            .unwrap()
+                + "\n",
+        )
+        .unwrap();
+
+        std::thread::sleep(Duration::from_millis(5));
+
+        let exported_path = exported_sessions.join("rollout-exported.jsonl");
+        std::fs::write(
+            &exported_path,
+            serde_json::to_string(&json!({
+                "type": "session_meta",
+                "payload": { "id": "exported-session", "cwd": "/tmp/exported" }
+            }))
+            .unwrap()
+                + "\n",
+        )
+        .unwrap();
+
+        let previous_codex_home = env::var_os("CODEX_HOME");
+        let previous_dirs = env::var_os("SIVTR_CODEX_SESSION_DIRS");
+        env::set_var("CODEX_HOME", &codex_home);
+        env::set_var("SIVTR_CODEX_SESSION_DIRS", exported_root.join("sessions"));
+
+        let sessions = CodexProvider.list_recent_sessions(None).unwrap();
+
+        match previous_codex_home {
+            Some(value) => env::set_var("CODEX_HOME", value),
+            None => env::remove_var("CODEX_HOME"),
+        }
+        match previous_dirs {
+            Some(value) => env::set_var("SIVTR_CODEX_SESSION_DIRS", value),
+            None => env::remove_var("SIVTR_CODEX_SESSION_DIRS"),
+        }
+
+        assert_eq!(sessions.len(), 2);
+        assert_eq!(sessions[0].id.as_deref(), Some("exported-session"));
+        assert_eq!(sessions[1].id.as_deref(), Some("local-session"));
+        assert_eq!(sessions[0].path, exported_path);
+        assert_eq!(sessions[1].path, local_path);
+    }
+
+    #[test]
+    fn parses_session_when_last_json_line_is_still_incomplete() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"type":"session_meta","payload":{"id":"abc","cwd":"/tmp/repo"}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"text":"hello"}]}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"text":"done"}]}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"text":"partial"#,
+        )
+        .unwrap();
+
+        let session = CodexProvider.parse_session_file(&path).unwrap();
+
+        assert_eq!(session.id.as_deref(), Some("abc"));
+        assert_eq!(session.blocks.len(), 2);
+        assert_eq!(session.blocks[0].text, "hello");
+        assert_eq!(session.blocks[1].text, "done");
     }
 }

--- a/crates/sivtr-core/src/codex.rs
+++ b/crates/sivtr-core/src/codex.rs
@@ -432,7 +432,11 @@ mod tests {
     #[test]
     fn configured_codex_session_dirs_reads_env_override_once() {
         let previous = env::var_os("SIVTR_CODEX_SESSION_DIRS");
-        env::set_var("SIVTR_CODEX_SESSION_DIRS", "/tmp/a:/tmp/b:/tmp/a");
+        let separator = if cfg!(windows) { ";" } else { ":" };
+        env::set_var(
+            "SIVTR_CODEX_SESSION_DIRS",
+            format!("/tmp/a{separator}/tmp/b{separator}/tmp/a"),
+        );
 
         let dirs = configured_codex_session_dirs();
 

--- a/crates/sivtr-core/src/config/mod.rs
+++ b/crates/sivtr-core/src/config/mod.rs
@@ -16,6 +16,8 @@ pub struct SivtrConfig {
     pub history: HistoryConfig,
     /// Copy command settings.
     pub copy: CopyConfig,
+    /// Codex session settings.
+    pub codex: CodexConfig,
     /// Global hotkey settings.
     pub hotkey: HotkeyConfig,
 }
@@ -77,6 +79,14 @@ impl CopyConfig {
     pub fn prompt_values(&self) -> impl Iterator<Item = &String> {
         self.legacy_prompt_presets.iter().chain(self.prompts.iter())
     }
+}
+
+/// Codex session configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CodexConfig {
+    /// Additional directories that contain exported Codex session JSONL trees.
+    pub session_dirs: Vec<PathBuf>,
 }
 
 /// Global hotkey configuration.
@@ -218,5 +228,21 @@ mod tests {
 
         assert!(toml.contains("[hotkey]"));
         assert!(toml.contains("chord = \"alt+y\""));
+    }
+
+    #[test]
+    fn serializes_codex_config() {
+        let config = SivtrConfig {
+            codex: CodexConfig {
+                session_dirs: vec![PathBuf::from("/srv/sivtr/root-codex/sessions")],
+            },
+            ..SivtrConfig::default()
+        };
+
+        let toml = to_toml_string(&config).unwrap();
+
+        assert!(toml.contains("[codex]"));
+        assert!(toml.contains("session_dirs = ["));
+        assert!(toml.contains("/srv/sivtr/root-codex/sessions"));
     }
 }

--- a/docs-site/src/content/docs/reference/config-file.md
+++ b/docs-site/src/content/docs/reference/config-file.md
@@ -32,6 +32,9 @@ max_entries = 0
 [copy]
 prompts = ["PS C:\\repo> ", "dev>"]
 
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+
 [hotkey]
 chord = "alt+y"
 ```
@@ -94,6 +97,17 @@ prompts = []
 | `prompts` | string array | `[]` | Prompt profiles or literal prefixes used when detecting command lines |
 
 `prompt_presets` is a legacy field and is not serialized by the current config writer.
+
+## codex
+
+```toml
+[codex]
+session_dirs = []
+```
+
+| Key | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `session_dirs` | string array | `[]` | Extra exported Codex `sessions` directories to browse with `copy codex --pick` |
 
 ## hotkey
 

--- a/docs-site/src/content/docs/usage/codex-capture.md
+++ b/docs-site/src/content/docs/usage/codex-capture.md
@@ -3,7 +3,9 @@ title: Codex Capture
 description: Copy useful blocks from the current Codex session.
 ---
 
-`sivtr copy codex` reads Codex rollout JSONL files from `~/.codex/sessions`. By default it chooses the newest session whose `cwd` matches the current working directory.
+`sivtr copy codex` reads Codex rollout JSONL files from `~/.codex/sessions`. If the current shell exports `CODEX_THREAD_ID`, `sivtr` prefers that exact local session first. Otherwise it chooses the newest local session whose `cwd` matches the current working directory.
+
+If another account publishes a read-only mirror with `sivtr codex export --dest ...`, add that mirrored `sessions` directory to `[codex].session_dirs` so explicit `--pick` browsing can read it without elevated privileges.
 
 This is useful when you want to reuse the last answer, input, tool output, or whole parsed session without opening the Codex transcript manually.
 
@@ -62,11 +64,29 @@ sivtr copy codex out --print
 ```bash
 sivtr copy codex --pick
 sivtr copy codex out --pick
+sivtr copy codex --pick  # includes mirrored session trees from [codex].session_dirs
 ```
 
 The plain CLI picker starts with the session list, then lets you choose one or more units from that session. Press `t` to open the Vim-style view. In Codex views, `T` toggles tool content when an alternate full view is available.
 
 Context-aware launchers such as the Windows hotkey and VS Code extension first open the newest non-empty session for the current workspace. If that session is missing or empty, they fall back to the session list.
+
+Shared/mirrored session trees only participate in explicit `--pick` browsing. Implicit current-session lookup stays local so another account's exported history does not override the current user's active Codex workflow.
+
+## Mirror sessions for another account
+
+Create a shared mirror from the source account:
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex --watch
+```
+
+Then consume it from another account:
+
+```toml
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+```
 
 ## Windows hotkey
 

--- a/docs-site/src/content/docs/usage/configuration.md
+++ b/docs-site/src/content/docs/usage/configuration.md
@@ -36,6 +36,9 @@ max_entries = 0
 [copy]
 prompts = []
 
+[codex]
+session_dirs = []
+
 [hotkey]
 chord = "alt+y"
 ```
@@ -62,3 +65,18 @@ prompts = ["dev>", "repo $", "PS C:\\repo>"]
 ```
 
 This helps command-block parsing identify the command input lines in session logs.
+
+## Shared Codex session trees
+
+Add shared exported session trees when another account publishes a read-only copy:
+
+```toml
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+```
+
+Create that shared tree from the source account with:
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex
+```

--- a/docs-site/src/content/docs/zh-cn/reference/config-file.md
+++ b/docs-site/src/content/docs/zh-cn/reference/config-file.md
@@ -32,6 +32,9 @@ max_entries = 0
 [copy]
 prompts = ["PS C:\\repo> ", "dev>"]
 
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+
 [hotkey]
 chord = "alt+y"
 ```
@@ -94,6 +97,17 @@ prompts = []
 | `prompts` | string array | `[]` | 检测命令行时使用的 prompt 配置或字面前缀 |
 
 `prompt_presets` 是旧字段，当前配置写入器不会序列化它。
+
+## codex
+
+```toml
+[codex]
+session_dirs = []
+```
+
+| 键 | 类型 | 默认值 | 含义 |
+| --- | --- | --- | --- |
+| `session_dirs` | string array | `[]` | 额外的导出 Codex `sessions` 目录，可供 `copy codex --pick` 浏览 |
 
 ## hotkey
 

--- a/docs-site/src/content/docs/zh-cn/usage/codex-capture.md
+++ b/docs-site/src/content/docs/zh-cn/usage/codex-capture.md
@@ -3,7 +3,9 @@ title: Codex 捕获
 description: 从当前 Codex 会话复制有用块。
 ---
 
-`sivtr copy codex` 会读取 `~/.codex/sessions` 下的 Codex rollout JSONL 文件。默认选择 `cwd` 与当前工作目录匹配的最新会话。
+`sivtr copy codex` 会读取 `~/.codex/sessions` 下的 Codex rollout JSONL 文件。如果当前 shell 暴露了 `CODEX_THREAD_ID`，`sivtr` 会优先匹配这个本地精确会话；否则默认选择 `cwd` 与当前工作目录匹配的最新本地会话。
+
+如果另一个账号先用 `sivtr codex export --dest ...` 发布了只读镜像，就把镜像后的 `sessions` 目录加入 `[codex].session_dirs`。这样显式 `--pick` 浏览就能在不提权的前提下读取它。
 
 当你想复用最后一个回答、输入、工具输出，或整个解析后的会话，但不想手动打开 Codex transcript 时，这个功能很有用。
 
@@ -62,11 +64,29 @@ sivtr copy codex out --print
 ```bash
 sivtr copy codex --pick
 sivtr copy codex out --pick
+sivtr copy codex --pick  # 同时浏览 [codex].session_dirs 里的共享镜像会话
 ```
 
 普通 CLI 选择器会先显示会话列表，进入某个会话后再选择一个或多个单元。按 `t` 打开 Vim 风格视图。在 Codex 视图里，如果存在替代完整视图，`T` 可以切换工具内容。
 
 Windows 热键和 VS Code 插件这类带上下文的入口会先打开当前 workspace 下最新的非空会话。如果这个会话不存在或为空，再退回到会话列表。
+
+共享/镜像会话树只参与显式 `--pick` 浏览。隐式“当前会话”解析仍然只看本地会话，避免另一个账号导出的历史抢占当前用户的 Codex 工作流。
+
+## 为另一个账号镜像会话
+
+先在源账号侧持续发布镜像树：
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex --watch
+```
+
+再在另一个账号的配置里引用镜像目录：
+
+```toml
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+```
 
 ## Windows 热键
 

--- a/docs-site/src/content/docs/zh-cn/usage/configuration.md
+++ b/docs-site/src/content/docs/zh-cn/usage/configuration.md
@@ -36,6 +36,9 @@ max_entries = 0
 [copy]
 prompts = []
 
+[codex]
+session_dirs = []
+
 [hotkey]
 chord = "alt+y"
 ```
@@ -62,3 +65,18 @@ prompts = ["dev>", "repo $", "PS C:\\repo>"]
 ```
 
 这有助于命令块解析识别会话日志里的命令输入行。
+
+## 共享 Codex 会话树
+
+当另一个账号发布了只读副本时，可以把共享导出的会话树加入配置：
+
+```toml
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+```
+
+源账号可以这样创建共享树：
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex
+```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -254,6 +254,9 @@ pub enum Commands {
     #[command(after_help = HOTKEY_AFTER_HELP)]
     Hotkey(HotkeyCommand),
 
+    /// Export local Codex session files into a shared read-only tree
+    Codex(CodexCommand),
+
     /// Clear session logs
     Clear(ClearArgs),
 
@@ -535,6 +538,37 @@ pub enum AgentCopyMode {
     All(CopySimpleArgs),
 }
 
+#[derive(Parser, Debug)]
+pub struct CodexCommand {
+    #[command(subcommand)]
+    pub action: CodexAction,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum CodexAction {
+    /// Export local Codex rollout JSONL files into a target directory
+    Export(CodexExportArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct CodexExportArgs {
+    /// Destination directory that will receive a sessions/ tree copy
+    #[arg(long, value_name = "PATH")]
+    pub dest: PathBuf,
+
+    /// Keep only the newest N session files; `0` means export all
+    #[arg(long, value_name = "N", default_value_t = 0)]
+    pub limit: usize,
+
+    /// Continue mirroring local sessions into the destination tree
+    #[arg(long, default_value_t = false)]
+    pub watch: bool,
+
+    /// Seconds between sync passes when `--watch` is enabled
+    #[arg(long, value_name = "SECONDS", default_value_t = 2, requires = "watch")]
+    pub interval: u64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -731,6 +765,35 @@ mod tests {
                 assert_eq!(args.provider, HotkeyProviderSelection::default());
             }
             _ => panic!("expected hotkey-pick-agent command"),
+        }
+    }
+
+    #[test]
+    fn codex_export_accepts_destination_and_watch_flags() {
+        let cli = Cli::try_parse_from([
+            "sivtr",
+            "codex",
+            "export",
+            "--dest",
+            "/tmp/shared-codex",
+            "--limit",
+            "5",
+            "--watch",
+            "--interval",
+            "3",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::Codex(cmd)) => match cmd.action {
+                CodexAction::Export(args) => {
+                    assert_eq!(args.dest, PathBuf::from("/tmp/shared-codex"));
+                    assert_eq!(args.limit, 5);
+                    assert!(args.watch);
+                    assert_eq!(args.interval, 3);
+                }
+            },
+            _ => panic!("expected codex export command"),
         }
     }
 

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -162,16 +162,18 @@ fn remove_stale_exported_files_inner(
     Ok(())
 }
 
+#[cfg(unix)]
 fn set_shared_read_permissions(path: &Path) -> Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::fs::PermissionsExt;
 
-        let mode = if path.is_dir() { 0o755 } else { 0o644 };
-        fs::set_permissions(path, fs::Permissions::from_mode(mode))
-            .with_context(|| format!("Failed to chmod {}", path.display()))?;
-    }
+    let mode = if path.is_dir() { 0o755 } else { 0o644 };
+    fs::set_permissions(path, fs::Permissions::from_mode(mode))
+        .with_context(|| format!("Failed to chmod {}", path.display()))?;
+    Ok(())
+}
 
+#[cfg(not(unix))]
+fn set_shared_read_permissions(_path: &Path) -> Result<()> {
     Ok(())
 }
 
@@ -193,10 +195,10 @@ fn set_shared_read_permissions_recursive(root: &Path, path: &Path) -> Result<()>
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        collect_session_files, copy_session_file_atomically, export_once,
-        set_shared_read_permissions_recursive,
-    };
+    #[cfg(unix)]
+    use super::set_shared_read_permissions_recursive;
+    use super::{collect_session_files, copy_session_file_atomically, export_once};
+    #[cfg(unix)]
     use std::path::Path;
 
     #[test]

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -1,0 +1,295 @@
+use crate::cli::{CodexAction, CodexCommand, CodexExportArgs};
+use anyhow::{Context, Result};
+use sivtr_core::codex::local_codex_sessions_dir;
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
+use std::time::SystemTime;
+
+pub fn execute(command: CodexCommand) -> Result<()> {
+    match command.action {
+        CodexAction::Export(args) => export(args),
+    }
+}
+
+fn export(args: CodexExportArgs) -> Result<()> {
+    let source_root = local_codex_sessions_dir();
+    if !source_root.exists() {
+        anyhow::bail!("No local Codex sessions found at {}", source_root.display());
+    }
+
+    let target_root = args.dest.join("sessions");
+
+    loop {
+        let copied = export_once(&source_root, &target_root, args.limit)?;
+        eprintln!(
+            "sivtr: mirrored {} Codex session file(s) to {}",
+            copied,
+            target_root.display()
+        );
+
+        if !args.watch {
+            return Ok(());
+        }
+
+        thread::sleep(Duration::from_secs(args.interval));
+    }
+}
+
+fn export_once(source_root: &Path, target_root: &Path, limit: usize) -> Result<usize> {
+    let files = collect_session_files(source_root, limit)?;
+    if files.is_empty() {
+        anyhow::bail!("No local Codex sessions found at {}", source_root.display());
+    }
+
+    fs::create_dir_all(target_root)
+        .with_context(|| format!("Failed to create {}", target_root.display()))?;
+    set_shared_read_permissions(target_root)?;
+
+    let mut kept = HashSet::new();
+    for source in &files {
+        let relative = source
+            .strip_prefix(source_root)
+            .with_context(|| format!("Failed to relativize {}", source.display()))?;
+        kept.insert(relative.to_path_buf());
+
+        let target = target_root.join(relative);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create {}", parent.display()))?;
+            set_shared_read_permissions_recursive(target_root, parent)?;
+        }
+        copy_session_file_atomically(source, &target)?;
+    }
+
+    remove_stale_exported_files(target_root, &kept)?;
+    Ok(files.len())
+}
+
+fn collect_session_files(root: &Path, limit: usize) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    collect_jsonl_files(root, &mut files)?;
+    files.sort_by_key(|path| modified_time(path).unwrap_or(SystemTime::UNIX_EPOCH));
+    files.reverse();
+    if limit > 0 {
+        files.truncate(limit);
+    }
+    Ok(files)
+}
+
+fn collect_jsonl_files(root: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(root).with_context(|| format!("Failed to read {}", root.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_jsonl_files(&path, files)?;
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("jsonl") {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn modified_time(path: &Path) -> Result<SystemTime> {
+    Ok(fs::metadata(path)?.modified()?)
+}
+
+fn copy_session_file_atomically(source: &Path, target: &Path) -> Result<()> {
+    let temp = target.with_extension("jsonl.tmp");
+    if temp.exists() {
+        fs::remove_file(&temp).with_context(|| format!("Failed to remove {}", temp.display()))?;
+    }
+
+    fs::copy(source, &temp).with_context(|| {
+        format!(
+            "Failed to copy Codex session from {} to {}",
+            source.display(),
+            temp.display()
+        )
+    })?;
+    set_shared_read_permissions(&temp)?;
+
+    if target.exists() {
+        fs::remove_file(target)
+            .with_context(|| format!("Failed to replace {}", target.display()))?;
+    }
+
+    fs::rename(&temp, target).with_context(|| format!("Failed to publish {}", target.display()))?;
+    set_shared_read_permissions(target)?;
+    Ok(())
+}
+
+fn remove_stale_exported_files(root: &Path, kept: &HashSet<PathBuf>) -> Result<()> {
+    if !root.exists() {
+        return Ok(());
+    }
+
+    remove_stale_exported_files_inner(root, root, kept)
+}
+
+fn remove_stale_exported_files_inner(
+    root: &Path,
+    dir: &Path,
+    kept: &HashSet<PathBuf>,
+) -> Result<()> {
+    for entry in fs::read_dir(dir).with_context(|| format!("Failed to read {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            remove_stale_exported_files_inner(root, &path, kept)?;
+            if fs::read_dir(&path)?.next().is_none() {
+                fs::remove_dir(&path)
+                    .with_context(|| format!("Failed to remove {}", path.display()))?;
+            }
+            continue;
+        }
+
+        if path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
+            continue;
+        }
+
+        let relative = path
+            .strip_prefix(root)
+            .with_context(|| format!("Failed to relativize {}", path.display()))?;
+        if !kept.contains(relative) {
+            fs::remove_file(&path)
+                .with_context(|| format!("Failed to remove stale export {}", path.display()))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn set_shared_read_permissions(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mode = if path.is_dir() { 0o755 } else { 0o644 };
+        fs::set_permissions(path, fs::Permissions::from_mode(mode))
+            .with_context(|| format!("Failed to chmod {}", path.display()))?;
+    }
+
+    Ok(())
+}
+
+fn set_shared_read_permissions_recursive(root: &Path, path: &Path) -> Result<()> {
+    let relative = path
+        .strip_prefix(root)
+        .with_context(|| format!("Failed to relativize {}", path.display()))?;
+
+    let mut current = root.to_path_buf();
+    set_shared_read_permissions(&current)?;
+
+    for component in relative.components() {
+        current.push(component.as_os_str());
+        set_shared_read_permissions(&current)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        collect_session_files, copy_session_file_atomically, export_once,
+        set_shared_read_permissions_recursive,
+    };
+    use std::path::Path;
+
+    #[test]
+    fn collect_session_files_sorts_newest_first() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("a.jsonl");
+        let second = dir.path().join("b.jsonl");
+        std::fs::write(&first, "{}\n").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        std::fs::write(&second, "{}\n").unwrap();
+
+        let files = collect_session_files(dir.path(), 0).unwrap();
+
+        assert_eq!(files, vec![second, first]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_permissions_are_applied_to_nested_export_directories() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("sessions");
+        let nested = root.join(Path::new("2026/05/07"));
+        std::fs::create_dir_all(&nested).unwrap();
+
+        set_shared_read_permissions_recursive(&root, &nested).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&root).unwrap().permissions().mode() & 0o777,
+            0o755
+        );
+        assert_eq!(
+            std::fs::metadata(root.join("2026"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o755
+        );
+        assert_eq!(
+            std::fs::metadata(root.join("2026/05"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o755
+        );
+        assert_eq!(
+            std::fs::metadata(&nested).unwrap().permissions().mode() & 0o777,
+            0o755
+        );
+    }
+
+    #[test]
+    fn export_once_removes_stale_files_outside_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_root = dir.path().join("source");
+        let target_root = dir.path().join("target").join("sessions");
+        let nested = source_root.join("2026/05/08");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let newest = nested.join("newest.jsonl");
+        let older = nested.join("older.jsonl");
+        std::fs::write(
+            &older,
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"older\"}}\n",
+        )
+        .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        std::fs::write(
+            &newest,
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"newest\"}}\n",
+        )
+        .unwrap();
+
+        export_once(&source_root, &target_root, 1).unwrap();
+
+        assert!(target_root.join("2026/05/08/newest.jsonl").exists());
+        assert!(!target_root.join("2026/05/08/older.jsonl").exists());
+    }
+
+    #[test]
+    fn atomic_copy_replaces_existing_file_contents() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.jsonl");
+        let target = dir.path().join("target.jsonl");
+        std::fs::write(&source, "new data\n").unwrap();
+        std::fs::write(&target, "old data\n").unwrap();
+
+        copy_session_file_atomically(&source, &target).unwrap();
+
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "new data\n");
+        assert!(!dir.path().join("target.jsonl.tmp").exists());
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod browse;
 pub mod capture_history;
 pub mod clear;
+pub mod codex;
 pub mod command_block_selector;
 pub mod config;
 pub mod copy;

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,9 @@ fn run() -> Result<()> {
         Some(Commands::Hotkey(cmd)) => {
             commands::hotkey::execute(cmd)?;
         }
+        Some(Commands::Codex(cmd)) => {
+            commands::codex::execute(cmd)?;
+        }
         Some(Commands::Config(cfg_cmd)) => {
             commands::config::execute(cfg_cmd)?;
         }


### PR DESCRIPTION
## Title: feat: add shared read-only Codex session mirroring

### 1. Context & Motivation (Context)
- **Issue:** n/a
- **Problem:** Cross-account Codex session reuse still pushed users toward privileged access because there was no supported way to continuously publish one account's rollout tree for another account to browse read-only.
- **Trade-offs:** This design keeps implicit current-session resolution local-only (safety and UX stability) and adds explicit shared browsing via mirrored trees (`session_dirs` + picker). That avoids session hijacking, at the cost of requiring an explicit export/mirror step.

### 2. Implementation Details (Implementation)
- Added `sivtr codex export --dest <PATH> [--limit N] [--watch] [--interval SECONDS]` with atomic file publish, recursive permission normalization (`755` dirs / `644` files on Unix), and stale-file pruning outside the active mirror set.
- Added `[codex].session_dirs` config support and `SIVTR_CODEX_SESSION_DIRS` env override; Codex provider now merges local + shared trees for explicit browsing while keeping `find_current_session` and `CODEX_THREAD_ID` local-only.
- Added JSONL tail tolerance for trailing incomplete lines during active writes, so mirrored files remain readable while source sessions are still growing.
- **Note:** This PR intentionally does not add explicit `--session` selection; that behavior is split into a separate PR to keep scope atomic.

### 3. Testing Strategies (Validation)
- [x] Added Unit Tests for mirror file ordering, atomic replacement, stale cleanup outside `--limit`, and recursive shared-permission application.
- [x] Added Unit Tests for Codex provider behavior: local-only thread/current resolution, merged shared-session discovery, and trailing incomplete JSONL line parsing.
- [x] Added CLI parsing tests for `codex export --dest ... --limit ... --watch --interval ...`.
- [x] Ran Integration Test Suite against local Linux environment with `cargo test --workspace`.
- [x] Verified lint and formatting with `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings`.
- [x] Verified backward compatibility by preserving local-only implicit current-session resolution.
- **Benchmark:** n/a