### PR TITLE
fix: satisfy clippy on Rust 1.88

### DIFF
--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -520,6 +520,16 @@ enum AgentHierarchyFocus {
     Content,
 }
 
+struct AgentHierarchyView<'a> {
+    groups: &'a [AgentGroup],
+    agent_state: &'a ListState,
+    session_state: &'a ListState,
+    dialogue_state: &'a ListState,
+    selected_dialogues: &'a [bool],
+    focus: AgentHierarchyFocus,
+    content_scroll: usize,
+}
+
 fn build_agent_session_choices(
     source: &dyn AgentSessionProvider,
     sessions: &[AgentSessionInfo],
@@ -633,13 +643,15 @@ fn run_agent_hierarchy_picker_on_terminal(
             render_agent_hierarchy_picker(
                 title,
                 frame,
-                &groups,
-                &agent_state,
-                &session_state,
-                &dialogue_state,
-                &selected_dialogues,
-                focus,
-                content_scroll,
+                AgentHierarchyView {
+                    groups: &groups,
+                    agent_state: &agent_state,
+                    session_state: &session_state,
+                    dialogue_state: &dialogue_state,
+                    selected_dialogues: &selected_dialogues,
+                    focus,
+                    content_scroll,
+                },
             )
         })?;
 
@@ -700,7 +712,7 @@ fn run_agent_hierarchy_picker_on_terminal(
                         if next != selected_index(&session_state) {
                             session_state.select(Some(next));
                             reset_agent_dialogue_state(
-                                &choices,
+                                choices,
                                 next,
                                 &mut dialogue_state,
                                 &mut selected_dialogues,
@@ -739,7 +751,7 @@ fn run_agent_hierarchy_picker_on_terminal(
                         if next != current {
                             session_state.select(Some(next));
                             reset_agent_dialogue_state(
-                                &choices,
+                                choices,
                                 next,
                                 &mut dialogue_state,
                                 &mut selected_dialogues,
@@ -873,17 +885,7 @@ fn current_agent_dialogue_text(choice: &AgentSessionChoice, dialogue_idx: usize)
         .unwrap_or("<empty>")
 }
 
-fn render_agent_hierarchy_picker(
-    title: &str,
-    frame: &mut Frame,
-    groups: &[AgentGroup],
-    agent_state: &ListState,
-    session_state: &ListState,
-    dialogue_state: &ListState,
-    selected_dialogues: &[bool],
-    focus: AgentHierarchyFocus,
-    content_scroll: usize,
-) {
+fn render_agent_hierarchy_picker(title: &str, frame: &mut Frame, view: AgentHierarchyView<'_>) {
     let area = frame.area();
     frame.render_widget(Clear, area);
 
@@ -892,7 +894,7 @@ fn render_agent_hierarchy_picker(
         .constraints([Constraint::Length(3), Constraint::Min(1)])
         .split(area);
 
-    let controls = match focus {
+    let controls = match view.focus {
         AgentHierarchyFocus::Agents => "j/k move  l/Right/Enter open sessions  q/Esc cancel",
         AgentHierarchyFocus::Sessions => "j/k move  l/Right/Enter open dialogues  q/Esc cancel",
         AgentHierarchyFocus::Dialogues => {
@@ -902,16 +904,17 @@ fn render_agent_hierarchy_picker(
             "j/k scroll  Ctrl-d/PageDown down  Ctrl-u/PageUp up  h/Left/Esc back  Enter copy  q cancel"
         }
     };
-    let agent_idx = selected_index(agent_state).min(groups.len().saturating_sub(1));
-    let choices = &groups[agent_idx].choices;
-    let session_idx = selected_index(session_state).min(choices.len().saturating_sub(1));
-    let selected_count = selected_dialogues
+    let agent_idx = selected_index(view.agent_state).min(view.groups.len().saturating_sub(1));
+    let choices = &view.groups[agent_idx].choices;
+    let session_idx = selected_index(view.session_state).min(choices.len().saturating_sub(1));
+    let selected_count = view
+        .selected_dialogues
         .iter()
         .filter(|selected| **selected)
         .count();
     let title = Paragraph::new(format!(
         "{controls}\nshowing {} agent(s), {} session(s), {} dialogue(s){}",
-        groups.len(),
+        view.groups.len(),
         choices.len(),
         choices[session_idx].dialogue_titles.len(),
         if selected_count == 0 {
@@ -932,19 +935,19 @@ fn render_agent_hierarchy_picker(
         .constraints([Constraint::Percentage(42), Constraint::Percentage(58)])
         .split(chunks[1]);
 
-    match focus {
+    match view.focus {
         AgentHierarchyFocus::Agents => {
-            render_agent_group_list(frame, body_chunks[0], groups, agent_state, true);
-            render_agent_session_list(frame, body_chunks[1], choices, session_state, false);
+            render_agent_group_list(frame, body_chunks[0], view.groups, view.agent_state, true);
+            render_agent_session_list(frame, body_chunks[1], choices, view.session_state, false);
         }
         AgentHierarchyFocus::Sessions => {
-            render_agent_session_list(frame, body_chunks[0], choices, session_state, true);
+            render_agent_session_list(frame, body_chunks[0], choices, view.session_state, true);
             render_agent_dialogue_list(
                 frame,
                 body_chunks[1],
                 &choices[session_idx],
-                dialogue_state,
-                selected_dialogues,
+                view.dialogue_state,
+                view.selected_dialogues,
                 false,
             );
         }
@@ -953,17 +956,17 @@ fn render_agent_hierarchy_picker(
                 frame,
                 body_chunks[0],
                 &choices[session_idx],
-                dialogue_state,
-                selected_dialogues,
+                view.dialogue_state,
+                view.selected_dialogues,
                 true,
             );
-            let dialogue_idx = selected_index(dialogue_state)
+            let dialogue_idx = selected_index(view.dialogue_state)
                 .min(choices[session_idx].dialogue_titles.len().saturating_sub(1));
             let content = Paragraph::new(current_agent_dialogue_text(
                 &choices[session_idx],
                 dialogue_idx,
             ))
-            .scroll((content_scroll as u16, 0))
+            .scroll((view.content_scroll as u16, 0))
             .wrap(ratatui::widgets::Wrap { trim: false })
             .block(Block::default().borders(Borders::ALL).title("Content"));
             frame.render_widget(content, body_chunks[1]);
@@ -973,17 +976,17 @@ fn render_agent_hierarchy_picker(
                 frame,
                 body_chunks[0],
                 &choices[session_idx],
-                dialogue_state,
-                selected_dialogues,
+                view.dialogue_state,
+                view.selected_dialogues,
                 false,
             );
-            let dialogue_idx = selected_index(dialogue_state)
+            let dialogue_idx = selected_index(view.dialogue_state)
                 .min(choices[session_idx].dialogue_titles.len().saturating_sub(1));
             let content = Paragraph::new(current_agent_dialogue_text(
                 &choices[session_idx],
                 dialogue_idx,
             ))
-            .scroll((content_scroll as u16, 0))
+            .scroll((view.content_scroll as u16, 0))
             .wrap(ratatui::widgets::Wrap { trim: false })
             .block(Block::default().borders(Borders::ALL).title("Content *"));
             frame.render_widget(content, body_chunks[1]);
@@ -1430,12 +1433,6 @@ fn agent_session_has_blocks(
     path: &std::path::Path,
 ) -> Result<bool> {
     Ok(!source.parse_session_file(path)?.blocks.is_empty())
-}
-
-fn session_modified_time(path: &std::path::Path) -> SystemTime {
-    path.metadata()
-        .and_then(|metadata| metadata.modified())
-        .unwrap_or(SystemTime::UNIX_EPOCH)
 }
 
 fn pick_agent_session_path(


### PR DESCRIPTION
## Title: fix: satisfy clippy on Rust 1.88

### 1. Context & Motivation (Context)
- **Issue:** Resolves the current CI failure mode blocking follow-up Codex session work.
- **Problem:** The current  branch fails  on Rust 1.88 because  triggers  and .
- **Trade-offs:** This keeps the fix narrowly scoped to lint-compatible structure changes instead of relaxing CI rules or bundling it into feature work.

### 2. Implementation Details (Implementation)
- Replaced the wide argument list passed to  with a small view struct to satisfy  without changing behavior.
- Removed two unnecessary borrows in the agent session picker flow to satisfy  on Rust 1.88.
- **Note:** No feature behavior changes are intended in this PR; it is a CI-unblocker for follow-up feature PRs.

### 3. Testing Strategies (Validation)
- [x] Ran 
- [x] Ran 
- [x] Ran 
running 64 tests
test app::tests::enters_and_exits_insert_mode ... ok
test app::tests::selects_current_command_block_range ... ok
test app::tests::jumps_between_command_blocks ... ok
test app::tests::selects_current_command_input_range ... ok
test cli::tests::clear_accepts_all_flag ... ok
test cli::tests::copy_aliases_accept_ansi_flag ... ok
test cli::tests::codex_copy_accepts_selector ... ok
test cli::tests::copy_cmd_does_not_accept_prompt_argument ... ok
test cli::tests::copy_input_accepts_prompt_override ... ok
test cli::tests::copy_out_does_not_accept_prompt_override ... ok
test cli::tests::diff_parses_two_selectors ... ok
test cli::tests::codex_copy_defaults_to_last_turn ... ok
test cli::tests::diff_parses_block_mode_and_side_by_side ... ok
test cli::tests::codex_copy_accepts_nested_mode ... ok
test command_blocks::tests::builds_line_ranges_from_structured_entries ... ok
test cli::tests::hotkey_start_accepts_chord_override ... ok
test cli::tests::claude_copy_accepts_nested_mode ... ok
test command_blocks::tests::parsed_block_text_modes_return_expected_text ... ok
test cli::tests::hotkey_provider_rejects_unknown_provider ... ok
test command_blocks::tests::preserves_output_only_blocks ... ok
test cli::tests::diff_rejects_multiple_content_modes ... ok
test commands::clear::tests::detects_session_artifacts_for_clear_all ... ok
test cli::tests::hotkey_start_accepts_provider_override ... ok
test cli::tests::run_accepts_hyphen_prefixed_child_args_without_separator ... ok
test commands::command_block_selector::tests::parses_selection_count ... ok
test cli::tests::hotkey_pick_agent_defaults_to_all ... ok
test commands::command_block_selector::tests::parses_selection_range ... ok
test commands::command_block_selector::tests::resolves_single_selection_as_exact_recent_command ... ok
test commands::command_block_selector::tests::resolves_explicit_selection_as_disjoint_commands ... ok
test commands::command_block_selector::tests::resolves_selection_range ... ok
test commands::copy::picker::tests::preview_search_wraps_forward ... ok
test commands::copy::picker::tests::preview_search_wraps_backward ... ok
test commands::copy::tests::builds_output_preview_from_first_lines ... ok
test commands::copy::tests::agent_turn_units_group_multiple_assistant_messages_for_one_user ... ok
test commands::copy::tests::codex_session_picker_uses_first_real_user_message ... ok
test commands::copy::tests::escapes_vim_single_quoted_strings ... ok
test commands::copy::tests::detects_vim_compatible_editor_commands ... ok
test commands::copy::tests::agent_vim_view_groups_multiple_assistant_messages_for_one_user ... ok
test commands::copy::picker::tests::pick_entry_is_constructible_for_parent_tests ... ok
test commands::copy::tests::formats_modes ... ok
test commands::copy::tests::picker_selection_keeps_disjoint_blocks ... ok
test commands::copy::tests::rejects_dash_ranges_for_lines ... ok
test commands::copy::tests::codex_vim_view_hides_tools_by_default_and_moves_by_turn ... ok
test commands::copy::tests::rewrites_prompt_in_copied_input ... ok
test commands::copy::tests::toggles_selected_range_in_picker ... ok
test commands::diff::tests::computes_non_zero_columns_for_small_width ... ok
test commands::diff::tests::rejects_multi_block_selector_for_diff ... ok
test commands::diff::tests::resolves_single_selector ... ok
test commands::diff::tests::builds_side_by_side_rows_with_replace_marks ... ok
test commands::init::tests::current_powershell_hook_does_not_redirect_flush_output_handle ... ok
test commands::init::tests::keeps_current_powershell_hook_unchanged ... ok
test commands::diff::tests::renders_unified_diff_headers_from_selectors ... ok
test commands::init::tests::replaces_existing_bash_block ... ok
test commands::init::tests::replaces_existing_nushell_block ... ok
test commands::init::tests::replaces_existing_zsh_block ... ok
test commands::init::tests::upgrades_legacy_powershell_hook_in_place ... ok
test commands::run::tests::quotes_arguments_with_spaces ... ok
test commands::copy::tests::filters_by_regex ... ok
test commands::copy::tests::filters_ansi_by_plain_regex_matches ... ok
test commands::run::tests::escapes_single_quotes_inside_arguments ... ok
test commands::copy::tests::filters_by_line_spec_with_colon_ranges ... ok
test commands::capture_history::tests::skips_save_when_auto_save_is_disabled ... ok
test commands::capture_history::tests::trims_history_to_configured_limit ... ok
test commands::capture_history::tests::saves_capture_when_auto_save_is_enabled ... ok

test result: ok. 64 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 66 tests
test buffer::line::tests::test_display_width ... ok
test buffer::line::tests::test_char_index_for_display_col ... ok
test buffer::line::tests::test_display_col_for_char_index ... ok
test buffer::line::tests::test_display_width_cjk ... ok
test buffer::line::tests::test_extract_cjk ... ok
test buffer::line::tests::test_extract_beyond_line ... ok
test buffer::line::tests::test_extract_ascii ... ok
test buffer::line::tests::test_extract_empty_range ... ok
test buffer::tests::vertical_motion_preserves_preferred_col ... ok
test capture::scrollback::tests::extracts_pid_from_session_artifacts ... ok
test config::tests::serializes_hotkey_config ... ok
test config::tests::serializes_copy_prompt_config ... ok
test parse::ansi::tests::test_parse_bold_green ... ok
test claude::tests::parses_embedded_tool_input_without_child_close ... ok
test parse::ansi::tests::test_parse_256_color ... ok
test parse::ansi::tests::test_parse_red_text ... ok
test claude::tests::parses_claude_messages_and_tools ... ok
test claude::tests::parses_claude_embedded_tool_markup_from_text_items ... ok
test claude::tests::parses_truncated_embedded_tool_output_at_next_tool_tag ... ok
test claude::tests::selects_last_claude_turn ... ok
test claude::tests::skips_claude_meta_user_messages ... ok
test parse::ansi::tests::test_parse_rgb_color ... ok
test claude::tests::splits_embedded_tool_when_next_tool_tag_precedes_close ... ok
test codex::tests::selects_last_turn_without_tool_noise ... ok
test codex::tests::skips_commentary_assistant_messages ... ok
test parse::ansi::tests::test_parse_styles_plain ... ok
test codex::tests::parses_codex_rollout_messages_and_tools ... ok
test parse::ansi::tests::test_strip_colored_text ... ok
test parse::ansi::tests::test_strip_empty ... ok
test parse::ansi::tests::test_strip_complex_escapes ... ok
test parse::ansi::tests::test_strip_plain_text ... ok
test parse::unicode::tests::test_ascii_widths ... ok
test parse::unicode::tests::test_cjk_widths ... ok
test parse::unicode::tests::test_display_col_to_char_range_ascii ... ok
test parse::unicode::tests::test_display_col_to_char_range_cjk ... ok
test parse::unicode::tests::test_display_col_to_char_range_empty ... ok
test parse::ansi::tests::test_parse_styles_empty ... ok
test search::matcher::tests::test_find_empty_pattern ... ok
test parse::unicode::tests::test_display_width ... ok
test search::navigator::tests::test_jump_to_row ... ok
test search::navigator::tests::test_next_wraps ... ok
test search::navigator::tests::test_prev_wraps ... ok
test selection::extract::tests::test_visual_block ... ok
test selection::extract::tests::test_visual_block_keeps_empty_rows_empty ... ok
test selection::extract::tests::test_visual_single_line ... ok
test selection::extract::tests::test_visual_line_mode ... ok
test session::capture::tests::extracts_output_after_latest_input_block ... ok
test session::capture::tests::extracts_output_when_prompt_scrolled_but_command_line_remains ... ok
test session::capture::tests::strips_trailing_prompt_from_captured_output ... ok
test session::capture::tests::strips_trailing_prompt_even_when_glyphs_degrade_in_snapshot ... ok
test session::entry::tests::renders_multiline_prompt_input ... ok
test session::entry::tests::renders_structured_entry ... ok
test session::entry::tests::strips_ansi_from_entry_at_construction_boundary ... ok
test search::matcher::tests::test_find_regex ... ok
test search::matcher::tests::test_find_no_match ... ok
test parse::unicode::tests::test_display_col_to_char_range_mixed ... ok
test search::matcher::tests::test_find_case_insensitive ... ok
test search::matcher::tests::test_find_literal ... ok
test parse::unicode::tests::test_mixed_widths ... ok
test parse::unicode::tests::test_tab_width ... ok
test session::entry::tests::renders_ansi_entries_with_fallback ... ok
test history::query::tests::test_insert_and_list ... ok
test history::query::tests::test_get_by_id ... ok
test history::query::tests::test_trim_to_max_entries_keeps_newest_rows ... ok
test history::query::tests::test_fts_search_handles_hyphenated_terms ... ok
test history::query::tests::test_fts_search ... ok

test result: ok. 66 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- [x] Verified no CLI or session-copy behavior changes were introduced beyond lint-compatible refactoring
