### PR TITLE
feat(copy): support explicit ai session selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,12 +151,18 @@ sivtr copy out --lines 10:40
 
 `sivtr copy codex` reads Codex rollout JSONL files from `~/.codex/sessions` and chooses the newest session whose `cwd` matches your current directory.
 
+Use `--session N` to open the Nth newest recorded session, or `--session ID` to match a session id / id prefix explicitly.
+
 ```bash
 sivtr copy codex        # latest completed user + assistant turn
+sivtr copy codex --session 2
+sivtr copy codex --session 019df7fb
 sivtr copy codex out    # latest assistant reply
+sivtr copy codex out --session 2 --print
 sivtr copy codex in     # latest user message
 sivtr copy codex tool   # latest tool output
 sivtr copy codex all    # parsed session
+sivtr copy codex --session 2 --pick
 ```
 
 Progress commentary is filtered by default, so `sivtr copy codex out` returns the final assistant reply instead of intermediate status updates.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -151,12 +151,18 @@ sivtr copy out --lines 10:40
 
 `sivtr copy codex` 会读取 `~/.codex/sessions` 下的 Codex rollout JSONL 文件，并优先选择 `cwd` 与当前目录匹配的最新会话。
 
+用 `--session N` 可以显式选择第 N 新的已记录会话；用 `--session ID` 可以按会话 id 或 id 前缀匹配。
+
 ```bash
 sivtr copy codex        # 最近一轮用户消息 + 助手回复
+sivtr copy codex --session 2
+sivtr copy codex --session 019df7fb
 sivtr copy codex out    # 最近助手回复
+sivtr copy codex out --session 2 --print
 sivtr copy codex in     # 最近用户消息
 sivtr copy codex tool   # 最近工具输出
 sivtr copy codex all    # 整个解析后的会话
+sivtr copy codex --session 2 --pick
 ```
 
 默认会过滤过程性 commentary，所以 `sivtr copy codex out` 更倾向返回最终助手回复，而不是中间状态更新。

--- a/docs-site/src/content/docs/usage/codex-capture.md
+++ b/docs-site/src/content/docs/usage/codex-capture.md
@@ -5,6 +5,8 @@ description: Copy useful blocks from the current Codex session.
 
 `sivtr copy codex` reads Codex rollout JSONL files from `~/.codex/sessions`. By default it chooses the newest session whose `cwd` matches the current working directory.
 
+Use `--session N` to select the Nth newest recorded session, or `--session ID` to match a session id / id prefix explicitly.
+
 This is useful when you want to reuse the last answer, input, tool output, or whole parsed session without opening the Codex transcript manually.
 
 ## Defaults
@@ -37,9 +39,11 @@ sivtr copy codex all
 Selectors work the same way as command-block copy:
 
 ```bash
+sivtr copy codex --session 2
+sivtr copy codex --session 019df7fb
 sivtr copy codex 2
 sivtr copy codex 2..4
-sivtr copy codex out 3
+sivtr copy codex out --session 3
 ```
 
 `1` means the newest matching Codex unit, `2` means the second newest, and so on.
@@ -60,6 +64,7 @@ sivtr copy codex out --print
 ## Pick interactively
 
 ```bash
+sivtr copy codex --session 2 --pick
 sivtr copy codex --pick
 sivtr copy codex out --pick
 ```

--- a/docs-site/src/content/docs/zh-cn/usage/codex-capture.md
+++ b/docs-site/src/content/docs/zh-cn/usage/codex-capture.md
@@ -5,6 +5,8 @@ description: 从当前 Codex 会话复制有用块。
 
 `sivtr copy codex` 会读取 `~/.codex/sessions` 下的 Codex rollout JSONL 文件。默认选择 `cwd` 与当前工作目录匹配的最新会话。
 
+用 `--session N` 可以显式选择第 N 新的已记录会话；用 `--session ID` 可以按会话 id 或 id 前缀匹配。
+
 当你想复用最后一个回答、输入、工具输出，或整个解析后的会话，但不想手动打开 Codex transcript 时，这个功能很有用。
 
 ## 默认行为
@@ -37,9 +39,11 @@ sivtr copy codex all
 选择器和命令块复制相同：
 
 ```bash
+sivtr copy codex --session 2
+sivtr copy codex --session 019df7fb
 sivtr copy codex 2
 sivtr copy codex 2..4
-sivtr copy codex out 3
+sivtr copy codex out --session 3
 ```
 
 `1` 表示最新匹配的 Codex 单元，`2` 表示第二新，依此类推。
@@ -60,6 +64,7 @@ sivtr copy codex out --print
 ## 交互式选择
 
 ```bash
+sivtr copy codex --session 2 --pick
 sivtr copy codex --pick
 sivtr copy codex out --pick
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -100,6 +100,8 @@ Defaults:
 Session Resolution:
   By default, sivtr reads the newest Codex rollout whose `cwd`
   matches the current working directory.
+  `--session N` picks the Nth newest recorded Codex session.
+  `--session ID` matches a session id or id prefix.
 
 Selector Semantics:
   Selection is relative to the newest matching Codex item.
@@ -118,9 +120,12 @@ Filters:
 
 Examples:
   sivtr copy codex
+  sivtr copy codex --session 2
+  sivtr copy codex --session 019df7fb
   sivtr copy codex 2
   sivtr copy codex 2..4
-  sivtr copy codex out --print
+  sivtr copy codex out --session 2 --print
+  sivtr copy codex --session 2 --pick
   sivtr copy codex out --pick
   sivtr copy codex tool --regex error
   sivtr copy codex all --lines 1:20
@@ -134,6 +139,8 @@ Defaults:
 Session Resolution:
   By default, sivtr reads the newest Claude Code transcript whose `cwd`
   matches the current working directory.
+  `--session N` picks the Nth newest recorded Claude session.
+  `--session ID` matches a session id or id prefix.
 
 Selector Semantics:
   Selection is relative to the newest matching Claude Code item.
@@ -148,7 +155,10 @@ Modes:
 
 Examples:
   sivtr copy claude
+  sivtr copy claude --session 2
+  sivtr copy claude --session abc123
   sivtr copy claude out --print
+  sivtr copy claude --session 2 --pick
   sivtr copy claude --pick
   sivtr copy claude all --lines 1:20
 ";
@@ -232,7 +242,7 @@ pub enum Commands {
 
     /// Copy recent command blocks to clipboard
     #[command(visible_alias = "c", after_help = COPY_AFTER_HELP)]
-    Copy(CopyCommand),
+    Copy(Box<CopyCommand>),
 
     /// Alias for `copy in`
     #[command(name = "ci", hide = true)]
@@ -343,6 +353,16 @@ pub struct CopyArgs {
 pub struct CopySimpleArgs {
     #[command(flatten)]
     pub common: CopyCommonArgs,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct AgentCopyArgs {
+    #[command(flatten)]
+    pub common: CopySimpleArgs,
+
+    /// Which recorded session to read; `1` means the newest session, or pass an id / id prefix
+    #[arg(long, value_name = "N|ID")]
+    pub session: Option<String>,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -517,22 +537,22 @@ pub struct AgentCopyCommand {
     pub mode: Option<AgentCopyMode>,
 
     #[command(flatten)]
-    pub args: CopySimpleArgs,
+    pub args: AgentCopyArgs,
 }
 
 #[derive(Subcommand, Debug)]
 pub enum AgentCopyMode {
     /// Copy the last user message
-    In(CopySimpleArgs),
+    In(AgentCopyArgs),
 
     /// Copy the last assistant reply
-    Out(CopySimpleArgs),
+    Out(AgentCopyArgs),
 
     /// Copy the last tool output
-    Tool(CopySimpleArgs),
+    Tool(AgentCopyArgs),
 
     /// Copy the whole parsed session
-    All(CopySimpleArgs),
+    All(AgentCopyArgs),
 }
 
 #[cfg(test)]
@@ -631,7 +651,7 @@ mod tests {
             Some(Commands::Copy(cmd)) => match cmd.mode {
                 Some(CopySubcommand::Codex(codex)) => {
                     assert!(codex.mode.is_none());
-                    assert_eq!(codex.args.common.selector, None);
+                    assert_eq!(codex.args.common.common.selector, None);
                 }
                 _ => panic!("expected copy codex mode"),
             },
@@ -646,7 +666,7 @@ mod tests {
         match cli.command {
             Some(Commands::Copy(cmd)) => match cmd.mode {
                 Some(CopySubcommand::Codex(codex)) => match codex.mode {
-                    Some(AgentCopyMode::Out(args)) => assert!(args.common.print),
+                    Some(AgentCopyMode::Out(args)) => assert!(args.common.common.print),
                     _ => panic!("expected copy codex out mode"),
                 },
                 _ => panic!("expected copy codex mode"),
@@ -662,7 +682,22 @@ mod tests {
         match cli.command {
             Some(Commands::Copy(cmd)) => match cmd.mode {
                 Some(CopySubcommand::Codex(codex)) => {
-                    assert_eq!(codex.args.common.selector.as_deref(), Some("2..4"));
+                    assert_eq!(codex.args.common.common.selector.as_deref(), Some("2..4"));
+                }
+                _ => panic!("expected copy codex mode"),
+            },
+            _ => panic!("expected copy command"),
+        }
+    }
+
+    #[test]
+    fn codex_copy_accepts_session_selector() {
+        let cli = Cli::try_parse_from(["sivtr", "copy", "codex", "--session", "2"]).unwrap();
+
+        match cli.command {
+            Some(Commands::Copy(cmd)) => match cmd.mode {
+                Some(CopySubcommand::Codex(codex)) => {
+                    assert_eq!(codex.args.session.as_deref(), Some("2"));
                 }
                 _ => panic!("expected copy codex mode"),
             },
@@ -677,9 +712,24 @@ mod tests {
         match cli.command {
             Some(Commands::Copy(cmd)) => match cmd.mode {
                 Some(CopySubcommand::Claude(claude)) => match claude.mode {
-                    Some(AgentCopyMode::Out(args)) => assert!(args.common.print),
+                    Some(AgentCopyMode::Out(args)) => assert!(args.common.common.print),
                     _ => panic!("expected copy claude out mode"),
                 },
+                _ => panic!("expected copy claude mode"),
+            },
+            _ => panic!("expected copy command"),
+        }
+    }
+
+    #[test]
+    fn claude_copy_accepts_session_selector() {
+        let cli = Cli::try_parse_from(["sivtr", "copy", "claude", "--session", "abc123"]).unwrap();
+
+        match cli.command {
+            Some(Commands::Copy(cmd)) => match cmd.mode {
+                Some(CopySubcommand::Claude(claude)) => {
+                    assert_eq!(claude.args.session.as_deref(), Some("abc123"));
+                }
                 _ => panic!("expected copy claude mode"),
             },
             _ => panic!("expected copy command"),

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -57,6 +57,7 @@ pub struct CopyRequest<'a> {
 pub struct AgentCopyRequest<'a> {
     pub provider: AgentProvider,
     pub selector: Option<&'a str>,
+    pub session_selector: Option<&'a str>,
     pub pick: bool,
     pub pick_current_session: bool,
     pub selection_mode: AgentSelection,
@@ -255,11 +256,12 @@ pub fn execute(request: CopyRequest<'_>) -> Result<()> {
 
 pub fn execute_agent(request: AgentCopyRequest<'_>) -> Result<()> {
     let source = request.provider.session_provider();
-    if request.pick && !request.pick_current_session {
+    if request.pick && !request.pick_current_session && request.session_selector.is_none() {
         return execute_agent_session_pick(source.as_ref(), request);
     }
 
-    let path = if request.pick && request.pick_current_session {
+    let path = if request.pick && request.pick_current_session && request.session_selector.is_none()
+    {
         let cwd = std::env::current_dir().context("Failed to resolve current directory")?;
         match resolve_current_agent_session_with_blocks(source.as_ref(), &cwd)? {
             Some(path) => {
@@ -268,7 +270,11 @@ pub fn execute_agent(request: AgentCopyRequest<'_>) -> Result<()> {
             None => return execute_agent_session_pick(source.as_ref(), request),
         }
     } else {
-        resolve_agent_session_path(source.as_ref(), request.pick_current_session)?
+        resolve_agent_session_path(
+            source.as_ref(),
+            request.session_selector,
+            request.pick_current_session,
+        )?
     };
     let session = source.parse_session_file(&path)?;
     let provider_name = source.provider().name();
@@ -327,6 +333,7 @@ pub fn execute_agent_picker(request: AgentPickerRequest<'_>) -> Result<()> {
     let copy_request = AgentCopyRequest {
         provider: picked.provider,
         selector: None,
+        session_selector: None,
         pick: true,
         pick_current_session: request.pick_current_session,
         selection_mode: request.selection_mode,
@@ -1348,8 +1355,13 @@ fn finish_copy(text: String, print_full: bool, success_message: String) -> Resul
 
 fn resolve_agent_session_path(
     source: &dyn AgentSessionProvider,
+    session_selector: Option<&str>,
     pick_current_session: bool,
 ) -> Result<std::path::PathBuf> {
+    if let Some(selector) = session_selector {
+        return resolve_explicit_agent_session_path(source, selector);
+    }
+
     let cwd = std::env::current_dir().context("Failed to resolve current directory")?;
     if pick_current_session {
         return resolve_current_agent_pick_session_path(source, &cwd);
@@ -1358,6 +1370,62 @@ fn resolve_agent_session_path(
     source
         .find_current_session(&cwd)?
         .with_context(|| format!("No {} sessions found", source.provider().name()))
+}
+
+fn resolve_explicit_agent_session_path(
+    source: &dyn AgentSessionProvider,
+    selector: &str,
+) -> Result<std::path::PathBuf> {
+    let sessions = source.list_recent_sessions(None)?;
+    resolve_agent_session_selector(source, &sessions, selector)
+}
+
+fn resolve_agent_session_selector(
+    source: &dyn AgentSessionProvider,
+    sessions: &[AgentSessionInfo],
+    selector: &str,
+) -> Result<std::path::PathBuf> {
+    let selector = selector.trim();
+    if selector.is_empty() {
+        anyhow::bail!(
+            "Empty {} session selector. Use `--session 2`, `--session <id>`, or `--pick`.",
+            source.provider().name()
+        );
+    }
+
+    if let Ok(recent) = selector.parse::<usize>() {
+        if recent == 0 {
+            anyhow::bail!(
+                "Session selectors are 1-based. Use `--session 1` for the newest session."
+            );
+        }
+        if recent <= sessions.len() && !selector.starts_with('0') {
+            return Ok(sessions[recent - 1].path.clone());
+        }
+    }
+
+    sessions
+        .iter()
+        .find(|session| agent_session_matches_selector(session, selector))
+        .map(|session| session.path.clone())
+        .with_context(|| {
+            format!(
+                "No {} session matched `{selector}`. Use `--pick` to browse recent sessions.",
+                source.provider().name()
+            )
+        })
+}
+
+fn agent_session_matches_selector(session: &AgentSessionInfo, selector: &str) -> bool {
+    session
+        .id
+        .as_deref()
+        .is_some_and(|id| id == selector || id.starts_with(selector))
+        || session
+            .path
+            .file_stem()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.contains(selector))
 }
 
 fn resolve_current_agent_pick_session_path(
@@ -2191,9 +2259,9 @@ mod tests {
     use super::{
         agent_session_preview, build_agent_units, build_agent_vim_view,
         build_current_agent_session_choices, build_output_preview, filter_lines_by_regex,
-        filter_lines_by_spec, format_block, is_vim_command, vim_single_quote, AgentBlock,
-        AgentBlockKind, AgentProvider, AgentSelection, AgentSession, AgentSessionInfo,
-        AgentSessionProvider, CommandBlock, CommandSelection, CopyMode, TextPair,
+        filter_lines_by_spec, format_block, is_vim_command, resolve_agent_session_selector,
+        vim_single_quote, AgentBlock, AgentBlockKind, AgentProvider, AgentSelection, AgentSession,
+        AgentSessionInfo, AgentSessionProvider, CommandBlock, CommandSelection, CopyMode, TextPair,
     };
     use anyhow::Result;
     use std::path::{Path, PathBuf};
@@ -2552,6 +2620,7 @@ mod tests {
     fn current_agent_picker_lists_all_sessions_for_cwd() {
         let cwd = PathBuf::from("d:\\repo");
         let source = FakeAgentSource {
+            require_cwd: true,
             infos: vec![
                 AgentSessionInfo {
                     path: PathBuf::from("old.jsonl"),
@@ -2577,7 +2646,70 @@ mod tests {
         assert_eq!(choices[1].title, "[Codex] old task  [old]");
     }
 
+    #[test]
+    fn resolves_agent_session_selector_by_recent_index() {
+        let source = FakeAgentSource {
+            require_cwd: false,
+            infos: vec![
+                AgentSessionInfo {
+                    path: PathBuf::from("new.jsonl"),
+                    id: Some("new".to_string()),
+                    cwd: Some("d:\\repo".to_string()),
+                    modified: SystemTime::UNIX_EPOCH + Duration::from_secs(2),
+                },
+                AgentSessionInfo {
+                    path: PathBuf::from("old.jsonl"),
+                    id: Some("old".to_string()),
+                    cwd: Some("d:\\repo".to_string()),
+                    modified: SystemTime::UNIX_EPOCH + Duration::from_secs(1),
+                },
+            ],
+        };
+
+        let path = resolve_agent_session_selector(&source, &source.infos, "2").unwrap();
+
+        assert_eq!(path, PathBuf::from("old.jsonl"));
+    }
+
+    #[test]
+    fn resolves_agent_session_selector_by_id_prefix() {
+        let source = FakeAgentSource {
+            require_cwd: false,
+            infos: vec![AgentSessionInfo {
+                path: PathBuf::from("rollout-019df7fb.jsonl"),
+                id: Some("019df7fb-8289-7fb0-97c3-fe5307ee1b0a".to_string()),
+                cwd: Some("d:\\repo".to_string()),
+                modified: SystemTime::UNIX_EPOCH,
+            }],
+        };
+
+        let path = resolve_agent_session_selector(&source, &source.infos, "019df7fb").unwrap();
+
+        assert_eq!(path, PathBuf::from("rollout-019df7fb.jsonl"));
+    }
+
+    #[test]
+    fn rejects_zero_agent_session_selector() {
+        let source = FakeAgentSource {
+            require_cwd: false,
+            infos: vec![AgentSessionInfo {
+                path: PathBuf::from("only.jsonl"),
+                id: Some("only".to_string()),
+                cwd: Some("d:\\repo".to_string()),
+                modified: SystemTime::UNIX_EPOCH,
+            }],
+        };
+
+        let error = resolve_agent_session_selector(&source, &source.infos, "0").unwrap_err();
+
+        assert!(
+            error.to_string().contains("Session selectors are 1-based"),
+            "{error:#}"
+        );
+    }
+
     struct FakeAgentSource {
+        require_cwd: bool,
         infos: Vec<AgentSessionInfo>,
     }
 
@@ -2587,10 +2719,12 @@ mod tests {
         }
 
         fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
-            assert!(
-                cwd.is_some(),
-                "current picker must request cwd-filtered sessions"
-            );
+            if self.require_cwd {
+                assert!(
+                    cwd.is_some(),
+                    "current picker must request cwd-filtered sessions"
+                );
+            }
             Ok(self.infos.clone())
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,8 @@ use anyhow::Result;
 use clap::Parser;
 
 use cli::{
-    AgentCopyCommand, AgentCopyMode, Cli, Commands, CopyArgs, CopySimpleArgs, CopySubcommand,
-    DiffArgs, HotkeyPickAgentArgs, HotkeyServeArgs,
+    AgentCopyArgs, AgentCopyCommand, AgentCopyMode, Cli, Commands, CopyArgs, CopySimpleArgs,
+    CopySubcommand, DiffArgs, HotkeyPickAgentArgs, HotkeyServeArgs,
 };
 use command_blocks::CommandBlockTextMode;
 use commands::copy::{AgentCopyRequest, CopyMode, CopyRequest};
@@ -143,18 +143,19 @@ fn run_agent_copy(provider: AgentProvider, cmd: AgentCopyCommand) -> Result<()> 
 
 fn run_agent_copy_args(
     provider: AgentProvider,
-    args: &CopySimpleArgs,
+    args: &AgentCopyArgs,
     selection_mode: AgentSelection,
 ) -> Result<()> {
     commands::copy::execute_agent(AgentCopyRequest {
         provider,
-        selector: args.common.selector.as_deref(),
-        pick: args.common.pick,
+        selector: args.common.common.selector.as_deref(),
+        session_selector: args.session.as_deref(),
+        pick: args.common.common.pick,
         pick_current_session: false,
         selection_mode,
-        print_full: args.common.print,
-        regex: args.common.regex.as_deref(),
-        lines: args.common.lines.as_deref(),
+        print_full: args.common.common.print,
+        regex: args.common.common.regex.as_deref(),
+        lines: args.common.common.lines.as_deref(),
     })
 }
 


### PR DESCRIPTION
## Title: feat: add explicit AI session selectors for copy

### 1. Context & Motivation (Context)
- **Issue:** n/a
- **Problem:** `copy codex` / `copy claude` could select message units but could not explicitly target an older session by index or id, which blocked deterministic cross-session reuse workflows.
- **Trade-offs:** Explicit `--session N|ID` gives deterministic selection without changing implicit current-session behavior. This keeps defaults stable, at the cost of a slightly larger CLI surface.

### 2. Implementation Details (Implementation)
- Added `AgentCopyArgs` and wired `--session N|ID` through `copy codex` and `copy claude` modes (including nested `in/out/tool/all` modes).
- Added explicit session resolution logic in `copy` command path:
  - numeric selectors are 1-based recent-session indices
  - non-numeric selectors match session id / id prefix / file stem
  - empty / zero selectors return actionable errors
- Kept implicit current-session logic unchanged when `--session` is absent; when `--session` is provided, session picker fallback is bypassed and content is selected from the explicit session.
- **Note:** This PR is intentionally separated from shared export/mirror functionality.

### 3. Testing Strategies (Validation)
- [x] Added Unit Tests for selector resolution by recent index, id prefix, and zero-index rejection.
- [x] Added CLI parsing tests for `copy codex --session ...` and `copy claude --session ...`.
- [x] Ran Integration Test Suite against local Linux environment with `cargo test --workspace`.
- [x] Verified lint and formatting with `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings`.
- [x] Verified backward compatibility by keeping implicit session resolution unchanged when `--session` is not set.
- **Benchmark:** n/a
