### PR TITLE
feat(linux): add shortcut helpers for Codex picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,68 @@ Alt+Y
 
 You can rebind it to `Ctrl+Y`, but that usually overrides the editor Redo shortcut.
 
+On Linux, this VS Code shortcut works as the default picker shortcut when the
+editor has focus. The extension runs:
+
+```bash
+sivtr hotkey-pick-codex --cwd .
+```
+
+and `sivtr` prefers the active `codex` / `codex resume` session when one is
+available.
+
+### Linux Shortcut Setup
+
+Linux does not currently ship a default global `sivtr` hotkey outside VS Code.
+
+Reasons:
+
+- Wayland does not provide a universal cross-desktop global hotkey API for
+  ordinary CLI apps.
+- X11-only approaches are legacy and do not cover common Wayland desktops.
+- Opening the picker also needs an interactive terminal, and Linux does not
+  have one portable terminal-launch command that works across GNOME, KDE,
+  Sway, headless SSH, and tmux-based Codex setups.
+
+Recommended Linux setups:
+
+- VS Code: use the built-in `Alt+Y` command binding.
+- tmux: install a helper that binds `prefix + y` to the current pane's working
+  directory:
+
+```bash
+sivtr init tmux
+tmux source-file ~/.tmux.conf
+```
+
+The generated block is:
+
+```tmux
+bind-key y new-window -c "#{pane_current_path}" "sivtr hotkey-pick-codex --cwd '#{pane_current_path}'"
+```
+
+- Terminal / desktop environment: generate a launcher for the current project:
+
+```bash
+sivtr init linux-shortcut
+```
+
+This writes:
+
+- `~/.local/bin/sivtr-pick-codex`
+- `~/.local/share/applications/sivtr-pick-codex.desktop`
+
+The launcher opens a terminal and runs:
+
+```bash
+sivtr hotkey-pick-codex --cwd "<project-path>"
+```
+
+Typical Linux usage examples:
+
+- GNOME / KDE: bind your desktop shortcut to `~/.local/bin/sivtr-pick-codex`.
+- Plain terminal launcher: run `~/.local/bin/sivtr-pick-codex`.
+- Manual one-off command: `sivtr hotkey-pick-codex --cwd /path/to/project`.
 ### Windows Global Hotkey
 
 On Windows, the hotkey daemon can open the AI session picker from anywhere:
@@ -200,7 +262,7 @@ The default shortcut is `alt+y`.
 | `sivtr diff <left> <right>` | Compare recent command blocks. |
 | `sivtr history` | List, search, and show captured output history. |
 | `sivtr config` | Manage the TOML config file. |
-| `sivtr init <shell>` | Generate shell integration for command-block capture. |
+| `sivtr init <target>` | Generate shell integration or Linux shortcut helpers. |
 | `sivtr import` | Open the current session log. |
 | `sivtr hotkey` | Manage the Windows AI session picker hotkey. |
 | `sivtr clear` | Clear session logs. |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -177,6 +177,65 @@ Alt+Y
 
 你可以改成 `Ctrl+Y`，但它通常会覆盖编辑器的 Redo。
 
+在 Linux 上，当焦点位于 VS Code 编辑器时，这个快捷键就是默认的
+Codex picker 快捷键。插件实际执行的是：
+
+```bash
+sivtr hotkey-pick-codex --cwd .
+```
+
+如果当前终端正运行在活动中的 `codex` 或 `codex resume` 会话里，
+`sivtr` 会优先使用这个精确会话。
+
+### Linux 快捷键设置
+
+Linux 目前没有提供 VS Code 之外的默认全局 `sivtr` 热键。
+
+原因：
+
+- Wayland 不给普通 CLI 工具提供统一的跨桌面全局热键接口。
+- 只做 X11 方案已经不够，因为很多 Linux 桌面环境默认是 Wayland。
+- 打开 picker 还需要一个交互式终端，而 GNOME、KDE、Sway、纯 SSH、
+  tmux 等环境并没有统一可移植的终端启动命令。
+
+推荐的 Linux 设置方式：
+
+- VS Code：直接使用内置的 `Alt+Y`。
+- tmux：安装一个把 `prefix + y` 绑定到当前 pane 目录的 helper：
+
+```bash
+sivtr init tmux
+tmux source-file ~/.tmux.conf
+```
+
+生成的配置块是：
+
+```tmux
+bind-key y new-window -c "#{pane_current_path}" "sivtr hotkey-pick-codex --cwd '#{pane_current_path}'"
+```
+
+- 终端或桌面环境：为当前项目生成一个 launcher：
+
+```bash
+sivtr init linux-shortcut
+```
+
+它会写入：
+
+- `~/.local/bin/sivtr-pick-codex`
+- `~/.local/share/applications/sivtr-pick-codex.desktop`
+
+这个 launcher 会打开一个终端，并执行：
+
+```bash
+sivtr hotkey-pick-codex --cwd "<project-path>"
+```
+
+常见 Linux 使用示例：
+
+- GNOME / KDE：把 `~/.local/bin/sivtr-pick-codex` 绑定到你的桌面快捷键。
+- 纯终端启动：直接运行 `~/.local/bin/sivtr-pick-codex`。
+- 一次性手动执行：`sivtr hotkey-pick-codex --cwd /path/to/project`。
 ### Windows 全局热键
 
 Windows 上可以启动全局热键守护进程：
@@ -200,7 +259,7 @@ sivtr hotkey stop
 | `sivtr diff <left> <right>` | 对比最近命令输出。 |
 | `sivtr history` | 列出、搜索、查看输出历史。 |
 | `sivtr config` | 管理 TOML 配置。 |
-| `sivtr init <shell>` | 生成命令块捕获所需的 shell 集成。 |
+| `sivtr init <target>` | 生成 shell 集成或 Linux 快捷键 helper。 |
 | `sivtr import` | 打开当前 session log。 |
 | `sivtr hotkey` | 管理 Windows AI session picker 热键。 |
 | `sivtr clear` | 清空 session logs。 |

--- a/docs-site/src/content/docs/usage/hotkey.md
+++ b/docs-site/src/content/docs/usage/hotkey.md
@@ -5,6 +5,11 @@ description: Start, stop, and configure the Windows AI session picker hotkey.
 
 The hotkey daemon is currently Windows-only. It registers one global shortcut and opens a new terminal window that runs the AI session picker for the working directory where the daemon was started.
 
+Linux does not currently ship a default desktop-wide `sivtr` hotkey. Wayland
+does not expose a universal cross-desktop global hotkey API for ordinary CLI
+apps, and launching the picker also requires an interactive terminal that is
+not portable across GNOME, KDE, Sway, tmux, and headless SSH sessions.
+
 ## Start
 
 ```bash
@@ -65,3 +70,28 @@ the session picker.
 
 Plain `sivtr copy codex --pick` is different: it always starts with the session
 picker.
+
+## Linux setups
+
+Use one of these Linux-specific entry points instead of a built-in global
+daemon:
+
+- VS Code: use the extension command bound to `Alt+Y` by default.
+- tmux: install the helper block and reload tmux:
+
+```bash
+sivtr init tmux
+tmux source-file ~/.tmux.conf
+```
+
+This binds `prefix + y` to the current pane path.
+
+- Desktop shortcut or terminal launcher: generate a project-specific launcher:
+
+```bash
+sivtr init linux-shortcut
+```
+
+This writes `~/.local/bin/sivtr-pick-codex` plus a desktop entry at
+`~/.local/share/applications/sivtr-pick-codex.desktop`. Bind your desktop
+shortcut to the script, or run it directly from a terminal.

--- a/docs-site/src/content/docs/zh-cn/usage/hotkey.md
+++ b/docs-site/src/content/docs/zh-cn/usage/hotkey.md
@@ -5,6 +5,11 @@ description: 启动、停止和配置 Windows Codex 选择器热键。
 
 热键守护进程目前仅支持 Windows。它注册一个全局快捷键，并打开一个新的终端窗口，为启动守护进程时的工作目录运行 Codex 选择器。
 
+Linux 目前没有内置的桌面级默认 `sivtr` 全局热键。原因是 Wayland
+没有给普通 CLI 工具提供统一的跨桌面全局热键接口，而打开 picker
+还需要一个交互式终端，这在 GNOME、KDE、Sway、tmux 和纯 SSH
+场景之间也没有统一可移植的启动方式。
+
 ## 启动
 
 ```bash
@@ -62,3 +67,26 @@ sivtr hotkey-pick-agent --cwd <daemon-working-directory> --provider all
 这个内部命令会先打开守护进程工作目录下最新的非空 Codex 会话。如果这个会话不存在或为空，再退回到会话选择器。
 
 普通的 `sivtr copy codex --pick` 不同：它总是从会话选择器开始。
+
+## Linux 设置方式
+
+在 Linux 上，推荐使用以下入口之一，而不是依赖内置全局守护进程：
+
+- VS Code：使用插件默认绑定的 `Alt+Y`。
+- tmux：安装 helper 配置块并重新加载 tmux：
+
+```bash
+sivtr init tmux
+tmux source-file ~/.tmux.conf
+```
+
+它会把 `prefix + y` 绑定到当前 pane 的工作目录。
+
+- 桌面快捷键或终端 launcher：为当前项目生成 launcher：
+
+```bash
+sivtr init linux-shortcut
+```
+
+它会写入 `~/.local/bin/sivtr-pick-codex`，以及
+`~/.local/share/applications/sivtr-pick-codex.desktop`。你可以把桌面快捷键绑定到这个脚本，或者直接在终端里运行它。

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -224,9 +224,9 @@ pub enum Commands {
     /// Manage configuration
     Config(ConfigCommand),
 
-    /// Generate shell integration hook
+    /// Generate shell integration or Linux shortcut helpers
     Init {
-        /// Shell type: powershell, bash, zsh, nushell
+        /// Integration target: powershell, bash, zsh, nushell, tmux, linux-shortcut
         shell: String,
     },
 
@@ -751,6 +751,26 @@ mod tests {
                 assert_eq!(args, vec!["-lc".to_string(), "printf ok".to_string()]);
             }
             _ => panic!("expected run command"),
+        }
+    }
+
+    #[test]
+    fn init_accepts_tmux_target() {
+        let cli = Cli::try_parse_from(["sivtr", "init", "tmux"]).unwrap();
+
+        match cli.command {
+            Some(Commands::Init { shell }) => assert_eq!(shell, "tmux"),
+            _ => panic!("expected init command"),
+        }
+    }
+
+    #[test]
+    fn init_accepts_linux_shortcut_target() {
+        let cli = Cli::try_parse_from(["sivtr", "init", "linux-shortcut"]).unwrap();
+
+        match cli.command {
+            Some(Commands::Init { shell }) => assert_eq!(shell, "linux-shortcut"),
+            _ => panic!("expected init command"),
         }
     }
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -4,6 +4,9 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 #[cfg(windows)]
 use crate::cli::{HotkeyAction, HotkeyCommand, HotkeyStartArgs};
 #[cfg(windows)]
@@ -126,6 +129,13 @@ if (($env.SIVTR_PROMPT_WRAPPED? | default false) != true) {
 # <<< sivtr shell integration <<<
 "#;
 
+const TMUX_MARKER_START: &str = "# >>> sivtr tmux shortcut >>>";
+const TMUX_MARKER_END: &str = "# <<< sivtr tmux shortcut <<<";
+const TMUX_HOOK: &str = r##"# >>> sivtr tmux shortcut >>>
+bind-key y new-window -c "#{pane_current_path}" "sivtr hotkey-pick-codex --cwd '#{pane_current_path}'"
+# <<< sivtr tmux shortcut <<<
+"##;
+
 const POWERSHELL_SPEC: HookSpec = HookSpec {
     hook: POWERSHELL_HOOK,
     marker_start: POWERSHELL_MARKER_START,
@@ -162,6 +172,15 @@ const NUSHELL_SPEC: HookSpec = HookSpec {
     legacy_hook: None,
 };
 
+const TMUX_SPEC: HookSpec = HookSpec {
+    hook: TMUX_HOOK,
+    marker_start: TMUX_MARKER_START,
+    marker_end: TMUX_MARKER_END,
+    legacy_marker_start: TMUX_MARKER_START,
+    legacy_marker_end: TMUX_MARKER_END,
+    legacy_hook: None,
+};
+
 enum InstallStatus {
     Installed,
     Updated,
@@ -175,9 +194,13 @@ pub fn execute(shell: &str) -> Result<()> {
         "bash" => install_single_shell_hook(&bash_profile_path()?, &BASH_SPEC),
         "zsh" => install_single_shell_hook(&zsh_profile_path()?, &ZSH_SPEC),
         "nu" | "nushell" => install_single_shell_hook(&nushell_config_path()?, &NUSHELL_SPEC),
+        "tmux" => install_tmux_shortcut(),
+        "linux-shortcut" => install_linux_shortcut(),
         _ => {
-            eprintln!("sivtr: supported shells are powershell, bash, zsh, nushell");
-            eprintln!("  usage: sivtr init <powershell|bash|zsh|nushell>");
+            eprintln!(
+                "sivtr: supported targets are powershell, bash, zsh, nushell, tmux, linux-shortcut"
+            );
+            eprintln!("  usage: sivtr init <powershell|bash|zsh|nushell|tmux|linux-shortcut>");
             std::process::exit(1);
         }
     }?;
@@ -224,6 +247,69 @@ fn install_single_shell_hook(profile_path: &Path, spec: &HookSpec) -> Result<()>
             eprintln!("sivtr: no new installation needed (already set up)");
         }
     }
+    Ok(())
+}
+
+fn install_tmux_shortcut() -> Result<()> {
+    #[cfg(not(unix))]
+    {
+        anyhow::bail!("`sivtr init tmux` is only supported on Unix-like systems");
+    }
+
+    let path = tmux_config_path()?;
+    match install_into_profile(&path, &TMUX_SPEC)? {
+        InstallStatus::Installed => {
+            eprintln!("sivtr: installed tmux shortcut into {}", path.display());
+            eprintln!("  shortcut: prefix + y");
+            eprintln!("  reload with: tmux source-file {}", path.display());
+        }
+        InstallStatus::Updated => {
+            eprintln!("sivtr: updated tmux shortcut in {}", path.display());
+            eprintln!("  shortcut: prefix + y");
+            eprintln!("  reload with: tmux source-file {}", path.display());
+        }
+        InstallStatus::Unchanged => {
+            eprintln!(
+                "sivtr: tmux shortcut already installed in {}",
+                path.display()
+            );
+            eprintln!("  shortcut: prefix + y");
+        }
+    }
+    Ok(())
+}
+
+fn install_linux_shortcut() -> Result<()> {
+    #[cfg(not(unix))]
+    {
+        anyhow::bail!("`sivtr init linux-shortcut` is only supported on Unix-like systems");
+    }
+
+    let home = dirs::home_dir().context("Failed to resolve home directory")?;
+    let bin_dir = home.join(".local").join("bin");
+    let applications_dir = home.join(".local").join("share").join("applications");
+    fs::create_dir_all(&bin_dir)?;
+    fs::create_dir_all(&applications_dir)?;
+
+    let cwd = std::env::current_dir().context("Failed to resolve current directory")?;
+    let terminal = detect_linux_terminal();
+    let script_path = bin_dir.join("sivtr-pick-codex");
+    let desktop_path = applications_dir.join("sivtr-pick-codex.desktop");
+
+    write_linux_shortcut_script(&script_path, &cwd, terminal.as_deref())?;
+    write_linux_shortcut_desktop_entry(&desktop_path, &script_path)?;
+
+    eprintln!("sivtr: installed Linux shortcut launcher");
+    eprintln!("  script:  {}", script_path.display());
+    eprintln!("  desktop: {}", desktop_path.display());
+    if let Some(terminal) = terminal {
+        eprintln!("  terminal: {terminal}");
+    } else {
+        eprintln!(
+            "  terminal: not auto-detected; edit the script before binding a desktop shortcut"
+        );
+    }
+    eprintln!("  bind your desktop shortcut to: {}", script_path.display());
     Ok(())
 }
 
@@ -323,6 +409,11 @@ fn nushell_config_path() -> Result<PathBuf> {
     Ok(config_dir.join("nushell").join("config.nu"))
 }
 
+fn tmux_config_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("Failed to resolve home directory")?;
+    Ok(home.join(".tmux.conf"))
+}
+
 fn get_ps_profile(cmd: &str) -> Result<String> {
     let output = Command::new(cmd)
         .args(["-NoProfile", "-Command", "Write-Output $PROFILE"])
@@ -379,6 +470,86 @@ fn update_existing_hook(content: &str, spec: &HookSpec) -> Option<String> {
     None
 }
 
+fn detect_linux_terminal() -> Option<String> {
+    for candidate in [
+        "x-terminal-emulator",
+        "gnome-terminal",
+        "konsole",
+        "kitty",
+        "alacritty",
+        "foot",
+        "wezterm",
+        "xterm",
+    ] {
+        if command_exists(candidate) {
+            return Some(candidate.to_string());
+        }
+    }
+    None
+}
+
+fn command_exists(name: &str) -> bool {
+    std::env::var_os("PATH")
+        .map(|paths| {
+            std::env::split_paths(&paths).any(|dir| {
+                let candidate = dir.join(name);
+                candidate.is_file()
+            })
+        })
+        .unwrap_or(false)
+}
+
+fn write_linux_shortcut_script(path: &Path, cwd: &Path, terminal: Option<&str>) -> Result<()> {
+    let script = render_linux_shortcut_script(cwd, terminal);
+    fs::write(path, script)?;
+    #[cfg(unix)]
+    {
+        let mut perms = fs::metadata(path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms)?;
+    }
+    Ok(())
+}
+
+fn render_linux_shortcut_script(cwd: &Path, terminal: Option<&str>) -> String {
+    let cwd = shell_single_quote(&cwd.to_string_lossy());
+    let launcher = terminal
+        .map(build_terminal_launch_command)
+        .unwrap_or_else(|| {
+            "printf 'Edit this launcher to choose a terminal, then run again.\\n'; read -r _"
+                .to_string()
+        });
+
+    format!("#!/usr/bin/env bash\nset -euo pipefail\nexport PROJECT_CWD='{cwd}'\n{launcher}\n")
+}
+
+fn build_terminal_launch_command(terminal: &str) -> String {
+    let picker = "sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\"";
+    match terminal {
+        "gnome-terminal" => format!("exec gnome-terminal -- bash -lc '{picker}'"),
+        "konsole" => format!("exec konsole --noclose -e bash -lc '{picker}'"),
+        "kitty" => format!("exec kitty bash -lc '{picker}'"),
+        "alacritty" => format!("exec alacritty -e bash -lc '{picker}'"),
+        "foot" => format!("exec foot bash -lc '{picker}'"),
+        "wezterm" => format!("exec wezterm start --cwd \"$PROJECT_CWD\" -- bash -lc '{picker}'"),
+        "xterm" => format!("exec xterm -e bash -lc '{picker}'"),
+        _ => format!("exec {terminal} -e bash -lc '{picker}'"),
+    }
+}
+
+fn write_linux_shortcut_desktop_entry(path: &Path, script_path: &Path) -> Result<()> {
+    let desktop = format!(
+        "[Desktop Entry]\nType=Application\nName=Sivtr Pick Codex\nExec={}\nTerminal=false\nCategories=Development;\n",
+        script_path.display()
+    );
+    fs::write(path, desktop)?;
+    Ok(())
+}
+
+fn shell_single_quote(value: &str) -> String {
+    value.replace('\'', "'\"'\"'")
+}
+
 fn find_marked_block(
     content: &str,
     start_marker: &str,
@@ -393,9 +564,12 @@ fn find_marked_block(
 #[cfg(test)]
 mod tests {
     use super::{
-        update_existing_hook, BASH_HOOK, BASH_SPEC, LEGACY_POWERSHELL_HOOK, NUSHELL_HOOK,
-        NUSHELL_SPEC, POWERSHELL_HOOK, POWERSHELL_SPEC, ZSH_HOOK, ZSH_SPEC,
+        build_terminal_launch_command, command_exists, render_linux_shortcut_script,
+        shell_single_quote, update_existing_hook, BASH_HOOK, BASH_SPEC, LEGACY_POWERSHELL_HOOK,
+        NUSHELL_HOOK, NUSHELL_SPEC, POWERSHELL_HOOK, POWERSHELL_SPEC, TMUX_HOOK, TMUX_SPEC,
+        ZSH_HOOK, ZSH_SPEC,
     };
+    use std::path::Path;
 
     #[cfg(windows)]
     use super::parse_yes_no_default_yes;
@@ -452,6 +626,41 @@ mod tests {
             update_existing_hook(&profile, &NUSHELL_SPEC).expect("nushell hook should be detected");
 
         assert_eq!(updated, profile);
+    }
+
+    #[test]
+    fn replaces_existing_tmux_block() {
+        let profile = format!("before\n{TMUX_HOOK}\nafter\n");
+        let updated =
+            update_existing_hook(&profile, &TMUX_SPEC).expect("tmux hook should be detected");
+
+        assert_eq!(updated, profile);
+    }
+
+    #[test]
+    fn gnome_terminal_launcher_uses_project_cwd() {
+        let command = build_terminal_launch_command("gnome-terminal");
+
+        assert!(command.contains("gnome-terminal"));
+        assert!(command.contains("sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\""));
+    }
+
+    #[test]
+    fn shell_single_quote_escapes_single_quotes() {
+        assert_eq!(shell_single_quote("/tmp/it's"), "/tmp/it'\"'\"'s");
+    }
+
+    #[test]
+    fn linux_shortcut_script_exports_project_cwd() {
+        let script = render_linux_shortcut_script(Path::new("/tmp/project"), Some("xterm"));
+
+        assert!(script.contains("export PROJECT_CWD='/tmp/project'"));
+        assert!(script.contains("sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\""));
+    }
+
+    #[test]
+    fn command_exists_detects_programs_via_path_scan() {
+        assert!(command_exists("sh"));
     }
 
     #[cfg(windows)]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -250,12 +250,8 @@ fn install_single_shell_hook(profile_path: &Path, spec: &HookSpec) -> Result<()>
     Ok(())
 }
 
+#[cfg(unix)]
 fn install_tmux_shortcut() -> Result<()> {
-    #[cfg(not(unix))]
-    {
-        anyhow::bail!("`sivtr init tmux` is only supported on Unix-like systems");
-    }
-
     let path = tmux_config_path()?;
     match install_into_profile(&path, &TMUX_SPEC)? {
         InstallStatus::Installed => {
@@ -279,12 +275,13 @@ fn install_tmux_shortcut() -> Result<()> {
     Ok(())
 }
 
-fn install_linux_shortcut() -> Result<()> {
-    #[cfg(not(unix))]
-    {
-        anyhow::bail!("`sivtr init linux-shortcut` is only supported on Unix-like systems");
-    }
+#[cfg(not(unix))]
+fn install_tmux_shortcut() -> Result<()> {
+    anyhow::bail!("`sivtr init tmux` is only supported on Unix-like systems");
+}
 
+#[cfg(unix)]
+fn install_linux_shortcut() -> Result<()> {
     let home = dirs::home_dir().context("Failed to resolve home directory")?;
     let bin_dir = home.join(".local").join("bin");
     let applications_dir = home.join(".local").join("share").join("applications");
@@ -311,6 +308,11 @@ fn install_linux_shortcut() -> Result<()> {
     }
     eprintln!("  bind your desktop shortcut to: {}", script_path.display());
     Ok(())
+}
+
+#[cfg(not(unix))]
+fn install_linux_shortcut() -> Result<()> {
+    anyhow::bail!("`sivtr init linux-shortcut` is only supported on Unix-like systems");
 }
 
 fn print_install_summary(installed: &[String], updated: &[String]) {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -129,8 +129,11 @@ if (($env.SIVTR_PROMPT_WRAPPED? | default false) != true) {
 # <<< sivtr shell integration <<<
 "#;
 
+#[cfg(unix)]
 const TMUX_MARKER_START: &str = "# >>> sivtr tmux shortcut >>>";
+#[cfg(unix)]
 const TMUX_MARKER_END: &str = "# <<< sivtr tmux shortcut <<<";
+#[cfg(unix)]
 const TMUX_HOOK: &str = r##"# >>> sivtr tmux shortcut >>>
 bind-key y new-window -c "#{pane_current_path}" "sivtr hotkey-pick-codex --cwd '#{pane_current_path}'"
 # <<< sivtr tmux shortcut <<<
@@ -172,6 +175,7 @@ const NUSHELL_SPEC: HookSpec = HookSpec {
     legacy_hook: None,
 };
 
+#[cfg(unix)]
 const TMUX_SPEC: HookSpec = HookSpec {
     hook: TMUX_HOOK,
     marker_start: TMUX_MARKER_START,
@@ -411,6 +415,7 @@ fn nushell_config_path() -> Result<PathBuf> {
     Ok(config_dir.join("nushell").join("config.nu"))
 }
 
+#[cfg(unix)]
 fn tmux_config_path() -> Result<PathBuf> {
     let home = dirs::home_dir().context("Failed to resolve home directory")?;
     Ok(home.join(".tmux.conf"))
@@ -472,6 +477,7 @@ fn update_existing_hook(content: &str, spec: &HookSpec) -> Option<String> {
     None
 }
 
+#[cfg(unix)]
 fn detect_linux_terminal() -> Option<String> {
     for candidate in [
         "x-terminal-emulator",
@@ -490,6 +496,7 @@ fn detect_linux_terminal() -> Option<String> {
     None
 }
 
+#[cfg(unix)]
 fn command_exists(name: &str) -> bool {
     std::env::var_os("PATH")
         .map(|paths| {
@@ -501,6 +508,7 @@ fn command_exists(name: &str) -> bool {
         .unwrap_or(false)
 }
 
+#[cfg(unix)]
 fn write_linux_shortcut_script(path: &Path, cwd: &Path, terminal: Option<&str>) -> Result<()> {
     let script = render_linux_shortcut_script(cwd, terminal);
     fs::write(path, script)?;
@@ -513,6 +521,7 @@ fn write_linux_shortcut_script(path: &Path, cwd: &Path, terminal: Option<&str>) 
     Ok(())
 }
 
+#[cfg(unix)]
 fn render_linux_shortcut_script(cwd: &Path, terminal: Option<&str>) -> String {
     let cwd = shell_single_quote(&cwd.to_string_lossy());
     let launcher = terminal
@@ -525,6 +534,7 @@ fn render_linux_shortcut_script(cwd: &Path, terminal: Option<&str>) -> String {
     format!("#!/usr/bin/env bash\nset -euo pipefail\nexport PROJECT_CWD='{cwd}'\n{launcher}\n")
 }
 
+#[cfg(unix)]
 fn build_terminal_launch_command(terminal: &str) -> String {
     let picker = "sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\"";
     match terminal {
@@ -539,6 +549,7 @@ fn build_terminal_launch_command(terminal: &str) -> String {
     }
 }
 
+#[cfg(unix)]
 fn write_linux_shortcut_desktop_entry(path: &Path, script_path: &Path) -> Result<()> {
     let desktop = format!(
         "[Desktop Entry]\nType=Application\nName=Sivtr Pick Codex\nExec={}\nTerminal=false\nCategories=Development;\n",
@@ -548,6 +559,7 @@ fn write_linux_shortcut_desktop_entry(path: &Path, script_path: &Path) -> Result
     Ok(())
 }
 
+#[cfg(unix)]
 fn shell_single_quote(value: &str) -> String {
     value.replace('\'', "'\"'\"'")
 }
@@ -565,12 +577,16 @@ fn find_marked_block(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
     use super::{
         build_terminal_launch_command, command_exists, render_linux_shortcut_script,
-        shell_single_quote, update_existing_hook, BASH_HOOK, BASH_SPEC, LEGACY_POWERSHELL_HOOK,
-        NUSHELL_HOOK, NUSHELL_SPEC, POWERSHELL_HOOK, POWERSHELL_SPEC, TMUX_HOOK, TMUX_SPEC,
-        ZSH_HOOK, ZSH_SPEC,
+        shell_single_quote, TMUX_HOOK, TMUX_SPEC,
     };
+    use super::{
+        update_existing_hook, BASH_HOOK, BASH_SPEC, LEGACY_POWERSHELL_HOOK, NUSHELL_HOOK,
+        NUSHELL_SPEC, POWERSHELL_HOOK, POWERSHELL_SPEC, ZSH_HOOK, ZSH_SPEC,
+    };
+    #[cfg(unix)]
     use std::path::Path;
 
     #[cfg(windows)]
@@ -630,6 +646,7 @@ mod tests {
         assert_eq!(updated, profile);
     }
 
+    #[cfg(unix)]
     #[test]
     fn replaces_existing_tmux_block() {
         let profile = format!("before\n{TMUX_HOOK}\nafter\n");
@@ -639,6 +656,7 @@ mod tests {
         assert_eq!(updated, profile);
     }
 
+    #[cfg(unix)]
     #[test]
     fn gnome_terminal_launcher_uses_project_cwd() {
         let command = build_terminal_launch_command("gnome-terminal");
@@ -647,11 +665,13 @@ mod tests {
         assert!(command.contains("sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\""));
     }
 
+    #[cfg(unix)]
     #[test]
     fn shell_single_quote_escapes_single_quotes() {
         assert_eq!(shell_single_quote("/tmp/it's"), "/tmp/it'\"'\"'s");
     }
 
+    #[cfg(unix)]
     #[test]
     fn linux_shortcut_script_exports_project_cwd() {
         let script = render_linux_shortcut_script(Path::new("/tmp/project"), Some("xterm"));
@@ -660,6 +680,7 @@ mod tests {
         assert!(script.contains("sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\""));
     }
 
+    #[cfg(unix)]
     #[test]
     fn command_exists_detects_programs_via_path_scan() {
         assert!(command_exists("sh"));


### PR DESCRIPTION
## Title: feat: add Linux shortcut helpers for Codex picker

### 1. Context & Motivation (Context)
- **Issue:** n/a
- **Problem:** Linux users outside VS Code still lacked an official, reproducible entrypoint for `hotkey-pick-codex`, and manual setup drift caused inconsistent behavior across tmux and desktop launchers.
- **Trade-offs:** This adds target-specific setup commands (`tmux`, `linux-shortcut`) instead of a pseudo-global daemon on Linux. It trades one extra install step for predictable, environment-aware behavior without relying on unsupported Wayland-wide hooks.

### 2. Implementation Details (Implementation)
- Added `sivtr init tmux` to inject/update a marked `~/.tmux.conf` block binding `prefix + y` to `sivtr hotkey-pick-codex --cwd "#{pane_current_path}"`.
- Added `sivtr init linux-shortcut` to generate `~/.local/bin/sivtr-pick-codex` plus desktop entry, with terminal auto-detection and executable script permissions on Unix.
- Updated CLI help text and Linux hotkey docs (English + Chinese) for the new init targets and recommended setup flows.
- Replaced `which` probing with PATH scanning in `command_exists()` for better portability in constrained/non-standard shells.
- **Note:** This PR intentionally keeps session-selection semantics unchanged and does not modify shared mirror/session-selector features.

### 3. Testing Strategies (Validation)
- [x] Added Unit Tests for tmux marker replacement, launcher command generation, single-quote escaping, Linux script rendering, and PATH-based command detection.
- [x] Ran Integration Test Suite against local Linux environment with `cargo test --workspace`.
- [x] Verified lint/format with `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings`.
- [x] Verified backward compatibility for existing shell hook targets (`powershell`, `bash`, `zsh`, `nushell`).
- **Benchmark:** n/a
