### PR TITLE
feat(macos): sync fork PR set with full regression validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,6 +1286,7 @@ dependencies = [
  "serde_json",
  "similar",
  "sivtr-core",
+ "tempfile",
  "tokio",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,6 @@ serde_json = "1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["fileapi", "handleapi", "processenv", "processthreadsapi", "winbase", "winnt", "winuser", "windef", "minwindef"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ It is not a terminal emulator and not a multiplexer. It is a companion tool for 
 - Pipe any command into a searchable, selectable output viewer.
 - Record shell command blocks and copy recent inputs, outputs, or bare commands.
 - Read Codex session JSONL files and copy useful user, assistant, or tool blocks.
-- Open an AI session picker from VS Code with one shortcut.
+- Open a Codex picker from VS Code with one shortcut.
 - Filter copied text with regex and line ranges.
 - Keep a local SQLite history for later search.
 - Compare recent command outputs while iterating on tests and builds.
@@ -69,7 +69,7 @@ Install the VS Code bridge from the Marketplace:
 ariestar.sivtr-vscode
 ```
 
-The extension launches the AI session picker from the current workspace. If the `sivtr` CLI is missing, it offers to run `cargo install sivtr` in a visible terminal.
+The extension launches the Codex picker from the current workspace. If the `sivtr` CLI is missing, it offers to run `cargo install sivtr` in a visible terminal.
 
 ## Quick Start
 
@@ -149,40 +149,32 @@ sivtr copy out --lines 10:40
 
 ### Reuse Codex Sessions
 
-`sivtr copy codex` reads Codex rollout JSONL files from `~/.codex/sessions`. When an active Codex shell exports `CODEX_THREAD_ID`, `sivtr` prefers that exact local session first. Otherwise it chooses the newest local session whose `cwd` matches your current directory.
-
-For shared read-only access to another account's Codex sessions, mirror them into a separate directory and add that directory to `[codex].session_dirs` instead of running `sivtr` with elevated privileges. Shared/mirrored trees only participate in explicit browsing through `--pick`.
+`sivtr copy codex` reads Codex rollout JSONL files from `~/.codex/sessions`. When you run it inside an active `codex` or `codex resume` shell, it prefers that exact session id first. Otherwise it chooses the newest session whose `cwd` matches your current directory. Use `--session N` to target the Nth newest recorded session, or `--session ID` to target a specific session id / id prefix.
 
 ```bash
 sivtr copy codex        # latest completed user + assistant turn
+sivtr copy codex --session 2
+sivtr copy codex --session 019df7fb
 sivtr copy codex out    # latest assistant reply
+sivtr copy codex out --session 2 --print
 sivtr copy codex in     # latest user message
 sivtr copy codex tool   # latest tool output
 sivtr copy codex all    # parsed session
-sivtr copy codex --pick # browse local and mirrored sessions
+sivtr copy codex --session 2 --pick
+sivtr copy codex all --max-blocks 0
+sivtr copy codex all --max-blocks 10000
 ```
 
 Progress commentary is filtered by default, so `sivtr copy codex out` returns the final assistant reply instead of intermediate status updates.
 
-Mirror the current account's sessions into a shared tree:
-
-```bash
-sivtr codex export --dest /srv/sivtr/root-codex --watch
-```
-
-Then point another account at that mirrored tree:
-
-```toml
-[codex]
-session_dirs = ["/srv/sivtr/root-codex/sessions"]
-```
+Large Codex transcripts are capped to the latest `10000` parsed blocks by default for robustness. Set `[codex].max_blocks = 0` in config or pass `--max-blocks 0` for a full import.
 
 ### VS Code Shortcut
 
 The VS Code extension contributes:
 
 ```text
-Sivtr: Pick AI Session
+Sivtr: Pick Codex Turn
 ```
 
 Default keybinding:
@@ -193,9 +185,71 @@ Alt+Y
 
 You can rebind it to `Ctrl+Y`, but that usually overrides the editor Redo shortcut.
 
+On Linux, this VS Code shortcut works as the default picker shortcut when the
+editor has focus. The extension runs:
+
+```bash
+sivtr hotkey-pick-codex --cwd .
+```
+
+and `sivtr` prefers the active `codex` / `codex resume` session when one is
+available.
+
+On macOS, the same VS Code shortcut works as the default picker shortcut when
+the editor has focus.
+
+### Linux Shortcut Setup
+
+Linux does not currently ship a default global `sivtr` hotkey outside VS Code.
+
+Reasons:
+
+- Wayland does not provide a universal cross-desktop global hotkey API for
+  ordinary CLI apps.
+- X11-only approaches are legacy and do not cover common Wayland desktops.
+- Opening the picker also needs an interactive terminal, and Linux does not
+  have one portable terminal-launch command that works across GNOME, KDE,
+  Sway, headless SSH, and tmux-based Codex setups.
+
+Recommended Linux setups:
+
+- VS Code: use the built-in `Alt+Y` command binding.
+- tmux: bind a key to the current pane's working directory:
+
+```tmux
+bind-key y new-window -c "#{pane_current_path}" "sivtr hotkey-pick-codex --cwd '#{pane_current_path}'"
+```
+
+- Terminal / desktop environment: create a custom shortcut that launches
+  `sivtr hotkey-pick-codex --cwd <project-path>` in a terminal for the project
+  you want to inspect.
+
+### macOS Shortcut Setup
+
+macOS does not currently ship a built-in `sivtr` global hotkey daemon. The
+recommended default is the VS Code shortcut above.
+
+For a project-local Terminal launcher plus a LaunchAgent wrapper, generate the
+helper files on macOS:
+
+```bash
+sivtr init macos-shortcut
+```
+
+This writes:
+
+- `~/.local/bin/sivtr-pick-codex`
+- `~/Library/LaunchAgents/dev.sivtr.pick-codex.plist`
+
+You can:
+
+- run `~/.local/bin/sivtr-pick-codex` directly;
+- load the LaunchAgent with `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.sivtr.pick-codex.plist`;
+- keep using the VS Code command for the most reliable shortcut-driven flow.
+
 ### Windows Global Hotkey
 
-On Windows, the hotkey daemon can open the AI session picker from anywhere:
+On Windows, the hotkey daemon can open the Codex picker from anywhere:
 
 ```bash
 sivtr hotkey start
@@ -213,13 +267,12 @@ The default shortcut is `alt+y`.
 | `sivtr run <command>` | Execute a command, capture output, then browse it. |
 | `sivtr copy` | Copy recent command blocks. |
 | `sivtr copy codex` | Copy useful content from the current Codex session. |
-| `sivtr codex export --dest <path>` | Mirror local Codex sessions into a shared read-only tree. |
 | `sivtr diff <left> <right>` | Compare recent command blocks. |
 | `sivtr history` | List, search, and show captured output history. |
 | `sivtr config` | Manage the TOML config file. |
 | `sivtr init <shell>` | Generate shell integration for command-block capture. |
 | `sivtr import` | Open the current session log. |
-| `sivtr hotkey` | Manage the Windows AI session picker hotkey. |
+| `sivtr hotkey` | Manage the Windows Codex picker hotkey. |
 | `sivtr clear` | Clear session logs. |
 
 ## TUI Keys
@@ -271,7 +324,7 @@ sivtr/
 |- crates/sivtr-core/    # Capture, parsing, buffers, selection, search, history, export
 |- src/                  # CLI, TUI, commands, hotkey integration
 |- docs-site/            # Astro/Starlight documentation site
-|- editors/vscode/       # VS Code extension bridge for the AI session picker
+|- editors/vscode/       # VS Code extension bridge for the Codex picker
 `- .github/workflows/    # CI and release automation
 ```
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ On Linux, this VS Code shortcut works as the default picker shortcut when the
 editor has focus. The extension runs:
 
 ```bash
-sivtr hotkey-pick-codex --cwd .
+sivtr hotkey-pick-agent --cwd . --provider all
 ```
 
 and `sivtr` prefers the active `codex` / `codex resume` session when one is
@@ -217,11 +217,11 @@ Recommended Linux setups:
 - tmux: bind a key to the current pane's working directory:
 
 ```tmux
-bind-key y new-window -c "#{pane_current_path}" "sivtr hotkey-pick-codex --cwd '#{pane_current_path}'"
+bind-key y new-window -c "#{pane_current_path}" "sivtr copy codex all --pick"
 ```
 
 - Terminal / desktop environment: create a custom shortcut that launches
-  `sivtr hotkey-pick-codex --cwd <project-path>` in a terminal for the project
+  `cd <project-path> && sivtr copy codex all --pick` in a terminal for the project
   you want to inspect.
 
 ### macOS Shortcut Setup

--- a/README.md
+++ b/README.md
@@ -169,6 +169,16 @@ Progress commentary is filtered by default, so `sivtr copy codex out` returns th
 
 Large Codex transcripts are capped to the latest `10000` parsed blocks by default for robustness. Set `[codex].max_blocks = 0` in config or pass `--max-blocks 0` for a full import.
 
+To mirror sessions for another local account (for example read-only sharing),
+run export watch mode from the source account:
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex --watch --interval-ms 500
+```
+
+`--watch` defaults to a 1-second sync interval. Use `--interval-ms` for
+sub-second updates when you need faster session visibility.
+
 ### VS Code Shortcut
 
 The VS Code extension contributes:

--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ sivtr copy out --lines 10:40
 
 ### Reuse Codex Sessions
 
-`sivtr copy codex` reads Codex rollout JSONL files from `~/.codex/sessions` and chooses the newest session whose `cwd` matches your current directory.
+`sivtr copy codex` reads Codex rollout JSONL files from `~/.codex/sessions`. When an active Codex shell exports `CODEX_THREAD_ID`, `sivtr` prefers that exact local session first. Otherwise it chooses the newest local session whose `cwd` matches your current directory.
+
+For shared read-only access to another account's Codex sessions, mirror them into a separate directory and add that directory to `[codex].session_dirs` instead of running `sivtr` with elevated privileges. Shared/mirrored trees only participate in explicit browsing through `--pick`.
 
 ```bash
 sivtr copy codex        # latest completed user + assistant turn
@@ -157,9 +159,23 @@ sivtr copy codex out    # latest assistant reply
 sivtr copy codex in     # latest user message
 sivtr copy codex tool   # latest tool output
 sivtr copy codex all    # parsed session
+sivtr copy codex --pick # browse local and mirrored sessions
 ```
 
 Progress commentary is filtered by default, so `sivtr copy codex out` returns the final assistant reply instead of intermediate status updates.
+
+Mirror the current account's sessions into a shared tree:
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex --watch
+```
+
+Then point another account at that mirrored tree:
+
+```toml
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+```
 
 ### VS Code Shortcut
 
@@ -197,6 +213,7 @@ The default shortcut is `alt+y`.
 | `sivtr run <command>` | Execute a command, capture output, then browse it. |
 | `sivtr copy` | Copy recent command blocks. |
 | `sivtr copy codex` | Copy useful content from the current Codex session. |
+| `sivtr codex export --dest <path>` | Mirror local Codex sessions into a shared read-only tree. |
 | `sivtr diff <left> <right>` | Compare recent command blocks. |
 | `sivtr history` | List, search, and show captured output history. |
 | `sivtr config` | Manage the TOML config file. |

--- a/README.md
+++ b/README.md
@@ -217,11 +217,11 @@ Recommended Linux setups:
 - tmux: bind a key to the current pane's working directory:
 
 ```tmux
-bind-key y new-window -c "#{pane_current_path}" "sivtr copy codex all --pick"
+bind-key y new-window -c "#{pane_current_path}" "sivtr copy codex --pick"
 ```
 
 - Terminal / desktop environment: create a custom shortcut that launches
-  `cd <project-path> && sivtr copy codex all --pick` in a terminal for the project
+  `cd <project-path> && sivtr copy codex --pick` in a terminal for the project
   you want to inspect.
 
 ### macOS Shortcut Setup

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -169,6 +169,16 @@ sivtr copy codex all --max-blocks 10000
 
 为避免超大 Codex transcript 让导入或 picker 变慢，默认只保留最近 `10000` 个解析后的 block。若要全量导入，可在配置里设置 `[codex].max_blocks = 0`，或在命令行传 `--max-blocks 0`。
 
+如果你要把会话镜像给另一个本地账号做只读访问（例如 root 导出，jacob
+读取），可以在源账号启动持续导出：
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex --watch --interval-ms 500
+```
+
+`--watch` 默认每 1 秒同步一次；需要更快可见性时可用 `--interval-ms`
+改成毫秒级同步。
+
 ### VS Code 快捷键
 
 VS Code 插件提供命令：

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -42,7 +42,7 @@
 - 把任意命令输出通过管道送入可搜索、可选择的浏览器。
 - 记录 shell 命令块，之后复制最近的输入、输出或纯命令。
 - 读取 Codex 的 JSONL 会话文件，复制用户消息、助手回复或工具输出。
-- 在 VS Code 中用一个快捷键打开 AI session picker。
+- 在 VS Code 中用一个快捷键打开 Codex picker。
 - 支持用正则和行号范围过滤复制内容。
 - 用本地 SQLite 保存历史，之后可以检索。
 - 迭代测试和构建时，对比最近几次命令输出。
@@ -69,7 +69,7 @@ VS Code 插件：
 ariestar.sivtr-vscode
 ```
 
-插件会从当前 workspace 启动 AI session picker。如果没有安装 `sivtr` CLI，它会提示你是否在可见终端里运行 `cargo install sivtr`。
+插件会从当前 workspace 启动 Codex picker。如果没有安装 `sivtr` CLI，它会提示你是否在可见终端里运行 `cargo install sivtr`。
 
 ## 快速开始
 
@@ -149,40 +149,32 @@ sivtr copy out --lines 10:40
 
 ### 复用 Codex 会话
 
-`sivtr copy codex` 会读取 `~/.codex/sessions` 下的 Codex rollout JSONL 文件。如果当前 Codex shell 暴露了 `CODEX_THREAD_ID`，`sivtr` 会优先匹配这个本地精确会话；否则会优先选择 `cwd` 与当前目录匹配的最新本地会话。
-
-如果要只读共享另一个账号的 Codex 会话，推荐先把它们镜像到独立目录，再通过 `[codex].session_dirs` 读取，而不是用提权方式运行 `sivtr`。共享/镜像目录只参与 `--pick` 这类显式浏览，不会抢占当前本地会话解析。
+`sivtr copy codex` 会读取 `~/.codex/sessions` 下的 Codex rollout JSONL 文件。如果当前 shell 正运行在活动中的 `codex` 或 `codex resume` 会话里，它会优先使用这个精确会话 id；否则会优先选择 `cwd` 与当前目录匹配的最新会话。
 
 ```bash
 sivtr copy codex        # 最近一轮用户消息 + 助手回复
+sivtr copy codex --session 2
+sivtr copy codex --session 019df7fb
 sivtr copy codex out    # 最近助手回复
+sivtr copy codex out --session 2 --print
 sivtr copy codex in     # 最近用户消息
 sivtr copy codex tool   # 最近工具输出
 sivtr copy codex all    # 整个解析后的会话
-sivtr copy codex --pick # 浏览本地和共享镜像会话
+sivtr copy codex --session 2 --pick
+sivtr copy codex all --max-blocks 0
+sivtr copy codex all --max-blocks 10000
 ```
 
 默认会过滤过程性 commentary，所以 `sivtr copy codex out` 更倾向返回最终助手回复，而不是中间状态更新。
 
-先把当前账号的会话持续镜像成共享树：
-
-```bash
-sivtr codex export --dest /srv/sivtr/root-codex --watch
-```
-
-再让另一个账号在配置里引用镜像目录：
-
-```toml
-[codex]
-session_dirs = ["/srv/sivtr/root-codex/sessions"]
-```
+为避免超大 Codex transcript 让导入或 picker 变慢，默认只保留最近 `10000` 个解析后的 block。若要全量导入，可在配置里设置 `[codex].max_blocks = 0`，或在命令行传 `--max-blocks 0`。
 
 ### VS Code 快捷键
 
 VS Code 插件提供命令：
 
 ```text
-Sivtr: Pick AI Session
+Sivtr: Pick Codex Turn
 ```
 
 默认快捷键：
@@ -192,6 +184,39 @@ Alt+Y
 ```
 
 你可以改成 `Ctrl+Y`，但它通常会覆盖编辑器的 Redo。
+
+在 Linux 上，当焦点位于 VS Code 编辑器时，这个快捷键就是默认的
+Codex picker 快捷键。插件实际执行的是：
+
+```bash
+sivtr hotkey-pick-codex --cwd .
+```
+
+如果当前终端正运行在活动中的 `codex` 或 `codex resume` 会话里，
+`sivtr` 会优先使用这个精确会话。
+
+### Linux 快捷键设置
+
+Linux 目前没有提供 VS Code 之外的默认全局 `sivtr` 热键。
+
+原因：
+
+- Wayland 不给普通 CLI 工具提供统一的跨桌面全局热键接口。
+- 只做 X11 方案已经不够，因为很多 Linux 桌面环境默认是 Wayland。
+- 打开 picker 还需要一个交互式终端，而 GNOME、KDE、Sway、纯 SSH、
+  tmux 等环境并没有统一可移植的终端启动命令。
+
+推荐的 Linux 设置方式：
+
+- VS Code：直接使用内置的 `Alt+Y`。
+- tmux：给当前 pane 目录绑定一个快捷键：
+
+```tmux
+bind-key y new-window -c "#{pane_current_path}" "sivtr hotkey-pick-codex --cwd '#{pane_current_path}'"
+```
+
+- 终端或桌面环境：手动创建一个自定义快捷键，在终端中执行
+  `sivtr hotkey-pick-codex --cwd <project-path>`。
 
 ### Windows 全局热键
 
@@ -213,13 +238,12 @@ sivtr hotkey stop
 | `sivtr run <command>` | 执行命令、捕获输出并浏览。 |
 | `sivtr copy` | 复制最近命令块。 |
 | `sivtr copy codex` | 复制当前 Codex 会话中的有用内容。 |
-| `sivtr codex export --dest <path>` | 把本地 Codex 会话镜像成共享只读目录树。 |
 | `sivtr diff <left> <right>` | 对比最近命令输出。 |
 | `sivtr history` | 列出、搜索、查看输出历史。 |
 | `sivtr config` | 管理 TOML 配置。 |
 | `sivtr init <shell>` | 生成命令块捕获所需的 shell 集成。 |
 | `sivtr import` | 打开当前 session log。 |
-| `sivtr hotkey` | 管理 Windows AI session picker 热键。 |
+| `sivtr hotkey` | 管理 Windows Codex picker 热键。 |
 | `sivtr clear` | 清空 session logs。 |
 
 ## TUI 按键
@@ -271,7 +295,7 @@ sivtr/
 |- crates/sivtr-core/    # 捕获、解析、缓冲区、选择、搜索、历史、导出
 |- src/                  # CLI、TUI、命令、热键集成
 |- docs-site/            # Astro/Starlight 文档站
-|- editors/vscode/       # AI session picker 的 VS Code 插件桥接
+|- editors/vscode/       # Codex picker 的 VS Code 插件桥接
 `- .github/workflows/    # CI 和发布自动化
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -189,7 +189,7 @@ Alt+Y
 Codex picker 快捷键。插件实际执行的是：
 
 ```bash
-sivtr hotkey-pick-codex --cwd .
+sivtr hotkey-pick-agent --cwd . --provider all
 ```
 
 如果当前终端正运行在活动中的 `codex` 或 `codex resume` 会话里，
@@ -212,11 +212,11 @@ Linux 目前没有提供 VS Code 之外的默认全局 `sivtr` 热键。
 - tmux：给当前 pane 目录绑定一个快捷键：
 
 ```tmux
-bind-key y new-window -c "#{pane_current_path}" "sivtr hotkey-pick-codex --cwd '#{pane_current_path}'"
+bind-key y new-window -c "#{pane_current_path}" "sivtr copy codex all --pick"
 ```
 
 - 终端或桌面环境：手动创建一个自定义快捷键，在终端中执行
-  `sivtr hotkey-pick-codex --cwd <project-path>`。
+  `cd <project-path> && sivtr copy codex all --pick`。
 
 ### Windows 全局热键
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -149,7 +149,9 @@ sivtr copy out --lines 10:40
 
 ### 复用 Codex 会话
 
-`sivtr copy codex` 会读取 `~/.codex/sessions` 下的 Codex rollout JSONL 文件，并优先选择 `cwd` 与当前目录匹配的最新会话。
+`sivtr copy codex` 会读取 `~/.codex/sessions` 下的 Codex rollout JSONL 文件。如果当前 Codex shell 暴露了 `CODEX_THREAD_ID`，`sivtr` 会优先匹配这个本地精确会话；否则会优先选择 `cwd` 与当前目录匹配的最新本地会话。
+
+如果要只读共享另一个账号的 Codex 会话，推荐先把它们镜像到独立目录，再通过 `[codex].session_dirs` 读取，而不是用提权方式运行 `sivtr`。共享/镜像目录只参与 `--pick` 这类显式浏览，不会抢占当前本地会话解析。
 
 ```bash
 sivtr copy codex        # 最近一轮用户消息 + 助手回复
@@ -157,9 +159,23 @@ sivtr copy codex out    # 最近助手回复
 sivtr copy codex in     # 最近用户消息
 sivtr copy codex tool   # 最近工具输出
 sivtr copy codex all    # 整个解析后的会话
+sivtr copy codex --pick # 浏览本地和共享镜像会话
 ```
 
 默认会过滤过程性 commentary，所以 `sivtr copy codex out` 更倾向返回最终助手回复，而不是中间状态更新。
+
+先把当前账号的会话持续镜像成共享树：
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex --watch
+```
+
+再让另一个账号在配置里引用镜像目录：
+
+```toml
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+```
 
 ### VS Code 快捷键
 
@@ -197,6 +213,7 @@ sivtr hotkey stop
 | `sivtr run <command>` | 执行命令、捕获输出并浏览。 |
 | `sivtr copy` | 复制最近命令块。 |
 | `sivtr copy codex` | 复制当前 Codex 会话中的有用内容。 |
+| `sivtr codex export --dest <path>` | 把本地 Codex 会话镜像成共享只读目录树。 |
 | `sivtr diff <left> <right>` | 对比最近命令输出。 |
 | `sivtr history` | 列出、搜索、查看输出历史。 |
 | `sivtr config` | 管理 TOML 配置。 |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -212,11 +212,11 @@ Linux 目前没有提供 VS Code 之外的默认全局 `sivtr` 热键。
 - tmux：给当前 pane 目录绑定一个快捷键：
 
 ```tmux
-bind-key y new-window -c "#{pane_current_path}" "sivtr copy codex all --pick"
+bind-key y new-window -c "#{pane_current_path}" "sivtr copy codex --pick"
 ```
 
 - 终端或桌面环境：手动创建一个自定义快捷键，在终端中执行
-  `cd <project-path> && sivtr copy codex all --pick`。
+  `cd <project-path> && sivtr copy codex --pick`。
 
 ### Windows 全局热键
 

--- a/crates/sivtr-core/src/ai.rs
+++ b/crates/sivtr-core/src/ai.rs
@@ -233,13 +233,19 @@ pub fn parse_jsonl_session(
             continue;
         }
 
-        let value: Value = serde_json::from_str(&line).with_context(|| {
-            format!(
-                "Failed to parse {provider_name} session line {} as JSON: {}",
-                idx + 1,
-                path.display()
-            )
-        })?;
+        let value: Value = match serde_json::from_str(&line) {
+            Ok(value) => value,
+            Err(error) if idx > 0 && is_trailing_partial_json_line(&error) => break,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "Failed to parse {provider_name} session line {} as JSON: {}",
+                        idx + 1,
+                        path.display()
+                    )
+                });
+            }
+        };
         apply_event(&mut session, &value);
     }
 
@@ -372,6 +378,10 @@ fn normalize_path_for_match(path: &Path) -> String {
         .to_string_lossy()
         .replace('/', "\\")
         .to_lowercase()
+}
+
+fn is_trailing_partial_json_line(error: &serde_json::Error) -> bool {
+    matches!(error.classify(), serde_json::error::Category::Eof)
 }
 
 pub fn select_blocks(session: &AgentSession, selection: AgentSelection) -> Vec<AgentBlock> {

--- a/crates/sivtr-core/src/capture/scrollback.rs
+++ b/crates/sivtr-core/src/capture/scrollback.rs
@@ -85,6 +85,11 @@ fn session_pid_from_path(path: &Path) -> Option<u32> {
         .and_then(|rest| rest.strip_suffix(".state"))
     {
         pid
+    } else if let Some(pid) = name
+        .strip_prefix("session_")
+        .and_then(|rest| rest.strip_suffix(".capture"))
+    {
+        pid
     } else {
         return None;
     };
@@ -121,6 +126,15 @@ fn process_is_alive(pid: u32) -> bool {
 /// Get the flush state file path (derived from session log path).
 pub fn flush_state_path() -> std::path::PathBuf {
     session_log_path().with_extension("state")
+}
+
+/// Get the per-command capture file path used by Unix shell hooks.
+pub fn capture_file_path() -> std::path::PathBuf {
+    if let Ok(path) = env::var("SIVTR_CAPTURE_FILE") {
+        return PathBuf::from(path);
+    }
+
+    session_log_path().with_extension("capture")
 }
 
 /// Read the current session log populated by the shell hook.
@@ -354,6 +368,10 @@ mod tests {
         assert_eq!(session_pid_from_path(Path::new("session_42.log")), Some(42));
         assert_eq!(
             session_pid_from_path(Path::new("session_42.state")),
+            Some(42)
+        );
+        assert_eq!(
+            session_pid_from_path(Path::new("session_42.capture")),
             Some(42)
         );
         assert_eq!(session_pid_from_path(Path::new("session.log")), None);

--- a/crates/sivtr-core/src/codex.rs
+++ b/crates/sivtr-core/src/codex.rs
@@ -1,12 +1,14 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde_json::Value;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 use crate::ai::{
     extract_content_text, list_recent_jsonl_sessions, parse_jsonl_meta, parse_jsonl_session,
     pretty_json_string, pretty_json_value, push_block, AgentBlockKind, AgentProvider, AgentSession,
     AgentSessionInfo, AgentSessionMeta, AgentSessionProvider,
 };
+use crate::config::SivtrConfig;
 
 const PROVIDER_NAME: &str = "Codex";
 
@@ -19,11 +21,74 @@ impl AgentSessionProvider for CodexProvider {
     }
 
     fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
-        list_recent_jsonl_sessions(&codex_home().join("sessions"), cwd, parse_session_meta)
+        let wanted = cwd.map(normalize_path_for_match);
+        let mut sessions = Vec::new();
+
+        for root in configured_codex_session_dirs() {
+            for path in jsonl_files(&root)? {
+                let meta = parse_session_meta(&path)?;
+                if let Some(wanted) = wanted.as_deref() {
+                    let matches_cwd = meta
+                        .cwd
+                        .as_deref()
+                        .map(|cwd| normalize_path_for_match(Path::new(cwd)) == wanted)
+                        .unwrap_or(false);
+                    if !matches_cwd {
+                        continue;
+                    }
+                }
+
+                sessions.push(AgentSessionInfo {
+                    modified: std::fs::metadata(&path)
+                        .and_then(|meta| meta.modified())
+                        .unwrap_or(SystemTime::UNIX_EPOCH),
+                    path,
+                    id: meta.id,
+                    cwd: meta.cwd,
+                });
+            }
+        }
+
+        sessions.sort_by_key(|session| session.modified);
+        sessions.reverse();
+        Ok(sessions)
     }
 
     fn parse_session_file(&self, path: &Path) -> Result<AgentSession> {
         parse_jsonl_session(path, PROVIDER_NAME, apply_event)
+    }
+
+    fn find_session_by_id(&self, id: &str) -> Result<Option<PathBuf>> {
+        for path in local_session_files()? {
+            if path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.contains(id))
+            {
+                return Ok(Some(path));
+            }
+
+            if parse_session_meta(&path)?.id.as_deref() == Some(id) {
+                return Ok(Some(path));
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn find_current_session(&self, cwd: &Path) -> Result<Option<PathBuf>> {
+        if let Some(path) = find_current_thread_session()? {
+            return Ok(Some(path));
+        }
+
+        if let Some(session) = list_recent_local_sessions(Some(cwd))?.into_iter().next() {
+            return Ok(Some(session.path));
+        }
+
+        Ok(list_recent_local_sessions(None)?
+            .into_iter()
+            .next()
+            .map(|session| session.path))
     }
 }
 
@@ -35,6 +100,29 @@ pub fn codex_home() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".codex")
+}
+
+pub fn local_codex_sessions_dir() -> PathBuf {
+    codex_home().join("sessions")
+}
+
+pub fn configured_codex_session_dirs() -> Vec<PathBuf> {
+    let mut dirs = vec![local_codex_sessions_dir()];
+
+    if let Ok(extra) = std::env::var("SIVTR_CODEX_SESSION_DIRS") {
+        let separator = if cfg!(windows) { ';' } else { ':' };
+        dirs.extend(
+            extra
+                .split(separator)
+                .map(str::trim)
+                .filter(|entry| !entry.is_empty())
+                .map(PathBuf::from),
+        );
+    } else if let Ok(config) = SivtrConfig::load() {
+        dirs.extend(config.codex.session_dirs);
+    }
+
+    dedup_paths(dirs)
 }
 
 fn parse_session_meta(path: &Path) -> Result<AgentSessionMeta> {
@@ -128,12 +216,79 @@ fn extract_tool_call_text(payload: &Value) -> String {
     }
 }
 
+fn local_session_files() -> Result<Vec<PathBuf>> {
+    jsonl_files(&local_codex_sessions_dir())
+}
+
+fn list_recent_local_sessions(cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+    list_recent_jsonl_sessions(&local_codex_sessions_dir(), cwd, parse_session_meta)
+}
+
+fn find_current_thread_session() -> Result<Option<PathBuf>> {
+    let Ok(thread_id) = std::env::var("CODEX_THREAD_ID") else {
+        return Ok(None);
+    };
+
+    let thread_id = thread_id.trim();
+    if thread_id.is_empty() {
+        return Ok(None);
+    }
+
+    CodexProvider.find_session_by_id(thread_id)
+}
+
+fn dedup_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut deduped = Vec::new();
+    for path in paths {
+        if deduped.iter().any(|existing| existing == &path) {
+            continue;
+        }
+        deduped.push(path);
+    }
+    deduped
+}
+
+fn jsonl_files(root: &Path) -> Result<Vec<PathBuf>> {
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut files = Vec::new();
+    collect_jsonl_files(root, &mut files)?;
+    Ok(files)
+}
+
+fn collect_jsonl_files(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in
+        std::fs::read_dir(dir).with_context(|| format!("Failed to read {}", dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_jsonl_files(&path, files)?;
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("jsonl") {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn normalize_path_for_match(path: &Path) -> String {
+    path.canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .replace('/', "\\")
+        .to_lowercase()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::CodexProvider;
+    use super::{configured_codex_session_dirs, CodexProvider};
     use crate::ai::{
         format_blocks, select_blocks, AgentBlockKind, AgentSelection, AgentSessionProvider,
     };
+    use serde_json::json;
+    use std::{env, path::PathBuf, time::Duration};
 
     #[test]
     fn parses_codex_rollout_messages_and_tools() {
@@ -208,5 +363,179 @@ mod tests {
 
         assert_eq!(session.blocks.len(), 2);
         assert_eq!(blocks[0].text, "real answer");
+    }
+
+    #[test]
+    fn find_current_session_prefers_codex_thread_id_over_cwd_match() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_home = temp.path().join("codex-home");
+        let sessions_dir = codex_home
+            .join("sessions")
+            .join("2026")
+            .join("05")
+            .join("07");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+
+        let cwd_match = temp.path().join("cwd-match");
+        let thread_match = temp.path().join("thread-match");
+        std::fs::create_dir_all(&cwd_match).unwrap();
+        std::fs::create_dir_all(&thread_match).unwrap();
+
+        let cwd_session = sessions_dir.join("rollout-cwd.jsonl");
+        std::fs::write(
+            &cwd_session,
+            format!(
+                "{}\n",
+                serde_json::to_string(&json!({
+                    "type": "session_meta",
+                    "payload": { "id": "cwd-session", "cwd": cwd_match }
+                }))
+                .unwrap()
+            ),
+        )
+        .unwrap();
+        std::thread::sleep(Duration::from_millis(5));
+
+        let thread_session = sessions_dir.join("rollout-thread.jsonl");
+        std::fs::write(
+            &thread_session,
+            format!(
+                "{}\n",
+                serde_json::to_string(&json!({
+                    "type": "session_meta",
+                    "payload": { "id": "thread-session", "cwd": thread_match }
+                }))
+                .unwrap()
+            ),
+        )
+        .unwrap();
+
+        let previous_codex_home = env::var_os("CODEX_HOME");
+        let previous_thread_id = env::var_os("CODEX_THREAD_ID");
+        env::set_var("CODEX_HOME", &codex_home);
+        env::set_var("CODEX_THREAD_ID", "thread-session");
+
+        let resolved = CodexProvider.find_current_session(&cwd_match).unwrap();
+
+        match previous_codex_home {
+            Some(value) => env::set_var("CODEX_HOME", value),
+            None => env::remove_var("CODEX_HOME"),
+        }
+        match previous_thread_id {
+            Some(value) => env::set_var("CODEX_THREAD_ID", value),
+            None => env::remove_var("CODEX_THREAD_ID"),
+        }
+
+        assert_eq!(resolved, Some(thread_session));
+    }
+
+    #[test]
+    fn configured_codex_session_dirs_reads_env_override_once() {
+        let previous = env::var_os("SIVTR_CODEX_SESSION_DIRS");
+        env::set_var("SIVTR_CODEX_SESSION_DIRS", "/tmp/a:/tmp/b:/tmp/a");
+
+        let dirs = configured_codex_session_dirs();
+
+        match previous {
+            Some(value) => env::set_var("SIVTR_CODEX_SESSION_DIRS", value),
+            None => env::remove_var("SIVTR_CODEX_SESSION_DIRS"),
+        }
+
+        assert!(dirs.contains(&PathBuf::from("/tmp/a")));
+        assert!(dirs.contains(&PathBuf::from("/tmp/b")));
+        assert_eq!(
+            dirs.iter()
+                .filter(|path| *path == &PathBuf::from("/tmp/a"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn list_recent_sessions_includes_exported_session_dirs() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_home = temp.path().join("codex-home");
+        let local_sessions = codex_home
+            .join("sessions")
+            .join("2026")
+            .join("05")
+            .join("07");
+        let exported_root = temp.path().join("shared-export");
+        let exported_sessions = exported_root
+            .join("sessions")
+            .join("2026")
+            .join("05")
+            .join("06");
+        std::fs::create_dir_all(&local_sessions).unwrap();
+        std::fs::create_dir_all(&exported_sessions).unwrap();
+
+        let local_path = local_sessions.join("rollout-local.jsonl");
+        std::fs::write(
+            &local_path,
+            serde_json::to_string(&json!({
+                "type": "session_meta",
+                "payload": { "id": "local-session", "cwd": "/tmp/local" }
+            }))
+            .unwrap()
+                + "\n",
+        )
+        .unwrap();
+
+        std::thread::sleep(Duration::from_millis(5));
+
+        let exported_path = exported_sessions.join("rollout-exported.jsonl");
+        std::fs::write(
+            &exported_path,
+            serde_json::to_string(&json!({
+                "type": "session_meta",
+                "payload": { "id": "exported-session", "cwd": "/tmp/exported" }
+            }))
+            .unwrap()
+                + "\n",
+        )
+        .unwrap();
+
+        let previous_codex_home = env::var_os("CODEX_HOME");
+        let previous_dirs = env::var_os("SIVTR_CODEX_SESSION_DIRS");
+        env::set_var("CODEX_HOME", &codex_home);
+        env::set_var("SIVTR_CODEX_SESSION_DIRS", exported_root.join("sessions"));
+
+        let sessions = CodexProvider.list_recent_sessions(None).unwrap();
+
+        match previous_codex_home {
+            Some(value) => env::set_var("CODEX_HOME", value),
+            None => env::remove_var("CODEX_HOME"),
+        }
+        match previous_dirs {
+            Some(value) => env::set_var("SIVTR_CODEX_SESSION_DIRS", value),
+            None => env::remove_var("SIVTR_CODEX_SESSION_DIRS"),
+        }
+
+        assert_eq!(sessions.len(), 2);
+        assert_eq!(sessions[0].id.as_deref(), Some("exported-session"));
+        assert_eq!(sessions[1].id.as_deref(), Some("local-session"));
+        assert_eq!(sessions[0].path, exported_path);
+        assert_eq!(sessions[1].path, local_path);
+    }
+
+    #[test]
+    fn parses_session_when_last_json_line_is_still_incomplete() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"type":"session_meta","payload":{"id":"abc","cwd":"/tmp/repo"}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"text":"hello"}]}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"text":"done"}]}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"text":"partial"#,
+        )
+        .unwrap();
+
+        let session = CodexProvider.parse_session_file(&path).unwrap();
+
+        assert_eq!(session.id.as_deref(), Some("abc"));
+        assert_eq!(session.blocks.len(), 2);
+        assert_eq!(session.blocks[0].text, "hello");
+        assert_eq!(session.blocks[1].text, "done");
     }
 }

--- a/crates/sivtr-core/src/codex.rs
+++ b/crates/sivtr-core/src/codex.rs
@@ -55,7 +55,17 @@ impl AgentSessionProvider for CodexProvider {
     }
 
     fn parse_session_file(&self, path: &Path) -> Result<AgentSession> {
-        parse_jsonl_session(path, PROVIDER_NAME, apply_event)
+        let session = parse_jsonl_session(path, PROVIDER_NAME, apply_event)?;
+        if !session.blocks.is_empty() {
+            return Ok(session);
+        }
+
+        let fallback = parse_jsonl_session(path, PROVIDER_NAME, apply_event_with_event_fallback)?;
+        if !fallback.blocks.is_empty() {
+            return Ok(fallback);
+        }
+
+        Ok(session)
     }
 
     fn find_session_by_id(&self, id: &str) -> Result<Option<PathBuf>> {
@@ -162,6 +172,30 @@ fn apply_event(session: &mut AgentSession, value: &Value) {
     }
 }
 
+fn apply_event_with_event_fallback(session: &mut AgentSession, value: &Value) {
+    let timestamp = value
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let payload = value.get("payload").unwrap_or(&Value::Null);
+
+    match value.get("type").and_then(Value::as_str) {
+        Some("session_meta") => {
+            session.id = payload
+                .get("id")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            session.cwd = payload
+                .get("cwd")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+        }
+        Some("response_item") => apply_response_item(session, payload, timestamp.clone()),
+        Some("event_msg") => apply_event_msg(session, payload, timestamp),
+        _ => {}
+    }
+}
+
 fn apply_response_item(session: &mut AgentSession, payload: &Value, timestamp: Option<String>) {
     match payload.get("type").and_then(Value::as_str) {
         Some("message") => {
@@ -204,6 +238,31 @@ fn apply_response_item(session: &mut AgentSession, payload: &Value, timestamp: O
                 .unwrap_or_default()
                 .to_string(),
         ),
+        _ => {}
+    }
+}
+
+fn apply_event_msg(session: &mut AgentSession, payload: &Value, timestamp: Option<String>) {
+    match payload.get("type").and_then(Value::as_str) {
+        Some("user_message") => push_block(
+            session,
+            AgentBlockKind::User,
+            timestamp,
+            None,
+            extract_content_text(payload.get("message").unwrap_or(&Value::Null)),
+        ),
+        Some("agent_message") => {
+            if payload.get("phase").and_then(Value::as_str) == Some("commentary") {
+                return;
+            }
+            push_block(
+                session,
+                AgentBlockKind::Assistant,
+                timestamp,
+                None,
+                extract_content_text(payload.get("message").unwrap_or(&Value::Null)),
+            );
+        }
         _ => {}
     }
 }
@@ -541,5 +600,51 @@ mod tests {
         assert_eq!(session.blocks.len(), 2);
         assert_eq!(session.blocks[0].text, "hello");
         assert_eq!(session.blocks[1].text, "done");
+    }
+
+    #[test]
+    fn falls_back_to_event_messages_when_response_items_are_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"type":"session_meta","payload":{"id":"abc","cwd":"/tmp/repo"}}
+{"type":"event_msg","payload":{"type":"user_message","message":"hello from event"}}
+{"type":"event_msg","payload":{"type":"agent_message","phase":"commentary","message":"working"}}
+{"type":"event_msg","payload":{"type":"agent_message","phase":"final_answer","message":"done from event"}}
+"#,
+        )
+        .unwrap();
+
+        let session = CodexProvider.parse_session_file(&path).unwrap();
+
+        assert_eq!(session.id.as_deref(), Some("abc"));
+        assert_eq!(session.blocks.len(), 2);
+        assert_eq!(session.blocks[0].kind, AgentBlockKind::User);
+        assert_eq!(session.blocks[0].text, "hello from event");
+        assert_eq!(session.blocks[1].kind, AgentBlockKind::Assistant);
+        assert_eq!(session.blocks[1].text, "done from event");
+    }
+
+    #[test]
+    fn response_items_remain_primary_over_event_messages() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"type":"session_meta","payload":{"id":"abc"}}
+{"type":"event_msg","payload":{"type":"user_message","message":"event user"}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"text":"response user"}]}}
+{"type":"event_msg","payload":{"type":"agent_message","phase":"final_answer","message":"event answer"}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"text":"response answer"}]}}
+"#,
+        )
+        .unwrap();
+
+        let session = CodexProvider.parse_session_file(&path).unwrap();
+
+        assert_eq!(session.blocks.len(), 2);
+        assert_eq!(session.blocks[0].text, "response user");
+        assert_eq!(session.blocks[1].text, "response answer");
     }
 }

--- a/crates/sivtr-core/src/codex.rs
+++ b/crates/sivtr-core/src/codex.rs
@@ -119,6 +119,10 @@ pub fn local_codex_sessions_dir() -> PathBuf {
 pub fn configured_codex_session_dirs() -> Vec<PathBuf> {
     let mut dirs = vec![local_codex_sessions_dir()];
 
+    if let Ok(config) = SivtrConfig::load() {
+        dirs.extend(config.codex.session_dirs);
+    }
+
     if let Ok(extra) = std::env::var("SIVTR_CODEX_SESSION_DIRS") {
         let separator = if cfg!(windows) { ';' } else { ':' };
         dirs.extend(
@@ -128,8 +132,6 @@ pub fn configured_codex_session_dirs() -> Vec<PathBuf> {
                 .filter(|entry| !entry.is_empty())
                 .map(PathBuf::from),
         );
-    } else if let Ok(config) = SivtrConfig::load() {
-        dirs.extend(config.codex.session_dirs);
     }
 
     dedup_paths(dirs)
@@ -347,7 +349,7 @@ mod tests {
         format_blocks, select_blocks, AgentBlockKind, AgentSelection, AgentSessionProvider,
     };
     use serde_json::json;
-    use std::{env, path::PathBuf, time::Duration};
+    use std::{env, fs, path::PathBuf, time::Duration};
 
     #[test]
     fn parses_codex_rollout_messages_and_tools() {
@@ -509,6 +511,48 @@ mod tests {
         assert_eq!(
             dirs.iter()
                 .filter(|path| *path == &PathBuf::from("/tmp/a"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn configured_codex_session_dirs_combines_env_and_config_entries() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_home = temp.path().join("config-home");
+        let config_dir = config_home.join("sivtr");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(
+            config_dir.join("config.toml"),
+            "[codex]\nsession_dirs = [\"/tmp/from-config\", \"/tmp/shared\"]\n",
+        )
+        .unwrap();
+
+        let previous_xdg_config_home = env::var_os("XDG_CONFIG_HOME");
+        let previous_extra_dirs = env::var_os("SIVTR_CODEX_SESSION_DIRS");
+        let separator = if cfg!(windows) { ";" } else { ":" };
+        env::set_var("XDG_CONFIG_HOME", &config_home);
+        env::set_var(
+            "SIVTR_CODEX_SESSION_DIRS",
+            format!("/tmp/from-env{separator}/tmp/shared"),
+        );
+
+        let dirs = configured_codex_session_dirs();
+
+        match previous_xdg_config_home {
+            Some(value) => env::set_var("XDG_CONFIG_HOME", value),
+            None => env::remove_var("XDG_CONFIG_HOME"),
+        }
+        match previous_extra_dirs {
+            Some(value) => env::set_var("SIVTR_CODEX_SESSION_DIRS", value),
+            None => env::remove_var("SIVTR_CODEX_SESSION_DIRS"),
+        }
+
+        assert!(dirs.contains(&PathBuf::from("/tmp/from-config")));
+        assert!(dirs.contains(&PathBuf::from("/tmp/from-env")));
+        assert_eq!(
+            dirs.iter()
+                .filter(|path| *path == &PathBuf::from("/tmp/shared"))
                 .count(),
             1
         );

--- a/crates/sivtr-core/src/codex.rs
+++ b/crates/sivtr-core/src/codex.rs
@@ -432,7 +432,11 @@ mod tests {
     #[test]
     fn configured_codex_session_dirs_reads_env_override_once() {
         let previous = env::var_os("SIVTR_CODEX_SESSION_DIRS");
-        env::set_var("SIVTR_CODEX_SESSION_DIRS", "/tmp/a:/tmp/b:/tmp/a");
+        let separator = if cfg!(windows) { ";" } else { ":" };
+        env::set_var(
+            "SIVTR_CODEX_SESSION_DIRS",
+            format!("/tmp/a{separator}/tmp/b{separator}/tmp/a"),
+        );
 
         let dirs = configured_codex_session_dirs();
 

--- a/crates/sivtr-core/src/config/mod.rs
+++ b/crates/sivtr-core/src/config/mod.rs
@@ -16,6 +16,8 @@ pub struct SivtrConfig {
     pub history: HistoryConfig,
     /// Copy command settings.
     pub copy: CopyConfig,
+    /// Codex session settings.
+    pub codex: CodexConfig,
     /// Global hotkey settings.
     pub hotkey: HotkeyConfig,
 }
@@ -77,6 +79,14 @@ impl CopyConfig {
     pub fn prompt_values(&self) -> impl Iterator<Item = &String> {
         self.legacy_prompt_presets.iter().chain(self.prompts.iter())
     }
+}
+
+/// Codex session configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CodexConfig {
+    /// Additional directories that contain exported Codex session JSONL trees.
+    pub session_dirs: Vec<PathBuf>,
 }
 
 /// Global hotkey configuration.
@@ -218,5 +228,21 @@ mod tests {
 
         assert!(toml.contains("[hotkey]"));
         assert!(toml.contains("chord = \"alt+y\""));
+    }
+
+    #[test]
+    fn serializes_codex_config() {
+        let config = SivtrConfig {
+            codex: CodexConfig {
+                session_dirs: vec![PathBuf::from("/srv/sivtr/root-codex/sessions")],
+            },
+            ..SivtrConfig::default()
+        };
+
+        let toml = to_toml_string(&config).unwrap();
+
+        assert!(toml.contains("[codex]"));
+        assert!(toml.contains("session_dirs = ["));
+        assert!(toml.contains("/srv/sivtr/root-codex/sessions"));
     }
 }

--- a/docs-site/src/content/docs/reference/cli.md
+++ b/docs-site/src/content/docs/reference/cli.md
@@ -62,6 +62,9 @@ Supported shell names:
 - `zsh`
 - `nushell`
 - `nu`
+- `tmux`
+- `linux-shortcut`
+- `macos-shortcut`
 
 ## copy
 

--- a/docs-site/src/content/docs/reference/config-file.md
+++ b/docs-site/src/content/docs/reference/config-file.md
@@ -32,6 +32,9 @@ max_entries = 0
 [copy]
 prompts = ["PS C:\\repo> ", "dev>"]
 
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+
 [hotkey]
 chord = "alt+y"
 ```
@@ -94,6 +97,17 @@ prompts = []
 | `prompts` | string array | `[]` | Prompt profiles or literal prefixes used when detecting command lines |
 
 `prompt_presets` is a legacy field and is not serialized by the current config writer.
+
+## codex
+
+```toml
+[codex]
+session_dirs = []
+```
+
+| Key | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `session_dirs` | string array | `[]` | Extra exported Codex `sessions` directories to browse with `copy codex --pick` |
 
 ## hotkey
 

--- a/docs-site/src/content/docs/usage/codex-capture.md
+++ b/docs-site/src/content/docs/usage/codex-capture.md
@@ -3,7 +3,9 @@ title: Codex Capture
 description: Copy useful blocks from the current Codex session.
 ---
 
-`sivtr copy codex` reads Codex rollout JSONL files from `~/.codex/sessions`. By default it chooses the newest session whose `cwd` matches the current working directory.
+`sivtr copy codex` reads Codex rollout JSONL files from `~/.codex/sessions`. If the current shell exports `CODEX_THREAD_ID`, `sivtr` prefers that exact local session first. Otherwise it chooses the newest local session whose `cwd` matches the current working directory.
+
+If another account publishes a read-only mirror with `sivtr codex export --dest ...`, add that mirrored `sessions` directory to `[codex].session_dirs` so explicit `--pick` browsing can read it without elevated privileges.
 
 This is useful when you want to reuse the last answer, input, tool output, or whole parsed session without opening the Codex transcript manually.
 
@@ -62,11 +64,29 @@ sivtr copy codex out --print
 ```bash
 sivtr copy codex --pick
 sivtr copy codex out --pick
+sivtr copy codex --pick  # includes mirrored session trees from [codex].session_dirs
 ```
 
 The plain CLI picker starts with the session list, then lets you choose one or more units from that session. Press `t` to open the Vim-style view. In Codex views, `T` toggles tool content when an alternate full view is available.
 
 Context-aware launchers such as the Windows hotkey and VS Code extension first open the newest non-empty session for the current workspace. If that session is missing or empty, they fall back to the session list.
+
+Shared/mirrored session trees only participate in explicit `--pick` browsing. Implicit current-session lookup stays local so another account's exported history does not override the current user's active Codex workflow.
+
+## Mirror sessions for another account
+
+Create a shared mirror from the source account:
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex --watch
+```
+
+Then consume it from another account:
+
+```toml
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+```
 
 ## Windows hotkey
 

--- a/docs-site/src/content/docs/usage/codex-capture.md
+++ b/docs-site/src/content/docs/usage/codex-capture.md
@@ -7,6 +7,8 @@ description: Copy useful blocks from the current Codex session.
 
 If another account publishes a read-only mirror with `sivtr codex export --dest ...`, add that mirrored `sessions` directory to `[codex].session_dirs` so explicit `--pick` browsing can read it without elevated privileges.
 
+Use `--session N` to select the Nth newest recorded session, or `--session ID` to match a session id / id prefix explicitly.
+
 This is useful when you want to reuse the last answer, input, tool output, or whole parsed session without opening the Codex transcript manually.
 
 ## Defaults
@@ -39,9 +41,11 @@ sivtr copy codex all
 Selectors work the same way as command-block copy:
 
 ```bash
+sivtr copy codex --session 2
+sivtr copy codex --session 019df7fb
 sivtr copy codex 2
 sivtr copy codex 2..4
-sivtr copy codex out 3
+sivtr copy codex out --session 3
 ```
 
 `1` means the newest matching Codex unit, `2` means the second newest, and so on.
@@ -62,6 +66,7 @@ sivtr copy codex out --print
 ## Pick interactively
 
 ```bash
+sivtr copy codex --session 2 --pick
 sivtr copy codex --pick
 sivtr copy codex out --pick
 sivtr copy codex --pick  # includes mirrored session trees from [codex].session_dirs

--- a/docs-site/src/content/docs/usage/configuration.md
+++ b/docs-site/src/content/docs/usage/configuration.md
@@ -36,6 +36,9 @@ max_entries = 0
 [copy]
 prompts = []
 
+[codex]
+session_dirs = []
+
 [hotkey]
 chord = "alt+y"
 ```
@@ -62,3 +65,18 @@ prompts = ["dev>", "repo $", "PS C:\\repo>"]
 ```
 
 This helps command-block parsing identify the command input lines in session logs.
+
+## Shared Codex session trees
+
+Add shared exported session trees when another account publishes a read-only copy:
+
+```toml
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+```
+
+Create that shared tree from the source account with:
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex
+```

--- a/docs-site/src/content/docs/usage/hotkey.md
+++ b/docs-site/src/content/docs/usage/hotkey.md
@@ -5,6 +5,11 @@ description: Start, stop, and configure the Windows AI session picker hotkey.
 
 The hotkey daemon is currently Windows-only. It registers one global shortcut and opens a new terminal window that runs the AI session picker for the working directory where the daemon was started.
 
+Linux does not currently ship a default desktop-wide `sivtr` hotkey. Wayland
+does not expose a universal cross-desktop global hotkey API for ordinary CLI
+apps, and launching the picker also requires an interactive terminal that is
+not portable across GNOME, KDE, Sway, tmux, and headless SSH sessions.
+
 ## Start
 
 ```bash
@@ -65,3 +70,42 @@ the session picker.
 
 Plain `sivtr copy codex --pick` is different: it always starts with the session
 picker.
+
+## Linux setups
+
+Use one of these platform-specific entry points instead of a built-in global
+daemon:
+
+- VS Code: use the extension command bound to `Alt+Y` by default.
+- tmux: install the helper block and reload tmux:
+
+```bash
+sivtr init tmux
+tmux source-file ~/.tmux.conf
+```
+
+This binds `prefix + y` to the current pane path.
+
+- Desktop shortcut or terminal launcher: generate a project-specific launcher:
+
+```bash
+sivtr init linux-shortcut
+```
+
+This writes `~/.local/bin/sivtr-pick-codex` plus a desktop entry at
+`~/.local/share/applications/sivtr-pick-codex.desktop`. Bind your desktop
+shortcut to the script, or run it directly from a terminal.
+
+- macOS: generate a Terminal launcher plus a LaunchAgent wrapper:
+
+```bash
+sivtr init macos-shortcut
+```
+
+This writes `~/.local/bin/sivtr-pick-codex` and
+`~/Library/LaunchAgents/dev.sivtr.pick-codex.plist`. Run the script directly,
+or load the LaunchAgent with:
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.sivtr.pick-codex.plist
+```

--- a/docs-site/src/content/docs/zh-cn/reference/config-file.md
+++ b/docs-site/src/content/docs/zh-cn/reference/config-file.md
@@ -32,6 +32,9 @@ max_entries = 0
 [copy]
 prompts = ["PS C:\\repo> ", "dev>"]
 
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+
 [hotkey]
 chord = "alt+y"
 ```
@@ -94,6 +97,17 @@ prompts = []
 | `prompts` | string array | `[]` | 检测命令行时使用的 prompt 配置或字面前缀 |
 
 `prompt_presets` 是旧字段，当前配置写入器不会序列化它。
+
+## codex
+
+```toml
+[codex]
+session_dirs = []
+```
+
+| 键 | 类型 | 默认值 | 含义 |
+| --- | --- | --- | --- |
+| `session_dirs` | string array | `[]` | 额外的导出 Codex `sessions` 目录，可供 `copy codex --pick` 浏览 |
 
 ## hotkey
 

--- a/docs-site/src/content/docs/zh-cn/usage/codex-capture.md
+++ b/docs-site/src/content/docs/zh-cn/usage/codex-capture.md
@@ -3,7 +3,9 @@ title: Codex 捕获
 description: 从当前 Codex 会话复制有用块。
 ---
 
-`sivtr copy codex` 会读取 `~/.codex/sessions` 下的 Codex rollout JSONL 文件。默认选择 `cwd` 与当前工作目录匹配的最新会话。
+`sivtr copy codex` 会读取 `~/.codex/sessions` 下的 Codex rollout JSONL 文件。如果当前 shell 暴露了 `CODEX_THREAD_ID`，`sivtr` 会优先匹配这个本地精确会话；否则默认选择 `cwd` 与当前工作目录匹配的最新本地会话。
+
+如果另一个账号先用 `sivtr codex export --dest ...` 发布了只读镜像，就把镜像后的 `sessions` 目录加入 `[codex].session_dirs`。这样显式 `--pick` 浏览就能在不提权的前提下读取它。
 
 当你想复用最后一个回答、输入、工具输出，或整个解析后的会话，但不想手动打开 Codex transcript 时，这个功能很有用。
 
@@ -62,11 +64,29 @@ sivtr copy codex out --print
 ```bash
 sivtr copy codex --pick
 sivtr copy codex out --pick
+sivtr copy codex --pick  # 同时浏览 [codex].session_dirs 里的共享镜像会话
 ```
 
 普通 CLI 选择器会先显示会话列表，进入某个会话后再选择一个或多个单元。按 `t` 打开 Vim 风格视图。在 Codex 视图里，如果存在替代完整视图，`T` 可以切换工具内容。
 
 Windows 热键和 VS Code 插件这类带上下文的入口会先打开当前 workspace 下最新的非空会话。如果这个会话不存在或为空，再退回到会话列表。
+
+共享/镜像会话树只参与显式 `--pick` 浏览。隐式“当前会话”解析仍然只看本地会话，避免另一个账号导出的历史抢占当前用户的 Codex 工作流。
+
+## 为另一个账号镜像会话
+
+先在源账号侧持续发布镜像树：
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex --watch
+```
+
+再在另一个账号的配置里引用镜像目录：
+
+```toml
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+```
 
 ## Windows 热键
 

--- a/docs-site/src/content/docs/zh-cn/usage/codex-capture.md
+++ b/docs-site/src/content/docs/zh-cn/usage/codex-capture.md
@@ -7,6 +7,8 @@ description: 从当前 Codex 会话复制有用块。
 
 如果另一个账号先用 `sivtr codex export --dest ...` 发布了只读镜像，就把镜像后的 `sessions` 目录加入 `[codex].session_dirs`。这样显式 `--pick` 浏览就能在不提权的前提下读取它。
 
+用 `--session N` 可以显式选择第 N 新的已记录会话；用 `--session ID` 可以按会话 id 或 id 前缀匹配。
+
 当你想复用最后一个回答、输入、工具输出，或整个解析后的会话，但不想手动打开 Codex transcript 时，这个功能很有用。
 
 ## 默认行为
@@ -39,9 +41,11 @@ sivtr copy codex all
 选择器和命令块复制相同：
 
 ```bash
+sivtr copy codex --session 2
+sivtr copy codex --session 019df7fb
 sivtr copy codex 2
 sivtr copy codex 2..4
-sivtr copy codex out 3
+sivtr copy codex out --session 3
 ```
 
 `1` 表示最新匹配的 Codex 单元，`2` 表示第二新，依此类推。
@@ -62,6 +66,7 @@ sivtr copy codex out --print
 ## 交互式选择
 
 ```bash
+sivtr copy codex --session 2 --pick
 sivtr copy codex --pick
 sivtr copy codex out --pick
 sivtr copy codex --pick  # 同时浏览 [codex].session_dirs 里的共享镜像会话

--- a/docs-site/src/content/docs/zh-cn/usage/configuration.md
+++ b/docs-site/src/content/docs/zh-cn/usage/configuration.md
@@ -36,6 +36,9 @@ max_entries = 0
 [copy]
 prompts = []
 
+[codex]
+session_dirs = []
+
 [hotkey]
 chord = "alt+y"
 ```
@@ -62,3 +65,18 @@ prompts = ["dev>", "repo $", "PS C:\\repo>"]
 ```
 
 这有助于命令块解析识别会话日志里的命令输入行。
+
+## 共享 Codex 会话树
+
+当另一个账号发布了只读副本时，可以把共享导出的会话树加入配置：
+
+```toml
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+```
+
+源账号可以这样创建共享树：
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex
+```

--- a/docs-site/src/content/docs/zh-cn/usage/hotkey.md
+++ b/docs-site/src/content/docs/zh-cn/usage/hotkey.md
@@ -5,6 +5,11 @@ description: 启动、停止和配置 Windows Codex 选择器热键。
 
 热键守护进程目前仅支持 Windows。它注册一个全局快捷键，并打开一个新的终端窗口，为启动守护进程时的工作目录运行 Codex 选择器。
 
+Linux 目前没有内置的桌面级默认 `sivtr` 全局热键。原因是 Wayland
+没有给普通 CLI 工具提供统一的跨桌面全局热键接口，而打开 picker
+还需要一个交互式终端，这在 GNOME、KDE、Sway、tmux 和纯 SSH
+场景之间也没有统一可移植的启动方式。
+
 ## 启动
 
 ```bash
@@ -62,3 +67,26 @@ sivtr hotkey-pick-agent --cwd <daemon-working-directory> --provider all
 这个内部命令会先打开守护进程工作目录下最新的非空 Codex 会话。如果这个会话不存在或为空，再退回到会话选择器。
 
 普通的 `sivtr copy codex --pick` 不同：它总是从会话选择器开始。
+
+## Linux 设置方式
+
+在 Linux 上，推荐使用以下入口之一，而不是依赖内置全局守护进程：
+
+- VS Code：使用插件默认绑定的 `Alt+Y`。
+- tmux：安装 helper 配置块并重新加载 tmux：
+
+```bash
+sivtr init tmux
+tmux source-file ~/.tmux.conf
+```
+
+它会把 `prefix + y` 绑定到当前 pane 的工作目录。
+
+- 桌面快捷键或终端 launcher：为当前项目生成 launcher：
+
+```bash
+sivtr init linux-shortcut
+```
+
+它会写入 `~/.local/bin/sivtr-pick-codex`，以及
+`~/.local/share/applications/sivtr-pick-codex.desktop`。你可以把桌面快捷键绑定到这个脚本，或者直接在终端里运行它。

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -19,7 +19,7 @@ The extension opens a VS Code terminal in the current workspace and runs the
 context-aware Codex picker:
 
 ```bash
-sivtr hotkey-pick-codex --cwd .
+sivtr hotkey-pick-agent --cwd . --provider all
 ```
 
 If the terminal was opened from a live `codex resume` session, `sivtr` prefers
@@ -40,7 +40,7 @@ If you want a Terminal-based launcher outside VS Code, run
 | Setting | Default | Purpose |
 | --- | --- | --- |
 | `sivtr.command` | `sivtr` | Command used to launch sivtr |
-| `sivtr.args` | `["hotkey-pick-codex", "--cwd", "."]` | Arguments passed to sivtr |
+| `sivtr.args` | `["hotkey-pick-agent", "--cwd", ".", "--provider", "all"]` | Arguments passed to sivtr |
 | `sivtr.reuseTerminal` | `true` | Reuse the existing sivtr terminal |
 | `sivtr.closeTerminalOnSuccess` | `true` | Close the sivtr terminal when the picker exits successfully |
 | `sivtr.terminalName` | `sivtr` | Terminal name |

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,6 +1,6 @@
 # sivtr VS Code extension
 
-Launch the sivtr AI session picker from VS Code.
+Launch the sivtr Codex picker from VS Code.
 
 ## Usage
 
@@ -13,21 +13,34 @@ cargo install sivtr
 If `sivtr` is missing, the extension will offer to open a terminal and run that
 install command.
 
-Run `Sivtr: Pick AI Session` from the command palette, or press `Alt+Y`.
+Run `Sivtr: Pick Codex Turn` from the command palette, or press `Alt+Y`.
 
 The extension opens a VS Code terminal in the current workspace and runs the
-context-aware AI session picker:
+context-aware Codex picker:
 
 ```bash
-sivtr hotkey-pick-agent --cwd . --provider all
+sivtr hotkey-pick-codex --cwd .
 ```
+
+If the terminal was opened from a live `codex resume` session, `sivtr` prefers
+that exact session id first. Otherwise it falls back to the newest non-empty
+session whose `cwd` matches the workspace.
+
+On Linux, this VS Code keybinding is the recommended default shortcut. `sivtr`
+does not currently provide a desktop-wide global hotkey on Linux outside VS
+Code because global shortcut registration and terminal launching are not
+portable across Wayland, X11, and terminal-only environments.
+
+On macOS, the same VS Code shortcut is also the recommended default shortcut.
+If you want a Terminal-based launcher outside VS Code, run
+`sivtr init macos-shortcut` on the Mac host.
 
 ## Settings
 
 | Setting | Default | Purpose |
 | --- | --- | --- |
 | `sivtr.command` | `sivtr` | Command used to launch sivtr |
-| `sivtr.args` | `["hotkey-pick-agent", "--cwd", ".", "--provider", "all"]` | Arguments passed to sivtr |
+| `sivtr.args` | `["hotkey-pick-codex", "--cwd", "."]` | Arguments passed to sivtr |
 | `sivtr.reuseTerminal` | `true` | Reuse the existing sivtr terminal |
 | `sivtr.closeTerminalOnSuccess` | `true` | Close the sivtr terminal when the picker exits successfully |
 | `sivtr.terminalName` | `sivtr` | Terminal name |

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sivtr-vscode",
   "displayName": "sivtr",
-  "description": "Launch the sivtr AI session picker from VS Code.",
+  "description": "Launch the sivtr Codex picker from VS Code.",
   "version": "0.1.2",
   "publisher": "ariestar",
   "icon": "icon.png",
@@ -25,13 +25,13 @@
   "contributes": {
     "commands": [
       {
-        "command": "sivtr.pickAgent",
-        "title": "Sivtr: Pick AI Session"
+        "command": "sivtr.pickCodex",
+        "title": "Sivtr: Pick Codex Turn"
       }
     ],
     "keybindings": [
       {
-        "command": "sivtr.pickAgent",
+        "command": "sivtr.pickCodex",
         "key": "alt+y",
         "mac": "cmd+alt+y",
         "when": "!terminalFocus"
@@ -48,11 +48,9 @@
         "sivtr.args": {
           "type": "array",
           "default": [
-            "hotkey-pick-agent",
+            "hotkey-pick-codex",
             "--cwd",
-            ".",
-            "--provider",
-            "all"
+            "."
           ],
           "items": {
             "type": "string"
@@ -80,6 +78,7 @@
   "scripts": {
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
+    "test": "pnpm run compile && rm -f out/extension.test.js && node --test out/commandLine.test.js",
     "package": "pnpm run compile && node node_modules/@vscode/vsce/vsce package --no-dependencies --no-yarn --allow-missing-repository"
   },
   "devDependencies": {

--- a/editors/vscode/src/commandLine.test.ts
+++ b/editors/vscode/src/commandLine.test.ts
@@ -15,14 +15,39 @@ test("quoteShellToken escapes single quotes for POSIX shells", () => {
   );
 });
 
+test("quoteShellToken escapes single quotes for PowerShell", () => {
+  assert.equal(
+    quoteShellToken("C:\\Users\\O'Connor\\project", "powershell"),
+    "'C:\\Users\\O''Connor\\project'",
+  );
+});
+
+test("quoteShellToken uses double quotes for cmd.exe", () => {
+  assert.equal(
+    quoteShellToken("C:\\Program Files\\sivtr", "cmd"),
+    "\"C:\\Program Files\\sivtr\"",
+  );
+});
+
 test("buildCommandLine preserves a cwd with single quotes", () => {
   assert.equal(
     buildCommandLine("sivtr", [
       "hotkey-pick-codex",
       "--cwd",
       "/tmp/it's project",
-    ]),
+    ], "/usr/bin/bash"),
     "sivtr hotkey-pick-codex --cwd '/tmp/it'\\''s project'",
+  );
+});
+
+test("buildCommandLine uses shell-aware quoting for Windows shells", () => {
+  assert.equal(
+    buildCommandLine("sivtr", [
+      "hotkey-pick-codex",
+      "--cwd",
+      "C:\\Users\\O'Connor\\workspace",
+    ], "C:\\Program Files\\PowerShell\\7\\pwsh.exe"),
+    "sivtr hotkey-pick-codex --cwd 'C:\\Users\\O''Connor\\workspace'",
   );
 });
 
@@ -37,5 +62,13 @@ test("buildTerminalCommandLine appends shell-specific close logic", () => {
   assert.equal(
     buildTerminalCommandLine("sivtr hotkey-pick-codex", true, "/usr/bin/bash"),
     'sivtr hotkey-pick-codex; code=$?; if [ "$code" -eq 0 ]; then exit 0; fi',
+  );
+  assert.equal(
+    buildTerminalCommandLine("sivtr hotkey-pick-codex", true, "C:\\Windows\\System32\\cmd.exe"),
+    "sivtr hotkey-pick-codex & if not errorlevel 1 exit",
+  );
+  assert.equal(
+    buildTerminalCommandLine("sivtr hotkey-pick-codex", true, "C:\\Program Files\\PowerShell\\7\\pwsh.exe"),
+    "sivtr hotkey-pick-codex; if ($LASTEXITCODE -eq 0) { exit }",
   );
 });

--- a/editors/vscode/src/commandLine.test.ts
+++ b/editors/vscode/src/commandLine.test.ts
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildCommandLine,
+  buildTerminalCommandLine,
+  quoteShellToken,
+  resolveArgs,
+} from "./commandLine";
+
+test("quoteShellToken escapes single quotes for POSIX shells", () => {
+  assert.equal(
+    quoteShellToken("/tmp/it's project"),
+    "'/tmp/it'\\''s project'",
+  );
+});
+
+test("buildCommandLine preserves a cwd with single quotes", () => {
+  assert.equal(
+    buildCommandLine("sivtr", [
+      "hotkey-pick-codex",
+      "--cwd",
+      "/tmp/it's project",
+    ]),
+    "sivtr hotkey-pick-codex --cwd '/tmp/it'\\''s project'",
+  );
+});
+
+test("resolveArgs expands workspaceFolder placeholder only after --cwd", () => {
+  assert.deepEqual(
+    resolveArgs(["hotkey-pick-codex", "--cwd", "${workspaceFolder}", "--session", "2"], "/tmp/repo"),
+    ["hotkey-pick-codex", "--cwd", "/tmp/repo", "--session", "2"],
+  );
+});
+
+test("buildTerminalCommandLine appends shell-specific close logic", () => {
+  assert.equal(
+    buildTerminalCommandLine("sivtr hotkey-pick-codex", true, "/usr/bin/bash"),
+    'sivtr hotkey-pick-codex; code=$?; if [ "$code" -eq 0 ]; then exit 0; fi',
+  );
+});

--- a/editors/vscode/src/commandLine.ts
+++ b/editors/vscode/src/commandLine.ts
@@ -1,5 +1,35 @@
 import * as path from "node:path";
 
+type ShellKind = "cmd" | "posix" | "powershell";
+
+function shellNamesFromPath(shellPathOrKind: string): string[] {
+  const raw = shellPathOrKind.toLowerCase();
+  const posixName = path.posix.basename(shellPathOrKind).toLowerCase();
+  const winName = path.win32.basename(shellPathOrKind).toLowerCase();
+  return Array.from(new Set([raw, posixName, winName]));
+}
+
+function shellKindFromPath(shellPathOrKind: string): ShellKind {
+  const normalized = shellPathOrKind.toLowerCase();
+  if (
+    normalized === "cmd" ||
+    normalized === "posix" ||
+    normalized === "powershell"
+  ) {
+    return normalized;
+  }
+
+  const shellNames = shellNamesFromPath(shellPathOrKind);
+  if (shellNames.some((name) => name.includes("powershell") || name.includes("pwsh"))) {
+    return "powershell";
+  }
+  if (shellNames.some((name) => name === "cmd.exe" || name === "cmd")) {
+    return "cmd";
+  }
+
+  return "posix";
+}
+
 export function resolveArgs(
   configured: string[],
   cwd: string,
@@ -12,8 +42,15 @@ export function resolveArgs(
   });
 }
 
-export function buildCommandLine(command: string, args: string[]): string {
-  return [command, ...args].map(quoteShellToken).join(" ");
+export function buildCommandLine(
+  command: string,
+  args: string[],
+  shellPath: string,
+): string {
+  const shellKind = shellKindFromPath(shellPath);
+  return [command, ...args]
+    .map((value) => quoteShellToken(value, shellKind))
+    .join(" ");
 }
 
 export function buildTerminalCommandLine(
@@ -25,23 +62,32 @@ export function buildTerminalCommandLine(
     return commandLine;
   }
 
-  const shellName = path.basename(shellPath).toLowerCase();
-  if (shellName.includes("powershell") || shellName.includes("pwsh")) {
+  const shellKind = shellKindFromPath(shellPath);
+  if (shellKind === "powershell") {
     return `${commandLine}; if ($LASTEXITCODE -eq 0) { exit }`;
   }
-  if (shellName === "cmd.exe" || shellName === "cmd") {
+  if (shellKind === "cmd") {
     return `${commandLine} & if not errorlevel 1 exit`;
   }
-  if (shellName.includes("fish")) {
+
+  if (shellNamesFromPath(shellPath).some((name) => name.includes("fish"))) {
     return `${commandLine}; test $status -eq 0; and exit`;
   }
 
   return `${commandLine}; code=$?; if [ "$code" -eq 0 ]; then exit 0; fi`;
 }
 
-export function quoteShellToken(value: string): string {
-  if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) {
+export function quoteShellToken(value: string, shellPathOrKind = ""): string {
+  const shellKind = shellKindFromPath(shellPathOrKind);
+  if (/^[A-Za-z0-9_./:\\@+=,-]+$/.test(value)) {
     return value;
+  }
+
+  if (shellKind === "powershell") {
+    return `'${value.replace(/'/g, "''")}'`;
+  }
+  if (shellKind === "cmd") {
+    return `"${value.replace(/"/g, "\"\"")}"`;
   }
 
   return `'${value.replace(/'/g, `'\\''`)}'`;

--- a/editors/vscode/src/commandLine.ts
+++ b/editors/vscode/src/commandLine.ts
@@ -1,0 +1,48 @@
+import * as path from "node:path";
+
+export function resolveArgs(
+  configured: string[],
+  cwd: string,
+): string[] {
+  return configured.map((arg, index, args) => {
+    if ((arg === "." || arg === "${workspaceFolder}") && args[index - 1] === "--cwd") {
+      return cwd;
+    }
+    return arg;
+  });
+}
+
+export function buildCommandLine(command: string, args: string[]): string {
+  return [command, ...args].map(quoteShellToken).join(" ");
+}
+
+export function buildTerminalCommandLine(
+  commandLine: string,
+  closeOnSuccess: boolean,
+  shellPath: string,
+): string {
+  if (!closeOnSuccess) {
+    return commandLine;
+  }
+
+  const shellName = path.basename(shellPath).toLowerCase();
+  if (shellName.includes("powershell") || shellName.includes("pwsh")) {
+    return `${commandLine}; if ($LASTEXITCODE -eq 0) { exit }`;
+  }
+  if (shellName === "cmd.exe" || shellName === "cmd") {
+    return `${commandLine} & if not errorlevel 1 exit`;
+  }
+  if (shellName.includes("fish")) {
+    return `${commandLine}; test $status -eq 0; and exit`;
+  }
+
+  return `${commandLine}; code=$?; if [ "$code" -eq 0 ]; then exit 0; fi`;
+}
+
+export function quoteShellToken(value: string): string {
+  if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) {
+    return value;
+  }
+
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -62,7 +62,7 @@ async function pickCodex(): Promise<void> {
   terminal.show();
   terminal.sendText(
     buildTerminalCommandLine(
-      buildCommandLine(command, args),
+      buildCommandLine(command, args, vscode.env.shell),
       closeTerminalOnSuccess,
       vscode.env.shell,
     ),

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,6 +1,10 @@
 import { execFile } from "node:child_process";
-import * as path from "node:path";
 import * as vscode from "vscode";
+import {
+  buildCommandLine,
+  buildTerminalCommandLine,
+  resolveArgs,
+} from "./commandLine";
 
 let sivtrTerminal: vscode.Terminal | undefined;
 let sivtrTerminalCwd: string | undefined;
@@ -12,7 +16,7 @@ const INSTALL_DOCS_URL = "https://github.com/Ariestar/sivtr#installation";
 
 export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
-    vscode.commands.registerCommand("sivtr.pickAgent", pickAgent),
+    vscode.commands.registerCommand("sivtr.pickCodex", pickCodex),
     vscode.window.onDidCloseTerminal((terminal) => {
       if (terminal === sivtrTerminal) {
         sivtrTerminal = undefined;
@@ -27,7 +31,7 @@ export function deactivate(): void {
   sivtrTerminalCwd = undefined;
 }
 
-async function pickAgent(): Promise<void> {
+async function pickCodex(): Promise<void> {
   const workspaceFolder = resolveWorkspaceFolder();
   if (!workspaceFolder) {
     void vscode.window.showErrorMessage("sivtr: open a workspace folder first.");
@@ -36,13 +40,10 @@ async function pickAgent(): Promise<void> {
 
   const config = vscode.workspace.getConfiguration("sivtr");
   const command = config.get<string>("command", "sivtr").trim();
-  const args = config.get<string[]>("args", [
-    "hotkey-pick-agent",
-    "--cwd",
-    ".",
-    "--provider",
-    "all",
-  ]);
+  const args = resolveArgs(
+    config.get<string[]>("args", ["hotkey-pick-codex", "--cwd", "."]),
+    workspaceFolder.uri.fsPath,
+  );
   const terminalName = config.get<string>("terminalName", "sivtr");
   const reuseTerminal = config.get<boolean>("reuseTerminal", true);
   const closeTerminalOnSuccess = config.get<boolean>("closeTerminalOnSuccess", true);
@@ -60,7 +61,11 @@ async function pickAgent(): Promise<void> {
   const terminal = getTerminal(terminalName, workspaceFolder.uri.fsPath, reuseTerminal);
   terminal.show();
   terminal.sendText(
-    buildTerminalCommandLine(buildCommandLine(command, args), closeTerminalOnSuccess),
+    buildTerminalCommandLine(
+      buildCommandLine(command, args),
+      closeTerminalOnSuccess,
+      vscode.env.shell,
+    ),
     true,
   );
 }
@@ -127,35 +132,4 @@ function getTerminal(name: string, cwd: string, reuse: boolean): vscode.Terminal
   });
   sivtrTerminalCwd = cwd;
   return sivtrTerminal;
-}
-
-function buildCommandLine(command: string, args: string[]): string {
-  return [command, ...args].map(quoteShellToken).join(" ");
-}
-
-function buildTerminalCommandLine(commandLine: string, closeOnSuccess: boolean): string {
-  if (!closeOnSuccess) {
-    return commandLine;
-  }
-
-  const shellName = path.basename(vscode.env.shell).toLowerCase();
-  if (shellName.includes("powershell") || shellName.includes("pwsh")) {
-    return `${commandLine}; if ($LASTEXITCODE -eq 0) { exit }`;
-  }
-  if (shellName === "cmd.exe" || shellName === "cmd") {
-    return `${commandLine} & if not errorlevel 1 exit`;
-  }
-  if (shellName.includes("fish")) {
-    return `${commandLine}; test $status -eq 0; and exit`;
-  }
-
-  return `${commandLine}; code=$?; if [ "$code" -eq 0 ]; then exit 0; fi`;
-}
-
-function quoteShellToken(value: string): string {
-  if (/^[A-Za-z0-9_./:@%+=,-]+$/.test(value)) {
-    return value;
-  }
-
-  return `'${value.replace(/'/g, "''")}'`;
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -100,6 +100,8 @@ Defaults:
 Session Resolution:
   By default, sivtr reads the newest Codex rollout whose `cwd`
   matches the current working directory.
+  `--session N` picks the Nth newest recorded Codex session.
+  `--session ID` matches a session id or id prefix.
 
 Selector Semantics:
   Selection is relative to the newest matching Codex item.
@@ -118,9 +120,12 @@ Filters:
 
 Examples:
   sivtr copy codex
+  sivtr copy codex --session 2
+  sivtr copy codex --session 019df7fb
   sivtr copy codex 2
   sivtr copy codex 2..4
-  sivtr copy codex out --print
+  sivtr copy codex out --session 2 --print
+  sivtr copy codex --session 2 --pick
   sivtr copy codex out --pick
   sivtr copy codex tool --regex error
   sivtr copy codex all --lines 1:20
@@ -134,6 +139,8 @@ Defaults:
 Session Resolution:
   By default, sivtr reads the newest Claude Code transcript whose `cwd`
   matches the current working directory.
+  `--session N` picks the Nth newest recorded Claude session.
+  `--session ID` matches a session id or id prefix.
 
 Selector Semantics:
   Selection is relative to the newest matching Claude Code item.
@@ -148,7 +155,10 @@ Modes:
 
 Examples:
   sivtr copy claude
+  sivtr copy claude --session 2
+  sivtr copy claude --session abc123
   sivtr copy claude out --print
+  sivtr copy claude --session 2 --pick
   sivtr copy claude --pick
   sivtr copy claude all --lines 1:20
 ";
@@ -232,7 +242,7 @@ pub enum Commands {
 
     /// Copy recent command blocks to clipboard
     #[command(visible_alias = "c", after_help = COPY_AFTER_HELP)]
-    Copy(CopyCommand),
+    Copy(Box<CopyCommand>),
 
     /// Alias for `copy in`
     #[command(name = "ci", hide = true)]
@@ -346,6 +356,16 @@ pub struct CopyArgs {
 pub struct CopySimpleArgs {
     #[command(flatten)]
     pub common: CopyCommonArgs,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct AgentCopyArgs {
+    #[command(flatten)]
+    pub common: CopySimpleArgs,
+
+    /// Which recorded session to read; `1` means the newest session, or pass an id / id prefix
+    #[arg(long, value_name = "N|ID")]
+    pub session: Option<String>,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -520,22 +540,22 @@ pub struct AgentCopyCommand {
     pub mode: Option<AgentCopyMode>,
 
     #[command(flatten)]
-    pub args: CopySimpleArgs,
+    pub args: AgentCopyArgs,
 }
 
 #[derive(Subcommand, Debug)]
 pub enum AgentCopyMode {
     /// Copy the last user message
-    In(CopySimpleArgs),
+    In(AgentCopyArgs),
 
     /// Copy the last assistant reply
-    Out(CopySimpleArgs),
+    Out(AgentCopyArgs),
 
     /// Copy the last tool output
-    Tool(CopySimpleArgs),
+    Tool(AgentCopyArgs),
 
     /// Copy the whole parsed session
-    All(CopySimpleArgs),
+    All(AgentCopyArgs),
 }
 
 #[derive(Parser, Debug)]
@@ -665,7 +685,7 @@ mod tests {
             Some(Commands::Copy(cmd)) => match cmd.mode {
                 Some(CopySubcommand::Codex(codex)) => {
                     assert!(codex.mode.is_none());
-                    assert_eq!(codex.args.common.selector, None);
+                    assert_eq!(codex.args.common.common.selector, None);
                 }
                 _ => panic!("expected copy codex mode"),
             },
@@ -680,7 +700,7 @@ mod tests {
         match cli.command {
             Some(Commands::Copy(cmd)) => match cmd.mode {
                 Some(CopySubcommand::Codex(codex)) => match codex.mode {
-                    Some(AgentCopyMode::Out(args)) => assert!(args.common.print),
+                    Some(AgentCopyMode::Out(args)) => assert!(args.common.common.print),
                     _ => panic!("expected copy codex out mode"),
                 },
                 _ => panic!("expected copy codex mode"),
@@ -696,7 +716,22 @@ mod tests {
         match cli.command {
             Some(Commands::Copy(cmd)) => match cmd.mode {
                 Some(CopySubcommand::Codex(codex)) => {
-                    assert_eq!(codex.args.common.selector.as_deref(), Some("2..4"));
+                    assert_eq!(codex.args.common.common.selector.as_deref(), Some("2..4"));
+                }
+                _ => panic!("expected copy codex mode"),
+            },
+            _ => panic!("expected copy command"),
+        }
+    }
+
+    #[test]
+    fn codex_copy_accepts_session_selector() {
+        let cli = Cli::try_parse_from(["sivtr", "copy", "codex", "--session", "2"]).unwrap();
+
+        match cli.command {
+            Some(Commands::Copy(cmd)) => match cmd.mode {
+                Some(CopySubcommand::Codex(codex)) => {
+                    assert_eq!(codex.args.session.as_deref(), Some("2"));
                 }
                 _ => panic!("expected copy codex mode"),
             },
@@ -711,9 +746,24 @@ mod tests {
         match cli.command {
             Some(Commands::Copy(cmd)) => match cmd.mode {
                 Some(CopySubcommand::Claude(claude)) => match claude.mode {
-                    Some(AgentCopyMode::Out(args)) => assert!(args.common.print),
+                    Some(AgentCopyMode::Out(args)) => assert!(args.common.common.print),
                     _ => panic!("expected copy claude out mode"),
                 },
+                _ => panic!("expected copy claude mode"),
+            },
+            _ => panic!("expected copy command"),
+        }
+    }
+
+    #[test]
+    fn claude_copy_accepts_session_selector() {
+        let cli = Cli::try_parse_from(["sivtr", "copy", "claude", "--session", "abc123"]).unwrap();
+
+        match cli.command {
+            Some(Commands::Copy(cmd)) => match cmd.mode {
+                Some(CopySubcommand::Claude(claude)) => {
+                    assert_eq!(claude.args.session.as_deref(), Some("abc123"));
+                }
                 _ => panic!("expected copy claude mode"),
             },
             _ => panic!("expected copy command"),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -457,13 +457,17 @@ pub struct HotkeyServeArgs {
 
 #[derive(Args, Debug, Clone)]
 pub struct HotkeyPickAgentArgs {
-    /// Working directory used to resolve current AI sessions
+    /// Working directory used for launching the picker process
     #[arg(long, value_name = "PATH")]
     pub cwd: PathBuf,
 
     /// AI provider sessions to show
     #[arg(long, default_value_t = HotkeyProviderSelection::default(), value_name = "PROVIDER")]
     pub provider: HotkeyProviderSelection,
+
+    /// Restrict the picker to sessions whose cwd matches `--cwd`
+    #[arg(long, default_value_t = false)]
+    pub current_session: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -817,6 +821,27 @@ mod tests {
             Some(Commands::HotkeyPickAgent(args)) => {
                 assert_eq!(args.cwd, PathBuf::from("."));
                 assert_eq!(args.provider, HotkeyProviderSelection::default());
+                assert!(!args.current_session);
+            }
+            _ => panic!("expected hotkey-pick-agent command"),
+        }
+    }
+
+    #[test]
+    fn hotkey_pick_agent_accepts_current_session_flag() {
+        let cli = Cli::try_parse_from([
+            "sivtr",
+            "hotkey-pick-agent",
+            "--cwd",
+            ".",
+            "--current-session",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::HotkeyPickAgent(args)) => {
+                assert_eq!(args.cwd, PathBuf::from("."));
+                assert!(args.current_session);
             }
             _ => panic!("expected hotkey-pick-agent command"),
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -585,8 +585,12 @@ pub struct CodexExportArgs {
     pub watch: bool,
 
     /// Seconds between sync passes when `--watch` is enabled
-    #[arg(long, value_name = "SECONDS", default_value_t = 2, requires = "watch")]
+    #[arg(long, value_name = "SECONDS", default_value_t = 1, requires = "watch")]
     pub interval: u64,
+
+    /// Milliseconds between sync passes when `--watch` is enabled (overrides `--interval`)
+    #[arg(long, value_name = "MILLISECONDS", requires = "watch")]
+    pub interval_ms: Option<u64>,
 }
 
 #[cfg(test)]
@@ -841,6 +845,34 @@ mod tests {
                     assert_eq!(args.limit, 5);
                     assert!(args.watch);
                     assert_eq!(args.interval, 3);
+                    assert_eq!(args.interval_ms, None);
+                }
+            },
+            _ => panic!("expected codex export command"),
+        }
+    }
+
+    #[test]
+    fn codex_export_accepts_millisecond_interval() {
+        let cli = Cli::try_parse_from([
+            "sivtr",
+            "codex",
+            "export",
+            "--dest",
+            "/tmp/shared-codex",
+            "--watch",
+            "--interval-ms",
+            "250",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::Codex(cmd)) => match cmd.action {
+                CodexAction::Export(args) => {
+                    assert_eq!(args.dest, PathBuf::from("/tmp/shared-codex"));
+                    assert!(args.watch);
+                    assert_eq!(args.interval, 1);
+                    assert_eq!(args.interval_ms, Some(250));
                 }
             },
             _ => panic!("expected codex export command"),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -254,6 +254,9 @@ pub enum Commands {
     #[command(after_help = HOTKEY_AFTER_HELP)]
     Hotkey(HotkeyCommand),
 
+    /// Export local Codex session files into a shared read-only tree
+    Codex(CodexCommand),
+
     /// Clear session logs
     Clear(ClearArgs),
 
@@ -535,6 +538,37 @@ pub enum AgentCopyMode {
     All(CopySimpleArgs),
 }
 
+#[derive(Parser, Debug)]
+pub struct CodexCommand {
+    #[command(subcommand)]
+    pub action: CodexAction,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum CodexAction {
+    /// Export local Codex rollout JSONL files into a target directory
+    Export(CodexExportArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct CodexExportArgs {
+    /// Destination directory that will receive a sessions/ tree copy
+    #[arg(long, value_name = "PATH")]
+    pub dest: PathBuf,
+
+    /// Keep only the newest N session files; `0` means export all
+    #[arg(long, value_name = "N", default_value_t = 0)]
+    pub limit: usize,
+
+    /// Continue mirroring local sessions into the destination tree
+    #[arg(long, default_value_t = false)]
+    pub watch: bool,
+
+    /// Seconds between sync passes when `--watch` is enabled
+    #[arg(long, value_name = "SECONDS", default_value_t = 2, requires = "watch")]
+    pub interval: u64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -731,6 +765,35 @@ mod tests {
                 assert_eq!(args.provider, HotkeyProviderSelection::default());
             }
             _ => panic!("expected hotkey-pick-agent command"),
+        }
+    }
+
+    #[test]
+    fn codex_export_accepts_destination_and_watch_flags() {
+        let cli = Cli::try_parse_from([
+            "sivtr",
+            "codex",
+            "export",
+            "--dest",
+            "/tmp/shared-codex",
+            "--limit",
+            "5",
+            "--watch",
+            "--interval",
+            "3",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::Codex(cmd)) => match cmd.action {
+                CodexAction::Export(args) => {
+                    assert_eq!(args.dest, PathBuf::from("/tmp/shared-codex"));
+                    assert_eq!(args.limit, 5);
+                    assert!(args.watch);
+                    assert_eq!(args.interval, 3);
+                }
+            },
+            _ => panic!("expected codex export command"),
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -224,9 +224,9 @@ pub enum Commands {
     /// Manage configuration
     Config(ConfigCommand),
 
-    /// Generate shell integration hook
+    /// Generate shell integration or Linux shortcut helpers
     Init {
-        /// Shell type: powershell, bash, zsh, nushell
+        /// Integration target: powershell, bash, zsh, nushell, tmux, linux-shortcut, macos-shortcut
         shell: String,
     },
 
@@ -814,6 +814,49 @@ mod tests {
                 assert_eq!(args, vec!["-lc".to_string(), "printf ok".to_string()]);
             }
             _ => panic!("expected run command"),
+        }
+    }
+
+    #[test]
+    fn init_accepts_tmux_target() {
+        let cli = Cli::try_parse_from(["sivtr", "init", "tmux"]).unwrap();
+
+        match cli.command {
+            Some(Commands::Init { shell }) => assert_eq!(shell, "tmux"),
+            _ => panic!("expected init command"),
+        }
+    }
+
+    #[test]
+    fn init_accepts_linux_shortcut_target() {
+        let cli = Cli::try_parse_from(["sivtr", "init", "linux-shortcut"]).unwrap();
+
+        match cli.command {
+            Some(Commands::Init { shell }) => assert_eq!(shell, "linux-shortcut"),
+            _ => panic!("expected init command"),
+        }
+    }
+
+    #[test]
+    fn run_accepts_hyphenated_args() {
+        let cli = Cli::try_parse_from(["sivtr", "run", "bash", "-lc", "printf ok"]).unwrap();
+
+        match cli.command {
+            Some(Commands::Run { command, args }) => {
+                assert_eq!(command, "bash");
+                assert_eq!(args, vec!["-lc", "printf ok"]);
+            }
+            _ => panic!("expected run command"),
+        }
+    }
+
+    #[test]
+    fn init_accepts_macos_shortcut_target() {
+        let cli = Cli::try_parse_from(["sivtr", "init", "macos-shortcut"]).unwrap();
+
+        match cli.command {
+            Some(Commands::Init { shell }) => assert_eq!(shell, "macos-shortcut"),
+            _ => panic!("expected init command"),
         }
     }
 }

--- a/src/commands/browse.rs
+++ b/src/commands/browse.rs
@@ -1,5 +1,7 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
+use sivtr_core::config::SivtrConfig;
 use sivtr_core::export::editor;
+use sivtr_core::history::{store::CaptureSource, HistoryStore};
 
 use crate::app::{App, StatusMessage};
 use crate::tui;
@@ -7,6 +9,8 @@ use crate::tui;
 /// Shared TUI event loop with external editor support.
 /// Used by both `pipe` and `run` commands.
 pub fn run_tui(app: &mut App, start_at_bottom: bool) -> Result<()> {
+    ensure_tui_stdout()?;
+
     let mut terminal = tui::terminal::init()?;
     let size = terminal.size()?;
     app.buffer
@@ -65,4 +69,109 @@ pub fn run_tui(app: &mut App, start_at_bottom: bool) -> Result<()> {
 
     tui::terminal::restore(&mut terminal)?;
     Ok(())
+}
+
+pub(crate) fn record_history(
+    config: &SivtrConfig,
+    content: &str,
+    command: Option<&str>,
+    source: CaptureSource,
+) {
+    if let Err(error) = try_record_history(config, content, command, source) {
+        eprintln!("sivtr: failed to save history: {error:#}");
+    }
+}
+
+fn ensure_tui_stdout() -> Result<()> {
+    if atty::is(atty::Stream::Stdout) {
+        return Ok(());
+    }
+
+    bail!(
+        "sivtr: TUI mode requires an interactive terminal\n  hint: run inside a terminal or set `general.open_mode = \"editor\"` in config"
+    )
+}
+
+fn try_record_history(
+    config: &SivtrConfig,
+    content: &str,
+    command: Option<&str>,
+    source: CaptureSource,
+) -> Result<()> {
+    if !config.history.auto_save || content.trim().is_empty() {
+        return Ok(());
+    }
+
+    let store = HistoryStore::open_default()?;
+    try_record_history_with_store(&store, config, content, command, source)
+}
+
+fn try_record_history_with_store(
+    store: &HistoryStore,
+    config: &SivtrConfig,
+    content: &str,
+    command: Option<&str>,
+    source: CaptureSource,
+) -> Result<()> {
+    if !config.history.auto_save || content.trim().is_empty() {
+        return Ok(());
+    }
+
+    store.insert(content, command, source)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ensure_tui_stdout, try_record_history_with_store};
+    use sivtr_core::config::SivtrConfig;
+    use sivtr_core::history::{store::CaptureSource, HistoryStore};
+
+    #[test]
+    fn records_history_when_auto_save_is_enabled() {
+        let store = HistoryStore::open_memory().unwrap();
+        let config = SivtrConfig::default();
+
+        try_record_history_with_store(
+            &store,
+            &config,
+            "hello world",
+            Some("echo hello"),
+            CaptureSource::Run,
+        )
+        .unwrap();
+
+        let entries = store.list_recent(10).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].command.as_deref(), Some("echo hello"));
+        assert_eq!(entries[0].source, "run");
+    }
+
+    #[test]
+    fn skips_history_when_auto_save_is_disabled() {
+        let store = HistoryStore::open_memory().unwrap();
+        let mut config = SivtrConfig::default();
+        config.history.auto_save = false;
+
+        try_record_history_with_store(
+            &store,
+            &config,
+            "hello world",
+            Some("echo hello"),
+            CaptureSource::Run,
+        )
+        .unwrap();
+
+        let entries = store.list_recent(10).unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn rejects_non_interactive_tui_stdout() {
+        let error = ensure_tui_stdout().unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("TUI mode requires an interactive terminal"));
+    }
 }

--- a/src/commands/clear.rs
+++ b/src/commands/clear.rs
@@ -18,6 +18,7 @@ pub fn execute(clear_all: bool) -> Result<()> {
 
     let log = scrollback::session_log_path();
     let state = scrollback::flush_state_path();
+    let capture = scrollback::capture_file_path();
 
     let mut cleared = false;
 
@@ -25,7 +26,7 @@ pub fn execute(clear_all: bool) -> Result<()> {
         fs::remove_file(&log)?;
         cleared = true;
     }
-    for f in [&state] {
+    for f in [&state, &capture] {
         if f.exists() {
             let _ = fs::remove_file(f);
         }
@@ -81,7 +82,8 @@ fn is_session_artifact(path: &Path) -> bool {
     };
 
     (name == "session.log" || name == "session.state")
-        || (name.starts_with("session_") && (name.ends_with(".log") || name.ends_with(".state")))
+        || (name.starts_with("session_")
+            && (name.ends_with(".log") || name.ends_with(".state") || name.ends_with(".capture")))
 }
 
 #[cfg(test)]
@@ -95,6 +97,7 @@ mod tests {
         assert!(is_session_artifact(Path::new("session.state")));
         assert!(is_session_artifact(Path::new("session_1234.log")));
         assert!(is_session_artifact(Path::new("session_1234.state")));
+        assert!(is_session_artifact(Path::new("session_1234.capture")));
         assert!(!is_session_artifact(Path::new("config.toml")));
         assert!(!is_session_artifact(Path::new("history.db")));
     }

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -162,16 +162,18 @@ fn remove_stale_exported_files_inner(
     Ok(())
 }
 
+#[cfg(unix)]
 fn set_shared_read_permissions(path: &Path) -> Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::fs::PermissionsExt;
 
-        let mode = if path.is_dir() { 0o755 } else { 0o644 };
-        fs::set_permissions(path, fs::Permissions::from_mode(mode))
-            .with_context(|| format!("Failed to chmod {}", path.display()))?;
-    }
+    let mode = if path.is_dir() { 0o755 } else { 0o644 };
+    fs::set_permissions(path, fs::Permissions::from_mode(mode))
+        .with_context(|| format!("Failed to chmod {}", path.display()))?;
+    Ok(())
+}
 
+#[cfg(not(unix))]
+fn set_shared_read_permissions(_path: &Path) -> Result<()> {
     Ok(())
 }
 
@@ -193,10 +195,10 @@ fn set_shared_read_permissions_recursive(root: &Path, path: &Path) -> Result<()>
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        collect_session_files, copy_session_file_atomically, export_once,
-        set_shared_read_permissions_recursive,
-    };
+    #[cfg(unix)]
+    use super::set_shared_read_permissions_recursive;
+    use super::{collect_session_files, copy_session_file_atomically, export_once};
+    #[cfg(unix)]
     use std::path::Path;
 
     #[test]

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -49,6 +49,7 @@ fn export_once(source_root: &Path, target_root: &Path, limit: usize) -> Result<u
     set_shared_read_permissions(target_root)?;
 
     let mut kept = HashSet::new();
+    let mut seen_dirs = HashSet::new();
     for source in &files {
         let relative = source
             .strip_prefix(source_root)
@@ -57,14 +58,16 @@ fn export_once(source_root: &Path, target_root: &Path, limit: usize) -> Result<u
 
         let target = target_root.join(relative);
         if let Some(parent) = target.parent() {
-            fs::create_dir_all(parent)
-                .with_context(|| format!("Failed to create {}", parent.display()))?;
-            set_shared_read_permissions_recursive(target_root, parent)?;
+            if seen_dirs.insert(parent.to_path_buf()) {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("Failed to create {}", parent.display()))?;
+                set_shared_read_permissions_recursive(target_root, parent)?;
+            }
         }
         copy_session_file_atomically(source, &target)?;
     }
 
-    remove_stale_exported_files(target_root, &kept)?;
+    remove_stale_exported_files(target_root, &kept);
     Ok(files.len())
 }
 
@@ -121,27 +124,62 @@ fn copy_session_file_atomically(source: &Path, target: &Path) -> Result<()> {
     Ok(())
 }
 
-fn remove_stale_exported_files(root: &Path, kept: &HashSet<PathBuf>) -> Result<()> {
+fn remove_stale_exported_files(root: &Path, kept: &HashSet<PathBuf>) {
     if !root.exists() {
-        return Ok(());
+        return;
     }
 
-    remove_stale_exported_files_inner(root, root, kept)
+    remove_stale_exported_files_inner(root, root, kept);
 }
 
-fn remove_stale_exported_files_inner(
-    root: &Path,
-    dir: &Path,
-    kept: &HashSet<PathBuf>,
-) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("Failed to read {}", dir.display()))? {
-        let entry = entry?;
+fn remove_stale_exported_files_inner(root: &Path, dir: &Path, kept: &HashSet<PathBuf>) {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) => {
+            eprintln!(
+                "sivtr: warning: failed to read {} during stale export cleanup: {}",
+                dir.display(),
+                err
+            );
+            return;
+        }
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) => {
+                eprintln!(
+                    "sivtr: warning: failed to inspect an entry under {}: {}",
+                    dir.display(),
+                    err
+                );
+                continue;
+            }
+        };
         let path = entry.path();
         if path.is_dir() {
-            remove_stale_exported_files_inner(root, &path, kept)?;
-            if fs::read_dir(&path)?.next().is_none() {
-                fs::remove_dir(&path)
-                    .with_context(|| format!("Failed to remove {}", path.display()))?;
+            remove_stale_exported_files_inner(root, &path, kept);
+
+            match fs::read_dir(&path) {
+                Ok(mut children) => {
+                    if children.next().is_none() {
+                        if let Err(err) = fs::remove_dir(&path) {
+                            eprintln!(
+                                "sivtr: warning: failed to remove empty export directory {}: {}",
+                                path.display(),
+                                err
+                            );
+                        }
+                    }
+                }
+                Err(err) => {
+                    eprintln!(
+                        "sivtr: warning: failed to re-read {} for cleanup: {}",
+                        path.display(),
+                        err
+                    );
+                }
             }
             continue;
         }
@@ -150,16 +188,27 @@ fn remove_stale_exported_files_inner(
             continue;
         }
 
-        let relative = path
-            .strip_prefix(root)
-            .with_context(|| format!("Failed to relativize {}", path.display()))?;
+        let relative = match path.strip_prefix(root) {
+            Ok(relative) => relative,
+            Err(err) => {
+                eprintln!(
+                    "sivtr: warning: failed to relativize {}: {}",
+                    path.display(),
+                    err
+                );
+                continue;
+            }
+        };
         if !kept.contains(relative) {
-            fs::remove_file(&path)
-                .with_context(|| format!("Failed to remove stale export {}", path.display()))?;
+            if let Err(err) = fs::remove_file(&path) {
+                eprintln!(
+                    "sivtr: warning: failed to remove stale export {}: {}",
+                    path.display(),
+                    err
+                );
+            }
         }
     }
-
-    Ok(())
 }
 
 #[cfg(unix)]

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -21,6 +21,10 @@ fn export(args: CodexExportArgs) -> Result<()> {
     }
 
     let target_root = args.dest.join("sessions");
+    let watch_interval = args
+        .watch
+        .then(|| resolve_watch_interval(&args))
+        .transpose()?;
 
     loop {
         let copied = export_once(&source_root, &target_root, args.limit)?;
@@ -30,12 +34,26 @@ fn export(args: CodexExportArgs) -> Result<()> {
             target_root.display()
         );
 
-        if !args.watch {
+        let Some(watch_interval) = watch_interval else {
             return Ok(());
-        }
-
-        thread::sleep(Duration::from_secs(args.interval));
+        };
+        thread::sleep(watch_interval);
     }
+}
+
+fn resolve_watch_interval(args: &CodexExportArgs) -> Result<Duration> {
+    if let Some(interval_ms) = args.interval_ms {
+        if interval_ms == 0 {
+            anyhow::bail!("`--interval-ms` must be greater than 0 when `--watch` is enabled");
+        }
+        return Ok(Duration::from_millis(interval_ms));
+    }
+
+    if args.interval == 0 {
+        anyhow::bail!("`--interval` must be greater than 0 when `--watch` is enabled");
+    }
+
+    Ok(Duration::from_secs(args.interval))
 }
 
 fn export_once(source_root: &Path, target_root: &Path, limit: usize) -> Result<usize> {
@@ -246,9 +264,14 @@ fn set_shared_read_permissions_recursive(root: &Path, path: &Path) -> Result<()>
 mod tests {
     #[cfg(unix)]
     use super::set_shared_read_permissions_recursive;
-    use super::{collect_session_files, copy_session_file_atomically, export_once};
+    use super::{
+        collect_session_files, copy_session_file_atomically, export_once, resolve_watch_interval,
+    };
+    use crate::cli::CodexExportArgs;
     #[cfg(unix)]
     use std::path::Path;
+    use std::path::PathBuf;
+    use std::time::Duration;
 
     #[test]
     fn collect_session_files_sorts_newest_first() {
@@ -342,5 +365,65 @@ mod tests {
 
         assert_eq!(std::fs::read_to_string(&target).unwrap(), "new data\n");
         assert!(!dir.path().join("target.jsonl.tmp").exists());
+    }
+
+    #[test]
+    fn resolve_watch_interval_defaults_to_seconds() {
+        let args = CodexExportArgs {
+            dest: PathBuf::from("/tmp/shared-codex"),
+            limit: 0,
+            watch: true,
+            interval: 2,
+            interval_ms: None,
+        };
+
+        let interval = resolve_watch_interval(&args).unwrap();
+        assert_eq!(interval, Duration::from_secs(2));
+    }
+
+    #[test]
+    fn resolve_watch_interval_prefers_milliseconds_override() {
+        let args = CodexExportArgs {
+            dest: PathBuf::from("/tmp/shared-codex"),
+            limit: 0,
+            watch: true,
+            interval: 10,
+            interval_ms: Some(250),
+        };
+
+        let interval = resolve_watch_interval(&args).unwrap();
+        assert_eq!(interval, Duration::from_millis(250));
+    }
+
+    #[test]
+    fn resolve_watch_interval_rejects_zero_seconds() {
+        let args = CodexExportArgs {
+            dest: PathBuf::from("/tmp/shared-codex"),
+            limit: 0,
+            watch: true,
+            interval: 0,
+            interval_ms: None,
+        };
+
+        let error = resolve_watch_interval(&args).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("`--interval` must be greater than 0"));
+    }
+
+    #[test]
+    fn resolve_watch_interval_rejects_zero_milliseconds() {
+        let args = CodexExportArgs {
+            dest: PathBuf::from("/tmp/shared-codex"),
+            limit: 0,
+            watch: true,
+            interval: 1,
+            interval_ms: Some(0),
+        };
+
+        let error = resolve_watch_interval(&args).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("`--interval-ms` must be greater than 0"));
     }
 }

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -1,0 +1,295 @@
+use crate::cli::{CodexAction, CodexCommand, CodexExportArgs};
+use anyhow::{Context, Result};
+use sivtr_core::codex::local_codex_sessions_dir;
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
+use std::time::SystemTime;
+
+pub fn execute(command: CodexCommand) -> Result<()> {
+    match command.action {
+        CodexAction::Export(args) => export(args),
+    }
+}
+
+fn export(args: CodexExportArgs) -> Result<()> {
+    let source_root = local_codex_sessions_dir();
+    if !source_root.exists() {
+        anyhow::bail!("No local Codex sessions found at {}", source_root.display());
+    }
+
+    let target_root = args.dest.join("sessions");
+
+    loop {
+        let copied = export_once(&source_root, &target_root, args.limit)?;
+        eprintln!(
+            "sivtr: mirrored {} Codex session file(s) to {}",
+            copied,
+            target_root.display()
+        );
+
+        if !args.watch {
+            return Ok(());
+        }
+
+        thread::sleep(Duration::from_secs(args.interval));
+    }
+}
+
+fn export_once(source_root: &Path, target_root: &Path, limit: usize) -> Result<usize> {
+    let files = collect_session_files(source_root, limit)?;
+    if files.is_empty() {
+        anyhow::bail!("No local Codex sessions found at {}", source_root.display());
+    }
+
+    fs::create_dir_all(target_root)
+        .with_context(|| format!("Failed to create {}", target_root.display()))?;
+    set_shared_read_permissions(target_root)?;
+
+    let mut kept = HashSet::new();
+    for source in &files {
+        let relative = source
+            .strip_prefix(source_root)
+            .with_context(|| format!("Failed to relativize {}", source.display()))?;
+        kept.insert(relative.to_path_buf());
+
+        let target = target_root.join(relative);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create {}", parent.display()))?;
+            set_shared_read_permissions_recursive(target_root, parent)?;
+        }
+        copy_session_file_atomically(source, &target)?;
+    }
+
+    remove_stale_exported_files(target_root, &kept)?;
+    Ok(files.len())
+}
+
+fn collect_session_files(root: &Path, limit: usize) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    collect_jsonl_files(root, &mut files)?;
+    files.sort_by_key(|path| modified_time(path).unwrap_or(SystemTime::UNIX_EPOCH));
+    files.reverse();
+    if limit > 0 {
+        files.truncate(limit);
+    }
+    Ok(files)
+}
+
+fn collect_jsonl_files(root: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(root).with_context(|| format!("Failed to read {}", root.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_jsonl_files(&path, files)?;
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("jsonl") {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn modified_time(path: &Path) -> Result<SystemTime> {
+    Ok(fs::metadata(path)?.modified()?)
+}
+
+fn copy_session_file_atomically(source: &Path, target: &Path) -> Result<()> {
+    let temp = target.with_extension("jsonl.tmp");
+    if temp.exists() {
+        fs::remove_file(&temp).with_context(|| format!("Failed to remove {}", temp.display()))?;
+    }
+
+    fs::copy(source, &temp).with_context(|| {
+        format!(
+            "Failed to copy Codex session from {} to {}",
+            source.display(),
+            temp.display()
+        )
+    })?;
+    set_shared_read_permissions(&temp)?;
+
+    if target.exists() {
+        fs::remove_file(target)
+            .with_context(|| format!("Failed to replace {}", target.display()))?;
+    }
+
+    fs::rename(&temp, target).with_context(|| format!("Failed to publish {}", target.display()))?;
+    set_shared_read_permissions(target)?;
+    Ok(())
+}
+
+fn remove_stale_exported_files(root: &Path, kept: &HashSet<PathBuf>) -> Result<()> {
+    if !root.exists() {
+        return Ok(());
+    }
+
+    remove_stale_exported_files_inner(root, root, kept)
+}
+
+fn remove_stale_exported_files_inner(
+    root: &Path,
+    dir: &Path,
+    kept: &HashSet<PathBuf>,
+) -> Result<()> {
+    for entry in fs::read_dir(dir).with_context(|| format!("Failed to read {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            remove_stale_exported_files_inner(root, &path, kept)?;
+            if fs::read_dir(&path)?.next().is_none() {
+                fs::remove_dir(&path)
+                    .with_context(|| format!("Failed to remove {}", path.display()))?;
+            }
+            continue;
+        }
+
+        if path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
+            continue;
+        }
+
+        let relative = path
+            .strip_prefix(root)
+            .with_context(|| format!("Failed to relativize {}", path.display()))?;
+        if !kept.contains(relative) {
+            fs::remove_file(&path)
+                .with_context(|| format!("Failed to remove stale export {}", path.display()))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn set_shared_read_permissions(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mode = if path.is_dir() { 0o755 } else { 0o644 };
+        fs::set_permissions(path, fs::Permissions::from_mode(mode))
+            .with_context(|| format!("Failed to chmod {}", path.display()))?;
+    }
+
+    Ok(())
+}
+
+fn set_shared_read_permissions_recursive(root: &Path, path: &Path) -> Result<()> {
+    let relative = path
+        .strip_prefix(root)
+        .with_context(|| format!("Failed to relativize {}", path.display()))?;
+
+    let mut current = root.to_path_buf();
+    set_shared_read_permissions(&current)?;
+
+    for component in relative.components() {
+        current.push(component.as_os_str());
+        set_shared_read_permissions(&current)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        collect_session_files, copy_session_file_atomically, export_once,
+        set_shared_read_permissions_recursive,
+    };
+    use std::path::Path;
+
+    #[test]
+    fn collect_session_files_sorts_newest_first() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("a.jsonl");
+        let second = dir.path().join("b.jsonl");
+        std::fs::write(&first, "{}\n").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        std::fs::write(&second, "{}\n").unwrap();
+
+        let files = collect_session_files(dir.path(), 0).unwrap();
+
+        assert_eq!(files, vec![second, first]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_permissions_are_applied_to_nested_export_directories() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("sessions");
+        let nested = root.join(Path::new("2026/05/07"));
+        std::fs::create_dir_all(&nested).unwrap();
+
+        set_shared_read_permissions_recursive(&root, &nested).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&root).unwrap().permissions().mode() & 0o777,
+            0o755
+        );
+        assert_eq!(
+            std::fs::metadata(root.join("2026"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o755
+        );
+        assert_eq!(
+            std::fs::metadata(root.join("2026/05"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o755
+        );
+        assert_eq!(
+            std::fs::metadata(&nested).unwrap().permissions().mode() & 0o777,
+            0o755
+        );
+    }
+
+    #[test]
+    fn export_once_removes_stale_files_outside_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_root = dir.path().join("source");
+        let target_root = dir.path().join("target").join("sessions");
+        let nested = source_root.join("2026/05/08");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let newest = nested.join("newest.jsonl");
+        let older = nested.join("older.jsonl");
+        std::fs::write(
+            &older,
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"older\"}}\n",
+        )
+        .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        std::fs::write(
+            &newest,
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"newest\"}}\n",
+        )
+        .unwrap();
+
+        export_once(&source_root, &target_root, 1).unwrap();
+
+        assert!(target_root.join("2026/05/08/newest.jsonl").exists());
+        assert!(!target_root.join("2026/05/08/older.jsonl").exists());
+    }
+
+    #[test]
+    fn atomic_copy_replaces_existing_file_contents() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.jsonl");
+        let target = dir.path().join("target.jsonl");
+        std::fs::write(&source, "new data\n").unwrap();
+        std::fs::write(&target, "old data\n").unwrap();
+
+        copy_session_file_atomically(&source, &target).unwrap();
+
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "new data\n");
+        assert!(!dir.path().join("target.jsonl.tmp").exists());
+    }
+}

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -15,7 +15,7 @@ pub fn execute(cmd: ConfigCommand) -> Result<()> {
                 let content = std::fs::read_to_string(&path)?;
                 println!("{content}");
             } else {
-                println!("(file does not exist 鈥?using defaults)");
+                println!("(file does not exist - using defaults)");
                 println!();
                 let config = SivtrConfig::default();
                 let content = sivtr_core::config::to_toml_string(&config)?;

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -57,6 +57,7 @@ pub struct CopyRequest<'a> {
 pub struct AgentCopyRequest<'a> {
     pub provider: AgentProvider,
     pub selector: Option<&'a str>,
+    pub session_selector: Option<&'a str>,
     pub pick: bool,
     pub pick_current_session: bool,
     pub selection_mode: AgentSelection,
@@ -255,11 +256,12 @@ pub fn execute(request: CopyRequest<'_>) -> Result<()> {
 
 pub fn execute_agent(request: AgentCopyRequest<'_>) -> Result<()> {
     let source = request.provider.session_provider();
-    if request.pick && !request.pick_current_session {
+    if request.pick && !request.pick_current_session && request.session_selector.is_none() {
         return execute_agent_session_pick(source.as_ref(), request);
     }
 
-    let path = if request.pick && request.pick_current_session {
+    let path = if request.pick && request.pick_current_session && request.session_selector.is_none()
+    {
         let cwd = std::env::current_dir().context("Failed to resolve current directory")?;
         match resolve_current_agent_session_with_blocks(source.as_ref(), &cwd)? {
             Some(path) => {
@@ -268,7 +270,11 @@ pub fn execute_agent(request: AgentCopyRequest<'_>) -> Result<()> {
             None => return execute_agent_session_pick(source.as_ref(), request),
         }
     } else {
-        resolve_agent_session_path(source.as_ref(), request.pick_current_session)?
+        resolve_agent_session_path(
+            source.as_ref(),
+            request.session_selector,
+            request.pick_current_session,
+        )?
     };
     let session = source.parse_session_file(&path)?;
     let provider_name = source.provider().name();
@@ -327,6 +333,7 @@ pub fn execute_agent_picker(request: AgentPickerRequest<'_>) -> Result<()> {
     let copy_request = AgentCopyRequest {
         provider: picked.provider,
         selector: None,
+        session_selector: None,
         pick: true,
         pick_current_session: request.pick_current_session,
         selection_mode: request.selection_mode,
@@ -1348,8 +1355,13 @@ fn finish_copy(text: String, print_full: bool, success_message: String) -> Resul
 
 fn resolve_agent_session_path(
     source: &dyn AgentSessionProvider,
+    session_selector: Option<&str>,
     pick_current_session: bool,
 ) -> Result<std::path::PathBuf> {
+    if let Some(selector) = session_selector {
+        return resolve_explicit_agent_session_path(source, selector);
+    }
+
     let cwd = std::env::current_dir().context("Failed to resolve current directory")?;
     if pick_current_session {
         return resolve_current_agent_pick_session_path(source, &cwd);
@@ -1358,6 +1370,62 @@ fn resolve_agent_session_path(
     source
         .find_current_session(&cwd)?
         .with_context(|| format!("No {} sessions found", source.provider().name()))
+}
+
+fn resolve_explicit_agent_session_path(
+    source: &dyn AgentSessionProvider,
+    selector: &str,
+) -> Result<std::path::PathBuf> {
+    let sessions = source.list_recent_sessions(None)?;
+    resolve_agent_session_selector(source, &sessions, selector)
+}
+
+fn resolve_agent_session_selector(
+    source: &dyn AgentSessionProvider,
+    sessions: &[AgentSessionInfo],
+    selector: &str,
+) -> Result<std::path::PathBuf> {
+    let selector = selector.trim();
+    if selector.is_empty() {
+        anyhow::bail!(
+            "Empty {} session selector. Use `--session 2`, `--session <id>`, or `--pick`.",
+            source.provider().name()
+        );
+    }
+
+    if let Ok(recent) = selector.parse::<usize>() {
+        if recent == 0 {
+            anyhow::bail!(
+                "Session selectors are 1-based. Use `--session 1` for the newest session."
+            );
+        }
+        if recent <= sessions.len() && !selector.starts_with('0') {
+            return Ok(sessions[recent - 1].path.clone());
+        }
+    }
+
+    sessions
+        .iter()
+        .find(|session| agent_session_matches_selector(session, selector))
+        .map(|session| session.path.clone())
+        .with_context(|| {
+            format!(
+                "No {} session matched `{selector}`. Use `--pick` to browse recent sessions.",
+                source.provider().name()
+            )
+        })
+}
+
+fn agent_session_matches_selector(session: &AgentSessionInfo, selector: &str) -> bool {
+    session
+        .id
+        .as_deref()
+        .is_some_and(|id| id == selector || id.starts_with(selector))
+        || session
+            .path
+            .file_stem()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.contains(selector))
 }
 
 fn resolve_current_agent_pick_session_path(
@@ -2191,9 +2259,9 @@ mod tests {
     use super::{
         agent_session_preview, build_agent_units, build_agent_vim_view,
         build_current_agent_session_choices, build_output_preview, filter_lines_by_regex,
-        filter_lines_by_spec, format_block, is_vim_command, vim_single_quote, AgentBlock,
-        AgentBlockKind, AgentProvider, AgentSelection, AgentSession, AgentSessionInfo,
-        AgentSessionProvider, CommandBlock, CommandSelection, CopyMode, TextPair,
+        filter_lines_by_spec, format_block, is_vim_command, resolve_agent_session_selector,
+        vim_single_quote, AgentBlock, AgentBlockKind, AgentProvider, AgentSelection, AgentSession,
+        AgentSessionInfo, AgentSessionProvider, CommandBlock, CommandSelection, CopyMode, TextPair,
     };
     use anyhow::Result;
     use std::path::{Path, PathBuf};
@@ -2552,6 +2620,7 @@ mod tests {
     fn current_agent_picker_lists_all_sessions_for_cwd() {
         let cwd = PathBuf::from("d:\\repo");
         let source = FakeAgentSource {
+            require_cwd: true,
             infos: vec![
                 AgentSessionInfo {
                     path: PathBuf::from("old.jsonl"),
@@ -2577,7 +2646,70 @@ mod tests {
         assert_eq!(choices[1].title, "[Codex] old task  [old]");
     }
 
+    #[test]
+    fn resolves_agent_session_selector_by_recent_index() {
+        let source = FakeAgentSource {
+            require_cwd: false,
+            infos: vec![
+                AgentSessionInfo {
+                    path: PathBuf::from("new.jsonl"),
+                    id: Some("new".to_string()),
+                    cwd: Some("d:\\repo".to_string()),
+                    modified: SystemTime::UNIX_EPOCH + Duration::from_secs(2),
+                },
+                AgentSessionInfo {
+                    path: PathBuf::from("old.jsonl"),
+                    id: Some("old".to_string()),
+                    cwd: Some("d:\\repo".to_string()),
+                    modified: SystemTime::UNIX_EPOCH + Duration::from_secs(1),
+                },
+            ],
+        };
+
+        let path = resolve_agent_session_selector(&source, &source.infos, "2").unwrap();
+
+        assert_eq!(path, PathBuf::from("old.jsonl"));
+    }
+
+    #[test]
+    fn resolves_agent_session_selector_by_id_prefix() {
+        let source = FakeAgentSource {
+            require_cwd: false,
+            infos: vec![AgentSessionInfo {
+                path: PathBuf::from("rollout-019df7fb.jsonl"),
+                id: Some("019df7fb-8289-7fb0-97c3-fe5307ee1b0a".to_string()),
+                cwd: Some("d:\\repo".to_string()),
+                modified: SystemTime::UNIX_EPOCH,
+            }],
+        };
+
+        let path = resolve_agent_session_selector(&source, &source.infos, "019df7fb").unwrap();
+
+        assert_eq!(path, PathBuf::from("rollout-019df7fb.jsonl"));
+    }
+
+    #[test]
+    fn rejects_zero_agent_session_selector() {
+        let source = FakeAgentSource {
+            require_cwd: false,
+            infos: vec![AgentSessionInfo {
+                path: PathBuf::from("only.jsonl"),
+                id: Some("only".to_string()),
+                cwd: Some("d:\\repo".to_string()),
+                modified: SystemTime::UNIX_EPOCH,
+            }],
+        };
+
+        let error = resolve_agent_session_selector(&source, &source.infos, "0").unwrap_err();
+
+        assert!(
+            error.to_string().contains("Session selectors are 1-based"),
+            "{error:#}"
+        );
+    }
+
     struct FakeAgentSource {
+        require_cwd: bool,
         infos: Vec<AgentSessionInfo>,
     }
 
@@ -2587,10 +2719,12 @@ mod tests {
         }
 
         fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
-            assert!(
-                cwd.is_some(),
-                "current picker must request cwd-filtered sessions"
-            );
+            if self.require_cwd {
+                assert!(
+                    cwd.is_some(),
+                    "current picker must request cwd-filtered sessions"
+                );
+            }
             Ok(self.infos.clone())
         }
 

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -25,7 +25,7 @@ use crate::tui::terminal::{init as init_tui, restore as restore_tui};
 use picker::{run_picker, run_single_picker, PickEntry};
 
 pub(crate) const PICK_CANCELLED_MESSAGE: &str = "Pick cancelled";
-const PICK_LIMIT: usize = 50;
+const COMMAND_PICK_LIMIT: usize = 50;
 const PICK_PREVIEW_LINES: usize = 8;
 
 pub(crate) fn is_pick_cancelled(error: &anyhow::Error) -> bool {
@@ -410,7 +410,6 @@ fn pick_agent_sessions_content_on_terminal(
         )?);
     }
     choices.sort_by(|a, b| b.modified.cmp(&a.modified));
-    choices.truncate(PICK_LIMIT);
 
     if choices.is_empty() {
         anyhow::bail!("No AI sessions with selectable content found");
@@ -464,7 +463,6 @@ fn build_current_agent_session_choices(
     }
 
     choices.sort_by(|a, b| b.modified.cmp(&a.modified));
-    choices.truncate(PICK_LIMIT);
     Ok(choices)
 }
 
@@ -544,7 +542,7 @@ fn build_agent_session_choices(
 ) -> Result<Vec<AgentSessionChoice>> {
     let mut choices = Vec::new();
 
-    for info in sessions.iter().take(PICK_LIMIT) {
+    for info in sessions {
         let session = source.parse_session_file(&info.path)?;
         if let Some(choice) = build_agent_session_choice(source, info, session, selection_mode) {
             choices.push(choice);
@@ -573,7 +571,6 @@ fn build_agent_session_choice(
     let dialogue_titles = units
         .iter()
         .rev()
-        .take(PICK_LIMIT)
         .map(|unit| build_text_preview(&unit.plain))
         .collect();
 
@@ -1219,7 +1216,7 @@ fn render_prompt_override(prompt: &str, command: &str) -> String {
 
 fn pick_selection(blocks: &[IndexedCommandBlock]) -> Result<CommandSelection> {
     let total = blocks.len();
-    let shown = total.min(PICK_LIMIT);
+    let shown = total.min(COMMAND_PICK_LIMIT);
     let entries: Vec<PickEntry> = blocks
         .iter()
         .rev()
@@ -1530,7 +1527,6 @@ fn build_agent_session_pick_entries(
 ) -> Result<Vec<PickEntry>> {
     sessions
         .iter()
-        .take(PICK_LIMIT)
         .enumerate()
         .map(|(idx, session)| build_agent_session_pick_entry(source, idx, session))
         .collect()
@@ -1912,7 +1908,6 @@ fn build_text_pick_entries(units: &[TextPair]) -> Vec<PickEntry> {
     units
         .iter()
         .rev()
-        .take(PICK_LIMIT)
         .enumerate()
         .map(|(offset, unit)| PickEntry {
             recent: offset + 1,
@@ -2644,6 +2639,47 @@ mod tests {
         assert_eq!(choices.len(), 2);
         assert_eq!(choices[0].title, "[Codex] new task  [new]");
         assert_eq!(choices[1].title, "[Codex] old task  [old]");
+    }
+
+    #[test]
+    fn current_agent_picker_does_not_truncate_large_session_lists() {
+        let cwd = PathBuf::from("d:\\repo");
+        let infos = (0..60)
+            .map(|idx| AgentSessionInfo {
+                path: PathBuf::from(format!("session-{idx}.jsonl")),
+                id: Some(format!("s{idx}")),
+                cwd: Some(cwd.display().to_string()),
+                modified: SystemTime::UNIX_EPOCH + Duration::from_secs((idx + 1) as u64),
+            })
+            .collect();
+        let source = FakeAgentSource {
+            require_cwd: true,
+            infos,
+        };
+        let sources: Vec<Box<dyn AgentSessionProvider>> = vec![Box::new(source)];
+
+        let choices =
+            build_current_agent_session_choices(&sources, &cwd, AgentSelection::LastTurn).unwrap();
+
+        assert_eq!(choices.len(), 60);
+        assert_eq!(choices[0].title, "[Codex] session-59 task  [session-]");
+        assert_eq!(choices[59].title, "[Codex] session-0 task  [session-]");
+    }
+
+    #[test]
+    fn agent_text_picker_entries_include_all_units() {
+        let units = (0..75)
+            .map(|idx| TextPair {
+                plain: format!("unit {idx}"),
+                ansi: String::new(),
+            })
+            .collect::<Vec<_>>();
+
+        let entries = super::build_text_pick_entries(&units);
+
+        assert_eq!(entries.len(), 75);
+        assert_eq!(entries[0].preview, "unit 74");
+        assert_eq!(entries[74].preview, "unit 0");
     }
 
     #[test]

--- a/src/commands/flush.rs
+++ b/src/commands/flush.rs
@@ -1,11 +1,8 @@
 use anyhow::Result;
-
-#[cfg(windows)]
 use std::env;
+use std::fs;
 
-#[cfg(windows)]
 use sivtr_core::capture::scrollback;
-#[cfg(windows)]
 use sivtr_core::session::{self, SessionEntry, SessionState};
 
 /// Flush: read console buffer, append new content to session.log.
@@ -27,10 +24,6 @@ fn do_flush() -> Result<()> {
         }
 
         let current_lines: Vec<&str> = snapshot.content.lines().collect();
-
-        let state_path = scrollback::flush_state_path();
-        let mut state = load_state_lossy(&state_path);
-
         let prompt = env::var("SIVTR_LAST_PROMPT").unwrap_or_default();
         let command = env::var("SIVTR_LAST_COMMAND").unwrap_or_default();
         let command_id = env::var("SIVTR_LAST_COMMAND_ID").ok();
@@ -40,31 +33,52 @@ fn do_flush() -> Result<()> {
             &current_lines,
             snapshot.width,
         );
-
-        if should_append_entry(&state, command_id.as_deref(), &command) {
-            let entry = SessionEntry::new(prompt, command.clone(), output);
-            session::append_entry(&scrollback::session_log_path(), &entry)?;
-            state.last_command_id = command_id;
-            state.last_command = Some(command);
-        }
-
-        session::save_state(&state_path, &state)?;
+        append_entry_from_output(
+            &scrollback::session_log_path(),
+            &scrollback::flush_state_path(),
+            prompt,
+            command,
+            command_id,
+            output,
+        )?;
     }
 
     #[cfg(not(windows))]
     {
-        // Non-Windows: no-op for now (tmux/zellij have native capture)
+        let capture_path = scrollback::capture_file_path();
+        if !capture_path.exists() {
+            return Ok(());
+        }
+
+        let output = String::from_utf8_lossy(&fs::read(&capture_path)?).into_owned();
+        let _ = fs::remove_file(&capture_path);
+
+        if output.trim().is_empty() {
+            return Ok(());
+        }
+
+        let prompt = env::var("SIVTR_LAST_PROMPT").unwrap_or_default();
+        let command = env::var("SIVTR_LAST_COMMAND").unwrap_or_default();
+        let command_id = env::var("SIVTR_LAST_COMMAND_ID").ok();
+        let output = trim_trailing_prompt_artifact(output, &prompt);
+
+        append_entry_from_output(
+            &scrollback::session_log_path(),
+            &scrollback::flush_state_path(),
+            prompt,
+            command,
+            command_id,
+            output,
+        )?;
     }
 
     Ok(())
 }
 
-#[cfg(windows)]
 fn load_state_lossy(path: &std::path::Path) -> SessionState {
     session::load_state(path).unwrap_or_default()
 }
 
-#[cfg(windows)]
 fn should_append_entry(state: &SessionState, command_id: Option<&str>, command: &str) -> bool {
     if command.trim().is_empty() {
         return false;
@@ -78,4 +92,154 @@ fn should_append_entry(state: &SessionState, command_id: Option<&str>, command: 
     }
 
     state.last_command.as_deref() != Some(command)
+}
+
+fn append_entry_from_output(
+    session_log_path: &std::path::Path,
+    state_path: &std::path::Path,
+    prompt: String,
+    command: String,
+    command_id: Option<String>,
+    output: String,
+) -> Result<()> {
+    let mut state = load_state_lossy(state_path);
+
+    if should_append_entry(&state, command_id.as_deref(), &command) {
+        let entry = SessionEntry::new(prompt, command.clone(), output);
+        session::append_entry(session_log_path, &entry)?;
+        state.last_command_id = command_id;
+        state.last_command = Some(command);
+    }
+
+    session::save_state(state_path, &state)
+}
+
+fn trim_trailing_prompt_artifact(output: String, prompt: &str) -> String {
+    let prompt_last_line = SessionEntry::new(prompt, "", "")
+        .prompt
+        .lines()
+        .last()
+        .unwrap_or_default()
+        .trim_end()
+        .to_string();
+    if prompt_last_line.is_empty() {
+        return output;
+    }
+
+    let mut raw_lines: Vec<&str> = output.lines().collect();
+    let Some(last_raw_line) = raw_lines.last().copied() else {
+        return output;
+    };
+
+    if !last_raw_line.contains('\x1b') && !last_raw_line.contains('\r') {
+        return output;
+    }
+
+    let last_plain_line = SessionEntry::new("", "", last_raw_line)
+        .output
+        .trim()
+        .to_string();
+    if last_plain_line.is_empty() || prompt_last_line.ends_with(&last_plain_line) {
+        raw_lines.pop();
+        return raw_lines.join("\n");
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{append_entry_from_output, should_append_entry, trim_trailing_prompt_artifact};
+    use sivtr_core::session::{self, SessionState};
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_test_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("sivtr-{name}-{}-{nanos}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn appends_structured_entry_for_capture_output() {
+        let dir = unique_test_dir("flush");
+        let log_path = dir.join("session_1.log");
+        let state_path = dir.join("session_1.state");
+
+        append_entry_from_output(
+            &log_path,
+            &state_path,
+            "repo on main\n❯  ".to_string(),
+            "cargo test".to_string(),
+            Some("42".to_string()),
+            "\u{1b}[32mok\u{1b}[0m\n".to_string(),
+        )
+        .unwrap();
+
+        let entries = session::load_entries(&log_path).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].command, "cargo test");
+        assert_eq!(entries[0].prompt, "repo on main\n❯  ");
+        assert_eq!(entries[0].output, "ok");
+        assert_eq!(
+            entries[0].output_ansi.as_deref(),
+            Some("\u{1b}[32mok\u{1b}[0m")
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn skips_duplicate_command_id_when_state_matches() {
+        let dir = unique_test_dir("flush-state");
+        let log_path = dir.join("session_1.log");
+        let state_path = dir.join("session_1.state");
+
+        append_entry_from_output(
+            &log_path,
+            &state_path,
+            "repo> ".to_string(),
+            "cargo test".to_string(),
+            Some("99".to_string()),
+            "ok".to_string(),
+        )
+        .unwrap();
+        append_entry_from_output(
+            &log_path,
+            &state_path,
+            "repo> ".to_string(),
+            "cargo test".to_string(),
+            Some("99".to_string()),
+            "still ok".to_string(),
+        )
+        .unwrap();
+
+        let entries = session::load_entries(&log_path).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].output, "ok");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn rejects_empty_commands_even_without_command_id() {
+        let state = SessionState::default();
+        assert!(!should_append_entry(&state, None, ""));
+        assert!(!should_append_entry(&state, Some("7"), "   "));
+    }
+
+    #[test]
+    fn trims_trailing_prompt_artifact_from_zsh_capture() {
+        let prompt = "jacob-NucBox-EVO-X2# ";
+        let output = "hello from zsh\n\u{1b}[1m\u{1b}[7m#\u{1b}[27m\u{1b}[1m\u{1b}[0m \r \r";
+
+        assert_eq!(
+            trim_trailing_prompt_artifact(output.to_string(), prompt),
+            "hello from zsh"
+        );
+    }
 }

--- a/src/commands/hotkey.rs
+++ b/src/commands/hotkey.rs
@@ -59,7 +59,7 @@ pub fn pick_agent(args: &HotkeyPickAgentArgs) -> Result<()> {
         let providers = args.provider.providers();
         copy::execute_agent_picker(AgentPickerRequest {
             providers: &providers,
-            pick_current_session: true,
+            pick_current_session: args.current_session,
             selection_mode: AgentSelection::LastTurn,
             print_full: false,
             regex: None,
@@ -475,6 +475,7 @@ fn spawn_picker_terminal(cwd: &str, provider: HotkeyProviderSelection) -> Result
         .arg("hotkey-pick-agent")
         .arg("--cwd")
         .arg(&cwd)
+        .arg("--current-session")
         .arg("--provider")
         .arg(provider.as_str())
         .creation_flags(CREATE_NEW_CONSOLE)

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -3,6 +3,7 @@ use sivtr_core::buffer::Buffer;
 use sivtr_core::capture::scrollback;
 use sivtr_core::config::{OpenMode, SivtrConfig};
 use sivtr_core::export::editor;
+use sivtr_core::history::store::CaptureSource;
 use sivtr_core::parse;
 
 use super::browse;
@@ -19,6 +20,7 @@ pub fn execute() -> Result<()> {
             }
 
             let config = SivtrConfig::load().unwrap_or_default();
+            browse::record_history(&config, &raw, Some("sivtr import"), CaptureSource::Import);
 
             match config.general.open_mode {
                 OpenMode::Editor => {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -188,7 +188,7 @@ const TMUX_MARKER_START: &str = "# >>> sivtr tmux shortcut >>>";
 const TMUX_MARKER_END: &str = "# <<< sivtr tmux shortcut <<<";
 #[cfg(unix)]
 const TMUX_HOOK: &str = r##"# >>> sivtr tmux shortcut >>>
-bind-key y new-window -c "#{pane_current_path}" "sivtr copy codex all --pick"
+bind-key y new-window -c "#{pane_current_path}" "sivtr copy codex --pick"
 # <<< sivtr tmux shortcut <<<
 "##;
 
@@ -632,7 +632,7 @@ fn render_linux_shortcut_script(cwd: &Path, terminal: Option<&str>) -> String {
 
 #[cfg(unix)]
 fn build_terminal_launch_command(terminal: &str) -> String {
-    let picker = "cd \"$PROJECT_CWD\"; exec sivtr copy codex all --pick";
+    let picker = "cd \"$PROJECT_CWD\"; exec sivtr copy codex --pick";
     match terminal {
         "gnome-terminal" => format!("exec gnome-terminal -- bash -lc '{picker}'"),
         "konsole" => format!("exec konsole --noclose -e bash -lc '{picker}'"),
@@ -662,7 +662,7 @@ fn write_macos_shortcut_script(path: &Path, cwd: &Path) -> Result<()> {
 fn render_macos_shortcut_script(cwd: &Path) -> String {
     let cwd = shell_single_quote(&cwd.to_string_lossy());
     format!(
-        "#!/usr/bin/env bash\nset -euo pipefail\nexport PROJECT_CWD='{cwd}'\ncd \"$PROJECT_CWD\"\nexec sivtr copy codex all --pick\n"
+        "#!/usr/bin/env bash\nset -euo pipefail\nexport PROJECT_CWD='{cwd}'\ncd \"$PROJECT_CWD\"\nexec sivtr copy codex --pick\n"
     )
 }
 
@@ -748,9 +748,9 @@ mod tests {
     };
     use super::{
         desktop_exec_quote, render_macos_shortcut_plist, render_macos_shortcut_script,
-        update_existing_hook, xml_escape, BASH_HOOK, BASH_SPEC,
-        LEGACY_POWERSHELL_HOOK, MACOS_SHORTCUT_LABEL, NUSHELL_HOOK, NUSHELL_SPEC, POWERSHELL_HOOK,
-        POWERSHELL_SPEC, ZSH_HOOK, ZSH_SPEC,
+        update_existing_hook, xml_escape, BASH_HOOK, BASH_SPEC, LEGACY_POWERSHELL_HOOK,
+        MACOS_SHORTCUT_LABEL, NUSHELL_HOOK, NUSHELL_SPEC, POWERSHELL_HOOK, POWERSHELL_SPEC,
+        ZSH_HOOK, ZSH_SPEC,
     };
     use std::path::Path;
 
@@ -842,7 +842,7 @@ mod tests {
         let command = build_terminal_launch_command("gnome-terminal");
 
         assert!(command.contains("gnome-terminal"));
-        assert!(command.contains("cd \"$PROJECT_CWD\"; exec sivtr copy codex all --pick"));
+        assert!(command.contains("cd \"$PROJECT_CWD\"; exec sivtr copy codex --pick"));
     }
 
     #[cfg(unix)]
@@ -857,7 +857,7 @@ mod tests {
         let script = render_linux_shortcut_script(Path::new("/tmp/project"), Some("xterm"));
 
         assert!(script.contains("export PROJECT_CWD='/tmp/project'"));
-        assert!(script.contains("cd \"$PROJECT_CWD\"; exec sivtr copy codex all --pick"));
+        assert!(script.contains("cd \"$PROJECT_CWD\"; exec sivtr copy codex --pick"));
     }
 
     #[test]
@@ -881,7 +881,7 @@ mod tests {
         let script = render_macos_shortcut_script(Path::new("/tmp/project"));
 
         assert!(script.contains("export PROJECT_CWD='/tmp/project'"));
-        assert!(script.contains("exec sivtr copy codex all --pick"));
+        assert!(script.contains("exec sivtr copy codex --pick"));
     }
 
     #[test]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -340,9 +340,7 @@ fn install_tmux_shortcut() -> Result<()> {
 
 #[cfg(not(unix))]
 fn install_tmux_shortcut() -> Result<()> {
-    Err(anyhow::anyhow!(
-        "`sivtr init tmux` is only supported on Unix-like systems"
-    ))
+    anyhow::bail!("`sivtr init tmux` is only supported on Unix-like systems");
 }
 
 #[cfg(unix)]
@@ -377,9 +375,7 @@ fn install_linux_shortcut() -> Result<()> {
 
 #[cfg(not(unix))]
 fn install_linux_shortcut() -> Result<()> {
-    Err(anyhow::anyhow!(
-        "`sivtr init linux-shortcut` is only supported on Unix-like systems"
-    ))
+    anyhow::bail!("`sivtr init linux-shortcut` is only supported on Unix-like systems");
 }
 
 #[cfg(unix)]
@@ -419,9 +415,7 @@ fn install_macos_shortcut() -> Result<()> {
 
 #[cfg(not(unix))]
 fn install_macos_shortcut() -> Result<()> {
-    Err(anyhow::anyhow!(
-        "`sivtr init macos-shortcut` is only supported on macOS"
-    ))
+    anyhow::bail!("`sivtr init macos-shortcut` is only supported on macOS");
 }
 
 fn print_install_summary(installed: &[String], updated: &[String]) {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -4,6 +4,9 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 #[cfg(windows)]
 use crate::cli::{HotkeyAction, HotkeyCommand, HotkeyStartArgs};
 #[cfg(windows)]
@@ -61,7 +64,29 @@ if [[ -n "${APPDATA:-}" ]]; then
 else
   export SIVTR_SESSION_LOG="${XDG_STATE_HOME:-$HOME/.local/state}/sivtr/session_$$.log"
 fi
+export SIVTR_CAPTURE_FILE="${SIVTR_SESSION_LOG%.log}.capture"
+mkdir -p "${SIVTR_SESSION_LOG%/*}"
+__sivtr_capture_active=0
+__sivtr_prompt_phase=0
+__sivtr_restore_capture() {
+  if [[ "${__sivtr_capture_active:-0}" -eq 1 ]]; then
+    exec 1>&19 2>&20
+    exec 19>&- 20>&-
+    __sivtr_capture_active=0
+  fi
+}
+__sivtr_preexec() {
+  [[ "${__sivtr_prompt_phase:-0}" -eq 1 ]] && return
+  [[ "${__sivtr_capture_active:-0}" -eq 1 ]] && return
+  : >| "$SIVTR_CAPTURE_FILE"
+  exec 19>&1 20>&2
+  exec > >(tee "$SIVTR_CAPTURE_FILE" >&19) 2>&1
+  __sivtr_capture_active=1
+}
 __sivtr_precmd() {
+  local exit_status=$?
+  __sivtr_prompt_phase=1
+  __sivtr_restore_capture
   local hist_entry
   hist_entry="$(HISTTIMEFORMAT= history 1)"
   if [[ $hist_entry =~ ^[[:space:]]*([0-9]+)[[:space:]]+(.*)$ ]]; then
@@ -70,7 +95,10 @@ __sivtr_precmd() {
   fi
   export SIVTR_LAST_PROMPT="${PS1@P}"
   sivtr flush >/dev/null 2>&1 || true
+  __sivtr_prompt_phase=0
+  return $exit_status
 }
+trap '__sivtr_preexec' DEBUG
 if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
   if [[ " ${PROMPT_COMMAND[*]} " != *" __sivtr_precmd "* ]]; then
     PROMPT_COMMAND=(__sivtr_precmd "${PROMPT_COMMAND[@]}")
@@ -94,13 +122,41 @@ if [[ -n "${APPDATA:-}" ]]; then
 else
   export SIVTR_SESSION_LOG="${XDG_STATE_HOME:-$HOME/.local/state}/sivtr/session_$$.log"
 fi
+export SIVTR_CAPTURE_FILE="${SIVTR_SESSION_LOG%.log}.capture"
+mkdir -p "${SIVTR_SESSION_LOG%/*}"
+typeset -ga preexec_functions precmd_functions
+typeset -g __sivtr_capture_active=0
+typeset -gi __sivtr_stdout_fd=-1 __sivtr_stderr_fd=-1
+_sivtr_restore_capture() {
+  if (( __sivtr_capture_active )); then
+    exec 1>&$__sivtr_stdout_fd
+    exec 2>&$__sivtr_stderr_fd
+    exec {__sivtr_stdout_fd}>&-
+    exec {__sivtr_stderr_fd}>&-
+    __sivtr_capture_active=0
+  fi
+}
+_sivtr_preexec() {
+  (( __sivtr_capture_active )) && return
+  : >| "$SIVTR_CAPTURE_FILE"
+  exec {__sivtr_stdout_fd}>&1
+  exec {__sivtr_stderr_fd}>&2
+  exec > >(tee "$SIVTR_CAPTURE_FILE" >&$__sivtr_stdout_fd) 2>&1
+  __sivtr_capture_active=1
+}
 _sivtr_precmd() {
+  local exit_status=$?
+  _sivtr_restore_capture
   export SIVTR_LAST_COMMAND="$(fc -ln -1)"
   export SIVTR_LAST_COMMAND_ID="$HISTCMD"
   export SIVTR_LAST_PROMPT="$(print -P "$PROMPT")"
   sivtr flush >/dev/null 2>&1 || true
+  return $exit_status
 }
-if (( ${precmd_functions[(I)_sivtr_precmd]} == 0 )); then
+if [[ " ${preexec_functions[*]:-} " != *" _sivtr_preexec "* ]]; then
+  preexec_functions=(_sivtr_preexec $preexec_functions)
+fi
+if [[ " ${precmd_functions[*]:-} " != *" _sivtr_precmd "* ]]; then
   precmd_functions=(_sivtr_precmd $precmd_functions)
 fi
 # <<< sivtr shell integration <<<
@@ -125,6 +181,16 @@ if (($env.SIVTR_PROMPT_WRAPPED? | default false) != true) {
 }
 # <<< sivtr shell integration <<<
 "#;
+
+#[cfg_attr(not(unix), allow(dead_code))]
+const TMUX_MARKER_START: &str = "# >>> sivtr tmux shortcut >>>";
+#[cfg_attr(not(unix), allow(dead_code))]
+const TMUX_MARKER_END: &str = "# <<< sivtr tmux shortcut <<<";
+#[cfg_attr(not(unix), allow(dead_code))]
+const TMUX_HOOK: &str = r##"# >>> sivtr tmux shortcut >>>
+bind-key y new-window -c "#{pane_current_path}" "sivtr hotkey-pick-codex --cwd '#{pane_current_path}'"
+# <<< sivtr tmux shortcut <<<
+"##;
 
 const POWERSHELL_SPEC: HookSpec = HookSpec {
     hook: POWERSHELL_HOOK,
@@ -162,6 +228,19 @@ const NUSHELL_SPEC: HookSpec = HookSpec {
     legacy_hook: None,
 };
 
+#[cfg_attr(not(unix), allow(dead_code))]
+const TMUX_SPEC: HookSpec = HookSpec {
+    hook: TMUX_HOOK,
+    marker_start: TMUX_MARKER_START,
+    marker_end: TMUX_MARKER_END,
+    legacy_marker_start: TMUX_MARKER_START,
+    legacy_marker_end: TMUX_MARKER_END,
+    legacy_hook: None,
+};
+
+#[cfg_attr(not(unix), allow(dead_code))]
+const MACOS_SHORTCUT_LABEL: &str = "dev.sivtr.pick-codex";
+
 enum InstallStatus {
     Installed,
     Updated,
@@ -175,9 +254,16 @@ pub fn execute(shell: &str) -> Result<()> {
         "bash" => install_single_shell_hook(&bash_profile_path()?, &BASH_SPEC),
         "zsh" => install_single_shell_hook(&zsh_profile_path()?, &ZSH_SPEC),
         "nu" | "nushell" => install_single_shell_hook(&nushell_config_path()?, &NUSHELL_SPEC),
+        "tmux" => install_tmux_shortcut(),
+        "linux-shortcut" => install_linux_shortcut(),
+        "macos-shortcut" => install_macos_shortcut(),
         _ => {
-            eprintln!("sivtr: supported shells are powershell, bash, zsh, nushell");
-            eprintln!("  usage: sivtr init <powershell|bash|zsh|nushell>");
+            eprintln!(
+                "sivtr: supported targets are powershell, bash, zsh, nushell, tmux, linux-shortcut, macos-shortcut"
+            );
+            eprintln!(
+                "  usage: sivtr init <powershell|bash|zsh|nushell|tmux|linux-shortcut|macos-shortcut>"
+            );
             std::process::exit(1);
         }
     }?;
@@ -227,6 +313,117 @@ fn install_single_shell_hook(profile_path: &Path, spec: &HookSpec) -> Result<()>
     Ok(())
 }
 
+#[cfg(unix)]
+fn install_tmux_shortcut() -> Result<()> {
+    let path = tmux_config_path()?;
+    match install_into_profile(&path, &TMUX_SPEC)? {
+        InstallStatus::Installed => {
+            eprintln!("sivtr: installed tmux shortcut into {}", path.display());
+            eprintln!("  shortcut: prefix + y");
+            eprintln!("  reload with: tmux source-file {}", path.display());
+        }
+        InstallStatus::Updated => {
+            eprintln!("sivtr: updated tmux shortcut in {}", path.display());
+            eprintln!("  shortcut: prefix + y");
+            eprintln!("  reload with: tmux source-file {}", path.display());
+        }
+        InstallStatus::Unchanged => {
+            eprintln!(
+                "sivtr: tmux shortcut already installed in {}",
+                path.display()
+            );
+            eprintln!("  shortcut: prefix + y");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn install_tmux_shortcut() -> Result<()> {
+    Err(anyhow::anyhow!(
+        "`sivtr init tmux` is only supported on Unix-like systems"
+    ))
+}
+
+#[cfg(unix)]
+fn install_linux_shortcut() -> Result<()> {
+    let home = dirs::home_dir().context("Failed to resolve home directory")?;
+    let bin_dir = home.join(".local").join("bin");
+    let applications_dir = home.join(".local").join("share").join("applications");
+    fs::create_dir_all(&bin_dir)?;
+    fs::create_dir_all(&applications_dir)?;
+
+    let cwd = std::env::current_dir().context("Failed to resolve current directory")?;
+    let terminal = detect_linux_terminal();
+    let script_path = bin_dir.join("sivtr-pick-codex");
+    let desktop_path = applications_dir.join("sivtr-pick-codex.desktop");
+
+    write_linux_shortcut_script(&script_path, &cwd, terminal.as_deref())?;
+    write_linux_shortcut_desktop_entry(&desktop_path, &script_path)?;
+
+    eprintln!("sivtr: installed Linux shortcut launcher");
+    eprintln!("  script:  {}", script_path.display());
+    eprintln!("  desktop: {}", desktop_path.display());
+    if let Some(terminal) = terminal {
+        eprintln!("  terminal: {terminal}");
+    } else {
+        eprintln!(
+            "  terminal: not auto-detected; edit the script before binding a desktop shortcut"
+        );
+    }
+    eprintln!("  bind your desktop shortcut to: {}", script_path.display());
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn install_linux_shortcut() -> Result<()> {
+    Err(anyhow::anyhow!(
+        "`sivtr init linux-shortcut` is only supported on Unix-like systems"
+    ))
+}
+
+#[cfg(unix)]
+fn install_macos_shortcut() -> Result<()> {
+    if !cfg!(target_os = "macos") {
+        return Err(anyhow::anyhow!(
+            "`sivtr init macos-shortcut` must be run on macOS"
+        ));
+    }
+
+    let home = dirs::home_dir().context("Failed to resolve home directory")?;
+    let bin_dir = home.join(".local").join("bin");
+    let launch_agents_dir = home.join("Library").join("LaunchAgents");
+    fs::create_dir_all(&bin_dir)?;
+    fs::create_dir_all(&launch_agents_dir)?;
+
+    let cwd = std::env::current_dir().context("Failed to resolve current directory")?;
+    let script_path = bin_dir.join("sivtr-pick-codex");
+    let plist_path = launch_agents_dir.join(format!("{MACOS_SHORTCUT_LABEL}.plist"));
+
+    write_macos_shortcut_script(&script_path, &cwd)?;
+    write_macos_shortcut_plist(&plist_path, &script_path)?;
+
+    eprintln!("sivtr: installed macOS shortcut launcher");
+    eprintln!("  script: {}", script_path.display());
+    eprintln!("  agent:  {}", plist_path.display());
+    eprintln!(
+        "  load with: launchctl bootstrap gui/$(id -u) {}",
+        plist_path.display()
+    );
+    eprintln!(
+        "  run manually: osascript -e 'tell application \"Terminal\" to do script \"{}\"'",
+        shell_double_quote(&script_path.to_string_lossy())
+    );
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn install_macos_shortcut() -> Result<()> {
+    Err(anyhow::anyhow!(
+        "`sivtr init macos-shortcut` is only supported on macOS"
+    ))
+}
+
 fn print_install_summary(installed: &[String], updated: &[String]) {
     if installed.is_empty() && updated.is_empty() {
         eprintln!("sivtr: no new installation needed (already set up)");
@@ -246,19 +443,16 @@ fn maybe_start_hotkey() -> Result<()> {
     #[cfg(windows)]
     {
         if !atty::is(atty::Stream::Stdin) {
-            eprintln!("sivtr: start the AI session hotkey later with `sivtr hotkey start`");
+            eprintln!("sivtr: start the Codex hotkey later with `sivtr hotkey start`");
             return Ok(());
         }
 
         if prompt_start_hotkey()? {
             crate::commands::hotkey::execute(HotkeyCommand {
-                action: Some(HotkeyAction::Start(HotkeyStartArgs {
-                    chord: None,
-                    provider: Default::default(),
-                })),
+                action: Some(HotkeyAction::Start(HotkeyStartArgs { chord: None })),
             })?;
         } else {
-            eprintln!("sivtr: start the AI session hotkey later with `sivtr hotkey start`");
+            eprintln!("sivtr: start the Codex hotkey later with `sivtr hotkey start`");
         }
     }
 
@@ -267,7 +461,7 @@ fn maybe_start_hotkey() -> Result<()> {
 
 #[cfg(windows)]
 fn prompt_start_hotkey() -> Result<bool> {
-    eprint!("sivtr: start the Windows AI session hotkey now? [Y/n] ");
+    eprint!("sivtr: start the Windows Codex hotkey now? [Y/n] ");
     io::stderr().flush()?;
 
     let mut input = String::new();
@@ -321,6 +515,12 @@ fn nushell_config_path() -> Result<PathBuf> {
 
     let config_dir = dirs::config_dir().context("Failed to resolve config directory")?;
     Ok(config_dir.join("nushell").join("config.nu"))
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+fn tmux_config_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("Failed to resolve home directory")?;
+    Ok(home.join(".tmux.conf"))
 }
 
 fn get_ps_profile(cmd: &str) -> Result<String> {
@@ -379,6 +579,161 @@ fn update_existing_hook(content: &str, spec: &HookSpec) -> Option<String> {
     None
 }
 
+#[cfg_attr(not(unix), allow(dead_code))]
+fn detect_linux_terminal() -> Option<String> {
+    for candidate in [
+        "x-terminal-emulator",
+        "gnome-terminal",
+        "konsole",
+        "kitty",
+        "alacritty",
+        "foot",
+        "wezterm",
+        "xterm",
+    ] {
+        if command_exists(candidate) {
+            return Some(candidate.to_string());
+        }
+    }
+    None
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+fn command_exists(name: &str) -> bool {
+    std::env::var_os("PATH")
+        .map(|paths| {
+            std::env::split_paths(&paths).any(|dir| {
+                let candidate = dir.join(name);
+                candidate.is_file()
+            })
+        })
+        .unwrap_or(false)
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+fn write_linux_shortcut_script(path: &Path, cwd: &Path, terminal: Option<&str>) -> Result<()> {
+    let script = render_linux_shortcut_script(cwd, terminal);
+    fs::write(path, script)?;
+    #[cfg(unix)]
+    {
+        let mut perms = fs::metadata(path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms)?;
+    }
+    Ok(())
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+fn render_linux_shortcut_script(cwd: &Path, terminal: Option<&str>) -> String {
+    let cwd = shell_single_quote(&cwd.to_string_lossy());
+    let launcher = terminal
+        .map(build_terminal_launch_command)
+        .unwrap_or_else(|| {
+            "printf 'Edit this launcher to choose a terminal, then run again.\\n'; read -r _"
+                .to_string()
+        });
+
+    format!("#!/usr/bin/env bash\nset -euo pipefail\nexport PROJECT_CWD='{cwd}'\n{launcher}\n")
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+fn build_terminal_launch_command(terminal: &str) -> String {
+    let picker = "sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\"";
+    match terminal {
+        "gnome-terminal" => format!("exec gnome-terminal -- bash -lc '{picker}'"),
+        "konsole" => format!("exec konsole --noclose -e bash -lc '{picker}'"),
+        "kitty" => format!("exec kitty bash -lc '{picker}'"),
+        "alacritty" => format!("exec alacritty -e bash -lc '{picker}'"),
+        "foot" => format!("exec foot bash -lc '{picker}'"),
+        "wezterm" => format!("exec wezterm start --cwd \"$PROJECT_CWD\" -- bash -lc '{picker}'"),
+        "xterm" => format!("exec xterm -e bash -lc '{picker}'"),
+        _ => format!("exec {terminal} -e bash -lc '{picker}'"),
+    }
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+fn write_macos_shortcut_script(path: &Path, cwd: &Path) -> Result<()> {
+    let script = render_macos_shortcut_script(cwd);
+    fs::write(path, script)?;
+    #[cfg(unix)]
+    {
+        let mut perms = fs::metadata(path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms)?;
+    }
+    Ok(())
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+fn render_macos_shortcut_script(cwd: &Path) -> String {
+    let cwd = shell_single_quote(&cwd.to_string_lossy());
+    format!(
+        "#!/usr/bin/env bash\nset -euo pipefail\nexport PROJECT_CWD='{cwd}'\ncd \"$PROJECT_CWD\"\nexec sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\"\n"
+    )
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+fn write_macos_shortcut_plist(path: &Path, script_path: &Path) -> Result<()> {
+    let plist = render_macos_shortcut_plist(script_path);
+    fs::write(path, plist)?;
+    Ok(())
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+fn render_macos_shortcut_plist(script_path: &Path) -> String {
+    let script = xml_escape(&script_path.to_string_lossy());
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>{MACOS_SHORTCUT_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/osascript</string>
+    <string>-e</string>
+    <string>tell application "Terminal" to do script "{script}"</string>
+  </array>
+</dict>
+</plist>
+"#
+    )
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+fn write_linux_shortcut_desktop_entry(path: &Path, script_path: &Path) -> Result<()> {
+    let desktop = format!(
+        "[Desktop Entry]\nType=Application\nName=Sivtr Pick Codex\nExec={}\nTerminal=false\nCategories=Development;\n",
+        desktop_exec_quote(&script_path.to_string_lossy())
+    );
+    fs::write(path, desktop)?;
+    Ok(())
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+fn shell_single_quote(value: &str) -> String {
+    value.replace('\'', "'\"'\"'")
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+fn desktop_exec_quote(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+fn shell_double_quote(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+fn xml_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
 fn find_marked_block(
     content: &str,
     start_marker: &str,
@@ -393,9 +748,13 @@ fn find_marked_block(
 #[cfg(test)]
 mod tests {
     use super::{
-        update_existing_hook, BASH_HOOK, BASH_SPEC, LEGACY_POWERSHELL_HOOK, NUSHELL_HOOK,
-        NUSHELL_SPEC, POWERSHELL_HOOK, POWERSHELL_SPEC, ZSH_HOOK, ZSH_SPEC,
+        build_terminal_launch_command, command_exists, desktop_exec_quote,
+        render_linux_shortcut_script, render_macos_shortcut_plist, render_macos_shortcut_script,
+        shell_single_quote, update_existing_hook, xml_escape, BASH_HOOK, BASH_SPEC,
+        LEGACY_POWERSHELL_HOOK, MACOS_SHORTCUT_LABEL, NUSHELL_HOOK, NUSHELL_SPEC, POWERSHELL_HOOK,
+        POWERSHELL_SPEC, TMUX_HOOK, TMUX_SPEC, ZSH_HOOK, ZSH_SPEC,
     };
+    use std::path::Path;
 
     #[cfg(windows)]
     use super::parse_yes_no_default_yes;
@@ -437,6 +796,13 @@ mod tests {
     }
 
     #[test]
+    fn bash_hook_sets_up_capture_file_and_debug_trap() {
+        assert!(BASH_HOOK.contains("export SIVTR_CAPTURE_FILE="));
+        assert!(BASH_HOOK.contains("trap '__sivtr_preexec' DEBUG"));
+        assert!(BASH_HOOK.contains("tee \"$SIVTR_CAPTURE_FILE\""));
+    }
+
+    #[test]
     fn replaces_existing_zsh_block() {
         let profile = format!("before\n{ZSH_HOOK}\nafter\n");
         let updated =
@@ -446,12 +812,94 @@ mod tests {
     }
 
     #[test]
+    fn zsh_hook_sets_up_preexec_capture() {
+        assert!(ZSH_HOOK.contains("export SIVTR_CAPTURE_FILE="));
+        assert!(ZSH_HOOK.contains("preexec_functions=(_sivtr_preexec"));
+        assert!(ZSH_HOOK.contains("typeset -ga preexec_functions precmd_functions"));
+        assert!(ZSH_HOOK.contains("tee \"$SIVTR_CAPTURE_FILE\""));
+    }
+
+    #[test]
     fn replaces_existing_nushell_block() {
         let profile = format!("before\n{NUSHELL_HOOK}\nafter\n");
         let updated =
             update_existing_hook(&profile, &NUSHELL_SPEC).expect("nushell hook should be detected");
 
         assert_eq!(updated, profile);
+    }
+
+    #[test]
+    fn replaces_existing_tmux_block() {
+        let profile = format!("before\n{TMUX_HOOK}\nafter\n");
+        let updated =
+            update_existing_hook(&profile, &TMUX_SPEC).expect("tmux hook should be detected");
+
+        assert_eq!(updated, profile);
+    }
+
+    #[test]
+    fn gnome_terminal_launcher_uses_project_cwd() {
+        let command = build_terminal_launch_command("gnome-terminal");
+
+        assert!(command.contains("gnome-terminal"));
+        assert!(command.contains("sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\""));
+    }
+
+    #[test]
+    fn shell_single_quote_escapes_single_quotes() {
+        assert_eq!(shell_single_quote("/tmp/it's"), "/tmp/it'\"'\"'s");
+    }
+
+    #[test]
+    fn linux_shortcut_script_exports_project_cwd() {
+        let script = render_linux_shortcut_script(Path::new("/tmp/project"), Some("xterm"));
+
+        assert!(script.contains("export PROJECT_CWD='/tmp/project'"));
+        assert!(script.contains("sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\""));
+    }
+
+    #[test]
+    fn desktop_exec_quote_wraps_paths_with_spaces() {
+        assert_eq!(
+            desktop_exec_quote("/tmp/sivtr desktop/sivtr-pick-codex"),
+            "\"/tmp/sivtr desktop/sivtr-pick-codex\""
+        );
+    }
+
+    #[test]
+    fn desktop_exec_quote_escapes_embedded_quotes_and_backslashes() {
+        assert_eq!(
+            desktop_exec_quote("/tmp/dir \\\"quoted\\\"/sivtr"),
+            "\"/tmp/dir \\\\\\\"quoted\\\\\\\"/sivtr\""
+        );
+    }
+
+    #[test]
+    fn macos_shortcut_script_runs_picker_in_project_cwd() {
+        let script = render_macos_shortcut_script(Path::new("/tmp/project"));
+
+        assert!(script.contains("export PROJECT_CWD='/tmp/project'"));
+        assert!(script.contains("exec sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\""));
+    }
+
+    #[test]
+    fn macos_shortcut_plist_uses_terminal_osascript_launcher() {
+        let plist = render_macos_shortcut_plist(Path::new("/tmp/sivtr-pick-codex"));
+
+        assert!(plist.contains(MACOS_SHORTCUT_LABEL));
+        assert!(plist.contains("/usr/bin/osascript"));
+        assert!(plist.contains("tell application \"Terminal\" to do script"));
+        assert!(plist.contains("/tmp/sivtr-pick-codex"));
+    }
+
+    #[test]
+    fn xml_escape_escapes_special_characters() {
+        assert_eq!(xml_escape("a&b<c>d"), "a&amp;b&lt;c&gt;d");
+    }
+
+    #[test]
+    fn command_exists_detects_programs_via_path_scan() {
+        assert!(command_exists("sh"));
     }
 
     #[cfg(windows)]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -188,7 +188,7 @@ const TMUX_MARKER_START: &str = "# >>> sivtr tmux shortcut >>>";
 const TMUX_MARKER_END: &str = "# <<< sivtr tmux shortcut <<<";
 #[cfg(unix)]
 const TMUX_HOOK: &str = r##"# >>> sivtr tmux shortcut >>>
-bind-key y new-window -c "#{pane_current_path}" "sivtr hotkey-pick-codex --cwd '#{pane_current_path}'"
+bind-key y new-window -c "#{pane_current_path}" "sivtr copy codex all --pick"
 # <<< sivtr tmux shortcut <<<
 "##;
 
@@ -632,7 +632,7 @@ fn render_linux_shortcut_script(cwd: &Path, terminal: Option<&str>) -> String {
 
 #[cfg(unix)]
 fn build_terminal_launch_command(terminal: &str) -> String {
-    let picker = "sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\"";
+    let picker = "cd \"$PROJECT_CWD\"; exec sivtr copy codex all --pick";
     match terminal {
         "gnome-terminal" => format!("exec gnome-terminal -- bash -lc '{picker}'"),
         "konsole" => format!("exec konsole --noclose -e bash -lc '{picker}'"),
@@ -662,7 +662,7 @@ fn write_macos_shortcut_script(path: &Path, cwd: &Path) -> Result<()> {
 fn render_macos_shortcut_script(cwd: &Path) -> String {
     let cwd = shell_single_quote(&cwd.to_string_lossy());
     format!(
-        "#!/usr/bin/env bash\nset -euo pipefail\nexport PROJECT_CWD='{cwd}'\ncd \"$PROJECT_CWD\"\nexec sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\"\n"
+        "#!/usr/bin/env bash\nset -euo pipefail\nexport PROJECT_CWD='{cwd}'\ncd \"$PROJECT_CWD\"\nexec sivtr copy codex all --pick\n"
     )
 }
 
@@ -842,7 +842,7 @@ mod tests {
         let command = build_terminal_launch_command("gnome-terminal");
 
         assert!(command.contains("gnome-terminal"));
-        assert!(command.contains("sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\""));
+        assert!(command.contains("cd \"$PROJECT_CWD\"; exec sivtr copy codex all --pick"));
     }
 
     #[cfg(unix)]
@@ -857,7 +857,7 @@ mod tests {
         let script = render_linux_shortcut_script(Path::new("/tmp/project"), Some("xterm"));
 
         assert!(script.contains("export PROJECT_CWD='/tmp/project'"));
-        assert!(script.contains("sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\""));
+        assert!(script.contains("cd \"$PROJECT_CWD\"; exec sivtr copy codex all --pick"));
     }
 
     #[test]
@@ -881,7 +881,7 @@ mod tests {
         let script = render_macos_shortcut_script(Path::new("/tmp/project"));
 
         assert!(script.contains("export PROJECT_CWD='/tmp/project'"));
-        assert!(script.contains("exec sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\""));
+        assert!(script.contains("exec sivtr copy codex all --pick"));
     }
 
     #[test]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -182,11 +182,11 @@ if (($env.SIVTR_PROMPT_WRAPPED? | default false) != true) {
 # <<< sivtr shell integration <<<
 "#;
 
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 const TMUX_MARKER_START: &str = "# >>> sivtr tmux shortcut >>>";
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 const TMUX_MARKER_END: &str = "# <<< sivtr tmux shortcut <<<";
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 const TMUX_HOOK: &str = r##"# >>> sivtr tmux shortcut >>>
 bind-key y new-window -c "#{pane_current_path}" "sivtr hotkey-pick-codex --cwd '#{pane_current_path}'"
 # <<< sivtr tmux shortcut <<<
@@ -228,7 +228,7 @@ const NUSHELL_SPEC: HookSpec = HookSpec {
     legacy_hook: None,
 };
 
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 const TMUX_SPEC: HookSpec = HookSpec {
     hook: TMUX_HOOK,
     marker_start: TMUX_MARKER_START,
@@ -511,7 +511,7 @@ fn nushell_config_path() -> Result<PathBuf> {
     Ok(config_dir.join("nushell").join("config.nu"))
 }
 
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 fn tmux_config_path() -> Result<PathBuf> {
     let home = dirs::home_dir().context("Failed to resolve home directory")?;
     Ok(home.join(".tmux.conf"))
@@ -573,7 +573,7 @@ fn update_existing_hook(content: &str, spec: &HookSpec) -> Option<String> {
     None
 }
 
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 fn detect_linux_terminal() -> Option<String> {
     for candidate in [
         "x-terminal-emulator",
@@ -592,7 +592,7 @@ fn detect_linux_terminal() -> Option<String> {
     None
 }
 
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 fn command_exists(name: &str) -> bool {
     std::env::var_os("PATH")
         .map(|paths| {
@@ -604,7 +604,7 @@ fn command_exists(name: &str) -> bool {
         .unwrap_or(false)
 }
 
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 fn write_linux_shortcut_script(path: &Path, cwd: &Path, terminal: Option<&str>) -> Result<()> {
     let script = render_linux_shortcut_script(cwd, terminal);
     fs::write(path, script)?;
@@ -617,7 +617,7 @@ fn write_linux_shortcut_script(path: &Path, cwd: &Path, terminal: Option<&str>) 
     Ok(())
 }
 
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 fn render_linux_shortcut_script(cwd: &Path, terminal: Option<&str>) -> String {
     let cwd = shell_single_quote(&cwd.to_string_lossy());
     let launcher = terminal
@@ -630,7 +630,7 @@ fn render_linux_shortcut_script(cwd: &Path, terminal: Option<&str>) -> String {
     format!("#!/usr/bin/env bash\nset -euo pipefail\nexport PROJECT_CWD='{cwd}'\n{launcher}\n")
 }
 
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 fn build_terminal_launch_command(terminal: &str) -> String {
     let picker = "sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\"";
     match terminal {
@@ -695,7 +695,7 @@ fn render_macos_shortcut_plist(script_path: &Path) -> String {
     )
 }
 
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 fn write_linux_shortcut_desktop_entry(path: &Path, script_path: &Path) -> Result<()> {
     let desktop = format!(
         "[Desktop Entry]\nType=Application\nName=Sivtr Pick Codex\nExec={}\nTerminal=false\nCategories=Development;\n",
@@ -705,7 +705,7 @@ fn write_linux_shortcut_desktop_entry(path: &Path, script_path: &Path) -> Result
     Ok(())
 }
 
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 fn shell_single_quote(value: &str) -> String {
     value.replace('\'', "'\"'\"'")
 }
@@ -741,12 +741,16 @@ fn find_marked_block(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
     use super::{
-        build_terminal_launch_command, command_exists, desktop_exec_quote,
-        render_linux_shortcut_script, render_macos_shortcut_plist, render_macos_shortcut_script,
-        shell_single_quote, update_existing_hook, xml_escape, BASH_HOOK, BASH_SPEC,
+        build_terminal_launch_command, command_exists, render_linux_shortcut_script,
+        shell_single_quote, TMUX_HOOK, TMUX_SPEC,
+    };
+    use super::{
+        desktop_exec_quote, render_macos_shortcut_plist, render_macos_shortcut_script,
+        update_existing_hook, xml_escape, BASH_HOOK, BASH_SPEC,
         LEGACY_POWERSHELL_HOOK, MACOS_SHORTCUT_LABEL, NUSHELL_HOOK, NUSHELL_SPEC, POWERSHELL_HOOK,
-        POWERSHELL_SPEC, TMUX_HOOK, TMUX_SPEC, ZSH_HOOK, ZSH_SPEC,
+        POWERSHELL_SPEC, ZSH_HOOK, ZSH_SPEC,
     };
     use std::path::Path;
 
@@ -822,6 +826,7 @@ mod tests {
         assert_eq!(updated, profile);
     }
 
+    #[cfg(unix)]
     #[test]
     fn replaces_existing_tmux_block() {
         let profile = format!("before\n{TMUX_HOOK}\nafter\n");
@@ -831,6 +836,7 @@ mod tests {
         assert_eq!(updated, profile);
     }
 
+    #[cfg(unix)]
     #[test]
     fn gnome_terminal_launcher_uses_project_cwd() {
         let command = build_terminal_launch_command("gnome-terminal");
@@ -839,11 +845,13 @@ mod tests {
         assert!(command.contains("sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\""));
     }
 
+    #[cfg(unix)]
     #[test]
     fn shell_single_quote_escapes_single_quotes() {
         assert_eq!(shell_single_quote("/tmp/it's"), "/tmp/it'\"'\"'s");
     }
 
+    #[cfg(unix)]
     #[test]
     fn linux_shortcut_script_exports_project_cwd() {
         let script = render_linux_shortcut_script(Path::new("/tmp/project"), Some("xterm"));
@@ -891,6 +899,7 @@ mod tests {
         assert_eq!(xml_escape("a&b<c>d"), "a&amp;b&lt;c&gt;d");
     }
 
+    #[cfg(unix)]
     #[test]
     fn command_exists_detects_programs_via_path_scan() {
         assert!(command_exists("sh"));

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod browse;
 pub mod capture_history;
 pub mod clear;
+pub mod codex;
 pub mod command_block_selector;
 pub mod config;
 pub mod copy;

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,9 @@ fn run() -> Result<()> {
         Some(Commands::Hotkey(cmd)) => {
             commands::hotkey::execute(cmd)?;
         }
+        Some(Commands::Codex(cmd)) => {
+            commands::codex::execute(cmd)?;
+        }
         Some(Commands::Config(cfg_cmd)) => {
             commands::config::execute(cfg_cmd)?;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,8 @@ use anyhow::Result;
 use clap::Parser;
 
 use cli::{
-    AgentCopyCommand, AgentCopyMode, Cli, Commands, CopyArgs, CopySimpleArgs, CopySubcommand,
-    DiffArgs, HotkeyPickAgentArgs, HotkeyServeArgs,
+    AgentCopyArgs, AgentCopyCommand, AgentCopyMode, Cli, Commands, CopyArgs, CopySimpleArgs,
+    CopySubcommand, DiffArgs, HotkeyPickAgentArgs, HotkeyServeArgs,
 };
 use command_blocks::CommandBlockTextMode;
 use commands::copy::{AgentCopyRequest, CopyMode, CopyRequest};
@@ -146,18 +146,19 @@ fn run_agent_copy(provider: AgentProvider, cmd: AgentCopyCommand) -> Result<()> 
 
 fn run_agent_copy_args(
     provider: AgentProvider,
-    args: &CopySimpleArgs,
+    args: &AgentCopyArgs,
     selection_mode: AgentSelection,
 ) -> Result<()> {
     commands::copy::execute_agent(AgentCopyRequest {
         provider,
-        selector: args.common.selector.as_deref(),
-        pick: args.common.pick,
+        selector: args.common.common.selector.as_deref(),
+        session_selector: args.session.as_deref(),
+        pick: args.common.common.pick,
         pick_current_session: false,
         selection_mode,
-        print_full: args.common.print,
-        regex: args.common.regex.as_deref(),
-        lines: args.common.lines.as_deref(),
+        print_full: args.common.common.print,
+        regex: args.common.common.regex.as_deref(),
+        lines: args.common.common.lines.as_deref(),
     })
 }
 


### PR DESCRIPTION
This PR brings the fork branch Jacobinwwey:feat/macos-basic-pr into upstream with the latest consolidated macOS-support line.

Closes https://github.com/Ariestar/sivtr/issues/5

Included synced PR work:
- feat(macos): sync full PR functions and add unix capture support
- fix(init): avoid non-unix unreachable code in shortcut helpers
- fix(init): gate unix-only shortcut symbols on windows
- feat(copy): support explicit ai session selectors
- fix(vscode): harden codex picker command-line quoting

Validation completed:
- cargo test: 98 passed, 0 failed
- editors/vscode: pnpm test passed
- copy codex --print smoke passed
- init linux-shortcut smoke passed
- init tmux smoke passed
- bash interactive capture smoke passed
- zsh interactive capture smoke passed

Notes:
- init macos-shortcut runtime behavior is guarded to macOS host by design.