### PR TITLE
fix(codex): mirror and expose complete cross-account Codex sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,6 +1286,7 @@ dependencies = [
  "serde_json",
  "similar",
  "sivtr-core",
+ "tempfile",
  "tokio",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,6 @@ serde_json = "1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["fileapi", "handleapi", "processenv", "processthreadsapi", "winbase", "winnt", "winuser", "windef", "minwindef"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ sivtr copy out --lines 10:40
 
 ### Reuse Codex Sessions
 
-`sivtr copy codex` reads Codex rollout JSONL files from `~/.codex/sessions` and chooses the newest session whose `cwd` matches your current directory.
+`sivtr copy codex` reads Codex rollout JSONL files from `~/.codex/sessions`. When an active Codex shell exports `CODEX_THREAD_ID`, `sivtr` prefers that exact local session first. Otherwise it chooses the newest local session whose `cwd` matches your current directory.
+
+For shared read-only access to another account's Codex sessions, mirror them into a separate directory and add that directory to `[codex].session_dirs` instead of running `sivtr` with elevated privileges. Shared/mirrored trees only participate in explicit browsing through `--pick`.
 
 Use `--session N` to open the Nth newest recorded session, or `--session ID` to match a session id / id prefix explicitly.
 
@@ -163,9 +165,23 @@ sivtr copy codex in     # latest user message
 sivtr copy codex tool   # latest tool output
 sivtr copy codex all    # parsed session
 sivtr copy codex --session 2 --pick
+sivtr copy codex --pick # browse local and mirrored sessions
 ```
 
 Progress commentary is filtered by default, so `sivtr copy codex out` returns the final assistant reply instead of intermediate status updates.
+
+Mirror the current account's sessions into a shared tree:
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex --watch
+```
+
+Then point another account at that mirrored tree:
+
+```toml
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+```
 
 ### VS Code Shortcut
 
@@ -265,6 +281,7 @@ The default shortcut is `alt+y`.
 | `sivtr run <command>` | Execute a command, capture output, then browse it. |
 | `sivtr copy` | Copy recent command blocks. |
 | `sivtr copy codex` | Copy useful content from the current Codex session. |
+| `sivtr codex export --dest <path>` | Mirror local Codex sessions into a shared read-only tree. |
 | `sivtr diff <left> <right>` | Compare recent command blocks. |
 | `sivtr history` | List, search, and show captured output history. |
 | `sivtr config` | Manage the TOML config file. |

--- a/README.md
+++ b/README.md
@@ -195,6 +195,11 @@ sivtr codex export --dest /Users/Shared/sivtr/root-codex --watch
 session_dirs = ["/Users/Shared/sivtr/root-codex/sessions"]
 ```
 
+Quick one-line checks:
+
+- export side: `rm -rf /Users/Shared/sivtr/root-codex-smoke && sivtr codex export --dest /Users/Shared/sivtr/root-codex-smoke && find /Users/Shared/sivtr/root-codex-smoke -maxdepth 2 -type f | sed -n '1,5p'`
+- read side after configuring `[codex].session_dirs`: `sivtr copy codex --pick`
+
 To mirror sessions for another local account (for example read-only sharing),
 run export watch mode from the source account:
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,18 @@ Then point another account at that mirrored tree:
 session_dirs = ["/srv/sivtr/root-codex/sessions"]
 ```
 
+On macOS, a shared path under `/Users/Shared` works well for read-only access
+across local accounts:
+
+```bash
+sivtr codex export --dest /Users/Shared/sivtr/root-codex --watch
+```
+
+```toml
+[codex]
+session_dirs = ["/Users/Shared/sivtr/root-codex/sessions"]
+```
+
 To mirror sessions for another local account (for example read-only sharing),
 run export watch mode from the source account:
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,16 @@ Then point another account at that mirrored tree:
 session_dirs = ["/srv/sivtr/root-codex/sessions"]
 ```
 
+To mirror sessions for another local account (for example read-only sharing),
+run export watch mode from the source account:
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex --watch --interval-ms 500
+```
+
+`--watch` defaults to a 1-second sync interval. Use `--interval-ms` for
+sub-second updates when you need faster session visibility.
+
 ### VS Code Shortcut
 
 The VS Code extension contributes:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -149,7 +149,9 @@ sivtr copy out --lines 10:40
 
 ### 复用 Codex 会话
 
-`sivtr copy codex` 会读取 `~/.codex/sessions` 下的 Codex rollout JSONL 文件，并优先选择 `cwd` 与当前目录匹配的最新会话。
+`sivtr copy codex` 会读取 `~/.codex/sessions` 下的 Codex rollout JSONL 文件。如果当前 Codex shell 暴露了 `CODEX_THREAD_ID`，`sivtr` 会优先匹配这个本地精确会话；否则会优先选择 `cwd` 与当前目录匹配的最新本地会话。
+
+如果要只读共享另一个账号的 Codex 会话，推荐先把它们镜像到独立目录，再通过 `[codex].session_dirs` 读取，而不是用提权方式运行 `sivtr`。共享/镜像目录只参与 `--pick` 这类显式浏览，不会抢占当前本地会话解析。
 
 用 `--session N` 可以显式选择第 N 新的已记录会话；用 `--session ID` 可以按会话 id 或 id 前缀匹配。
 
@@ -163,9 +165,23 @@ sivtr copy codex in     # 最近用户消息
 sivtr copy codex tool   # 最近工具输出
 sivtr copy codex all    # 整个解析后的会话
 sivtr copy codex --session 2 --pick
+sivtr copy codex --pick # 浏览本地和共享镜像会话
 ```
 
 默认会过滤过程性 commentary，所以 `sivtr copy codex out` 更倾向返回最终助手回复，而不是中间状态更新。
+
+先把当前账号的会话持续镜像成共享树：
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex --watch
+```
+
+再让另一个账号在配置里引用镜像目录：
+
+```toml
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+```
 
 ### VS Code 快捷键
 
@@ -262,6 +278,7 @@ sivtr hotkey stop
 | `sivtr run <command>` | 执行命令、捕获输出并浏览。 |
 | `sivtr copy` | 复制最近命令块。 |
 | `sivtr copy codex` | 复制当前 Codex 会话中的有用内容。 |
+| `sivtr codex export --dest <path>` | 把本地 Codex 会话镜像成共享只读目录树。 |
 | `sivtr diff <left> <right>` | 对比最近命令输出。 |
 | `sivtr history` | 列出、搜索、查看输出历史。 |
 | `sivtr config` | 管理 TOML 配置。 |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -183,6 +183,17 @@ sivtr codex export --dest /srv/sivtr/root-codex --watch
 session_dirs = ["/srv/sivtr/root-codex/sessions"]
 ```
 
+在 macOS 上，推荐把只读共享目录放在 `/Users/Shared` 下，便于不同本地账号读取：
+
+```bash
+sivtr codex export --dest /Users/Shared/sivtr/root-codex --watch
+```
+
+```toml
+[codex]
+session_dirs = ["/Users/Shared/sivtr/root-codex/sessions"]
+```
+
 如果你要把会话镜像给另一个本地账号做只读访问（例如 root 导出，jacob
 读取），可以在源账号启动持续导出：
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -194,6 +194,11 @@ sivtr codex export --dest /Users/Shared/sivtr/root-codex --watch
 session_dirs = ["/Users/Shared/sivtr/root-codex/sessions"]
 ```
 
+可直接复制的一行验证命令：
+
+- 导出侧：`rm -rf /Users/Shared/sivtr/root-codex-smoke && sivtr codex export --dest /Users/Shared/sivtr/root-codex-smoke && find /Users/Shared/sivtr/root-codex-smoke -maxdepth 2 -type f | sed -n '1,5p'`
+- 读取侧（在 `[codex].session_dirs` 配好之后）：`sivtr copy codex --pick`
+
 如果你要把会话镜像给另一个本地账号做只读访问（例如 root 导出，jacob
 读取），可以在源账号启动持续导出：
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -183,6 +183,16 @@ sivtr codex export --dest /srv/sivtr/root-codex --watch
 session_dirs = ["/srv/sivtr/root-codex/sessions"]
 ```
 
+如果你要把会话镜像给另一个本地账号做只读访问（例如 root 导出，jacob
+读取），可以在源账号启动持续导出：
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex --watch --interval-ms 500
+```
+
+`--watch` 默认每 1 秒同步一次；需要更快可见性时可用 `--interval-ms`
+改成毫秒级同步。
+
 ### VS Code 快捷键
 
 VS Code 插件提供命令：

--- a/crates/sivtr-core/src/ai.rs
+++ b/crates/sivtr-core/src/ai.rs
@@ -233,13 +233,19 @@ pub fn parse_jsonl_session(
             continue;
         }
 
-        let value: Value = serde_json::from_str(&line).with_context(|| {
-            format!(
-                "Failed to parse {provider_name} session line {} as JSON: {}",
-                idx + 1,
-                path.display()
-            )
-        })?;
+        let value: Value = match serde_json::from_str(&line) {
+            Ok(value) => value,
+            Err(error) if idx > 0 && is_trailing_partial_json_line(&error) => break,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "Failed to parse {provider_name} session line {} as JSON: {}",
+                        idx + 1,
+                        path.display()
+                    )
+                });
+            }
+        };
         apply_event(&mut session, &value);
     }
 
@@ -372,6 +378,10 @@ fn normalize_path_for_match(path: &Path) -> String {
         .to_string_lossy()
         .replace('/', "\\")
         .to_lowercase()
+}
+
+fn is_trailing_partial_json_line(error: &serde_json::Error) -> bool {
+    matches!(error.classify(), serde_json::error::Category::Eof)
 }
 
 pub fn select_blocks(session: &AgentSession, selection: AgentSelection) -> Vec<AgentBlock> {

--- a/crates/sivtr-core/src/ai.rs
+++ b/crates/sivtr-core/src/ai.rs
@@ -345,7 +345,7 @@ pub fn pretty_json_string(text: &str) -> String {
         .unwrap_or_else(|| text.to_string())
 }
 
-fn jsonl_files(root: &Path) -> Result<Vec<PathBuf>> {
+pub fn jsonl_files(root: &Path) -> Result<Vec<PathBuf>> {
     if !root.exists() {
         return Ok(Vec::new());
     }
@@ -372,7 +372,7 @@ fn modified_time(path: &Path) -> Result<SystemTime> {
     Ok(fs::metadata(path)?.modified()?)
 }
 
-fn normalize_path_for_match(path: &Path) -> String {
+pub fn normalize_path_for_match(path: &Path) -> String {
     path.canonicalize()
         .unwrap_or_else(|_| path.to_path_buf())
         .to_string_lossy()

--- a/crates/sivtr-core/src/codex.rs
+++ b/crates/sivtr-core/src/codex.rs
@@ -77,7 +77,57 @@ impl AgentSessionProvider for CodexProvider {
     }
 
     fn parse_session_file(&self, path: &Path) -> Result<AgentSession> {
-        parse_jsonl_session(path, PROVIDER_NAME, apply_event_with_event_fallback)
+        let mut saw_response_item = false;
+        let mut event_fallback_indices = Vec::new();
+        let mut session = parse_jsonl_session(path, PROVIDER_NAME, |session, value| {
+            let timestamp = value
+                .get("timestamp")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            let payload = value.get("payload").unwrap_or(&Value::Null);
+
+            match value.get("type").and_then(Value::as_str) {
+                Some("session_meta") => {
+                    session.id = payload
+                        .get("id")
+                        .and_then(Value::as_str)
+                        .map(str::to_string);
+                    session.cwd = payload
+                        .get("cwd")
+                        .and_then(Value::as_str)
+                        .map(str::to_string);
+                }
+                Some("response_item") => {
+                    saw_response_item = true;
+                    apply_response_item(session, payload, timestamp.clone());
+                }
+                Some("event_msg") => {
+                    let start = session.blocks.len();
+                    apply_event_msg(session, payload, timestamp);
+                    if session.blocks.len() > start {
+                        event_fallback_indices.extend(start..session.blocks.len());
+                    }
+                }
+                _ => {}
+            }
+        })?;
+
+        if saw_response_item && !event_fallback_indices.is_empty() {
+            let mut drop_mask = vec![false; session.blocks.len()];
+            for index in event_fallback_indices {
+                if let Some(slot) = drop_mask.get_mut(index) {
+                    *slot = true;
+                }
+            }
+            session.blocks = session
+                .blocks
+                .into_iter()
+                .enumerate()
+                .filter_map(|(index, block)| (!drop_mask[index]).then_some(block))
+                .collect();
+        }
+
+        Ok(session)
     }
 
     fn find_session_by_id(&self, id: &str) -> Result<Option<PathBuf>> {
@@ -161,30 +211,6 @@ fn parse_session_meta(path: &Path) -> Result<AgentSessionMeta> {
             .and_then(Value::as_str)
             .map(str::to_string);
     })
-}
-
-fn apply_event_with_event_fallback(session: &mut AgentSession, value: &Value) {
-    let timestamp = value
-        .get("timestamp")
-        .and_then(Value::as_str)
-        .map(str::to_string);
-    let payload = value.get("payload").unwrap_or(&Value::Null);
-
-    match value.get("type").and_then(Value::as_str) {
-        Some("session_meta") => {
-            session.id = payload
-                .get("id")
-                .and_then(Value::as_str)
-                .map(str::to_string);
-            session.cwd = payload
-                .get("cwd")
-                .and_then(Value::as_str)
-                .map(str::to_string);
-        }
-        Some("response_item") => apply_response_item(session, payload, timestamp.clone()),
-        Some("event_msg") => apply_event_msg(session, payload, timestamp),
-        _ => {}
-    }
 }
 
 fn apply_response_item(session: &mut AgentSession, payload: &Value, timestamp: Option<String>) {
@@ -306,7 +332,17 @@ mod tests {
         format_blocks, select_blocks, AgentBlockKind, AgentSelection, AgentSessionProvider,
     };
     use serde_json::json;
-    use std::{env, fs, path::PathBuf, time::Duration};
+    use std::{
+        env, fs,
+        path::PathBuf,
+        sync::{Mutex, OnceLock},
+        time::Duration,
+    };
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
 
     #[test]
     fn parses_codex_rollout_messages_and_tools() {
@@ -385,6 +421,7 @@ mod tests {
 
     #[test]
     fn find_current_session_prefers_codex_thread_id_over_cwd_match() {
+        let _guard = env_lock();
         let temp = tempfile::tempdir().unwrap();
         let codex_home = temp.path().join("codex-home");
         let sessions_dir = codex_home
@@ -449,6 +486,7 @@ mod tests {
 
     #[test]
     fn configured_codex_session_dirs_reads_env_override_once() {
+        let _guard = env_lock();
         let previous = env::var_os("SIVTR_CODEX_SESSION_DIRS");
         let separator = if cfg!(windows) { ";" } else { ":" };
         env::set_var(
@@ -475,6 +513,7 @@ mod tests {
 
     #[test]
     fn configured_codex_session_dirs_combines_env_and_config_entries() {
+        let _guard = env_lock();
         let temp = tempfile::tempdir().unwrap();
         let config_home = temp.path().join("config-home");
         let config_dir = config_home.join("sivtr");
@@ -517,6 +556,7 @@ mod tests {
 
     #[test]
     fn list_recent_sessions_includes_exported_session_dirs() {
+        let _guard = env_lock();
         let temp = tempfile::tempdir().unwrap();
         let codex_home = temp.path().join("codex-home");
         let local_sessions = codex_home

--- a/crates/sivtr-core/src/codex.rs
+++ b/crates/sivtr-core/src/codex.rs
@@ -1,12 +1,14 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde_json::Value;
 use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 
 use crate::ai::{
     extract_content_text, list_recent_jsonl_sessions, parse_jsonl_meta, parse_jsonl_session,
     pretty_json_string, pretty_json_value, push_block, AgentBlockKind, AgentProvider, AgentSession,
     AgentSessionInfo, AgentSessionMeta, AgentSessionProvider,
 };
+use crate::config::SivtrConfig;
 
 const PROVIDER_NAME: &str = "Codex";
 
@@ -19,11 +21,74 @@ impl AgentSessionProvider for CodexProvider {
     }
 
     fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
-        list_recent_jsonl_sessions(&codex_home().join("sessions"), cwd, parse_session_meta)
+        let wanted = cwd.map(normalize_path_for_match);
+        let mut sessions = Vec::new();
+
+        for root in configured_codex_session_dirs() {
+            for path in jsonl_files(&root)? {
+                let meta = parse_session_meta(&path)?;
+                if let Some(wanted) = wanted.as_deref() {
+                    let matches_cwd = meta
+                        .cwd
+                        .as_deref()
+                        .map(|cwd| normalize_path_for_match(Path::new(cwd)) == wanted)
+                        .unwrap_or(false);
+                    if !matches_cwd {
+                        continue;
+                    }
+                }
+
+                sessions.push(AgentSessionInfo {
+                    modified: std::fs::metadata(&path)
+                        .and_then(|meta| meta.modified())
+                        .unwrap_or(SystemTime::UNIX_EPOCH),
+                    path,
+                    id: meta.id,
+                    cwd: meta.cwd,
+                });
+            }
+        }
+
+        sessions.sort_by_key(|session| session.modified);
+        sessions.reverse();
+        Ok(sessions)
     }
 
     fn parse_session_file(&self, path: &Path) -> Result<AgentSession> {
         parse_jsonl_session(path, PROVIDER_NAME, apply_event)
+    }
+
+    fn find_session_by_id(&self, id: &str) -> Result<Option<PathBuf>> {
+        for path in local_session_files()? {
+            if path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.contains(id))
+            {
+                return Ok(Some(path));
+            }
+
+            if parse_session_meta(&path)?.id.as_deref() == Some(id) {
+                return Ok(Some(path));
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn find_current_session(&self, cwd: &Path) -> Result<Option<PathBuf>> {
+        if let Some(path) = find_current_thread_session()? {
+            return Ok(Some(path));
+        }
+
+        if let Some(session) = list_recent_local_sessions(Some(cwd))?.into_iter().next() {
+            return Ok(Some(session.path));
+        }
+
+        Ok(list_recent_local_sessions(None)?
+            .into_iter()
+            .next()
+            .map(|session| session.path))
     }
 }
 
@@ -35,6 +100,29 @@ pub fn codex_home() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".codex")
+}
+
+pub fn local_codex_sessions_dir() -> PathBuf {
+    codex_home().join("sessions")
+}
+
+pub fn configured_codex_session_dirs() -> Vec<PathBuf> {
+    let mut dirs = vec![local_codex_sessions_dir()];
+
+    if let Ok(extra) = std::env::var("SIVTR_CODEX_SESSION_DIRS") {
+        let separator = if cfg!(windows) { ';' } else { ':' };
+        dirs.extend(
+            extra
+                .split(separator)
+                .map(str::trim)
+                .filter(|entry| !entry.is_empty())
+                .map(PathBuf::from),
+        );
+    } else if let Ok(config) = SivtrConfig::load() {
+        dirs.extend(config.codex.session_dirs);
+    }
+
+    dedup_paths(dirs)
 }
 
 fn parse_session_meta(path: &Path) -> Result<AgentSessionMeta> {
@@ -128,12 +216,79 @@ fn extract_tool_call_text(payload: &Value) -> String {
     }
 }
 
+fn local_session_files() -> Result<Vec<PathBuf>> {
+    jsonl_files(&local_codex_sessions_dir())
+}
+
+fn list_recent_local_sessions(cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+    list_recent_jsonl_sessions(&local_codex_sessions_dir(), cwd, parse_session_meta)
+}
+
+fn find_current_thread_session() -> Result<Option<PathBuf>> {
+    let Ok(thread_id) = std::env::var("CODEX_THREAD_ID") else {
+        return Ok(None);
+    };
+
+    let thread_id = thread_id.trim();
+    if thread_id.is_empty() {
+        return Ok(None);
+    }
+
+    CodexProvider.find_session_by_id(thread_id)
+}
+
+fn dedup_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut deduped = Vec::new();
+    for path in paths {
+        if deduped.iter().any(|existing| existing == &path) {
+            continue;
+        }
+        deduped.push(path);
+    }
+    deduped
+}
+
+fn jsonl_files(root: &Path) -> Result<Vec<PathBuf>> {
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut files = Vec::new();
+    collect_jsonl_files(root, &mut files)?;
+    Ok(files)
+}
+
+fn collect_jsonl_files(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in
+        std::fs::read_dir(dir).with_context(|| format!("Failed to read {}", dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_jsonl_files(&path, files)?;
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("jsonl") {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn normalize_path_for_match(path: &Path) -> String {
+    path.canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .replace('/', "\\")
+        .to_lowercase()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::CodexProvider;
+    use super::{configured_codex_session_dirs, CodexProvider};
     use crate::ai::{
         format_blocks, select_blocks, AgentBlockKind, AgentSelection, AgentSessionProvider,
     };
+    use serde_json::json;
+    use std::{env, path::PathBuf, time::Duration};
 
     #[test]
     fn parses_codex_rollout_messages_and_tools() {
@@ -208,5 +363,179 @@ mod tests {
 
         assert_eq!(session.blocks.len(), 2);
         assert_eq!(blocks[0].text, "real answer");
+    }
+
+    #[test]
+    fn find_current_session_prefers_codex_thread_id_over_cwd_match() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_home = temp.path().join("codex-home");
+        let sessions_dir = codex_home
+            .join("sessions")
+            .join("2026")
+            .join("05")
+            .join("07");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+
+        let cwd_match = temp.path().join("cwd-match");
+        let thread_match = temp.path().join("thread-match");
+        std::fs::create_dir_all(&cwd_match).unwrap();
+        std::fs::create_dir_all(&thread_match).unwrap();
+
+        let cwd_session = sessions_dir.join("rollout-cwd.jsonl");
+        std::fs::write(
+            &cwd_session,
+            format!(
+                "{}\n",
+                serde_json::to_string(&json!({
+                    "type": "session_meta",
+                    "payload": { "id": "cwd-session", "cwd": cwd_match }
+                }))
+                .unwrap()
+            ),
+        )
+        .unwrap();
+        std::thread::sleep(Duration::from_millis(5));
+
+        let thread_session = sessions_dir.join("rollout-thread.jsonl");
+        std::fs::write(
+            &thread_session,
+            format!(
+                "{}\n",
+                serde_json::to_string(&json!({
+                    "type": "session_meta",
+                    "payload": { "id": "thread-session", "cwd": thread_match }
+                }))
+                .unwrap()
+            ),
+        )
+        .unwrap();
+
+        let previous_codex_home = env::var_os("CODEX_HOME");
+        let previous_thread_id = env::var_os("CODEX_THREAD_ID");
+        env::set_var("CODEX_HOME", &codex_home);
+        env::set_var("CODEX_THREAD_ID", "thread-session");
+
+        let resolved = CodexProvider.find_current_session(&cwd_match).unwrap();
+
+        match previous_codex_home {
+            Some(value) => env::set_var("CODEX_HOME", value),
+            None => env::remove_var("CODEX_HOME"),
+        }
+        match previous_thread_id {
+            Some(value) => env::set_var("CODEX_THREAD_ID", value),
+            None => env::remove_var("CODEX_THREAD_ID"),
+        }
+
+        assert_eq!(resolved, Some(thread_session));
+    }
+
+    #[test]
+    fn configured_codex_session_dirs_reads_env_override_once() {
+        let previous = env::var_os("SIVTR_CODEX_SESSION_DIRS");
+        env::set_var("SIVTR_CODEX_SESSION_DIRS", "/tmp/a:/tmp/b:/tmp/a");
+
+        let dirs = configured_codex_session_dirs();
+
+        match previous {
+            Some(value) => env::set_var("SIVTR_CODEX_SESSION_DIRS", value),
+            None => env::remove_var("SIVTR_CODEX_SESSION_DIRS"),
+        }
+
+        assert!(dirs.contains(&PathBuf::from("/tmp/a")));
+        assert!(dirs.contains(&PathBuf::from("/tmp/b")));
+        assert_eq!(
+            dirs.iter()
+                .filter(|path| *path == &PathBuf::from("/tmp/a"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn list_recent_sessions_includes_exported_session_dirs() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_home = temp.path().join("codex-home");
+        let local_sessions = codex_home
+            .join("sessions")
+            .join("2026")
+            .join("05")
+            .join("07");
+        let exported_root = temp.path().join("shared-export");
+        let exported_sessions = exported_root
+            .join("sessions")
+            .join("2026")
+            .join("05")
+            .join("06");
+        std::fs::create_dir_all(&local_sessions).unwrap();
+        std::fs::create_dir_all(&exported_sessions).unwrap();
+
+        let local_path = local_sessions.join("rollout-local.jsonl");
+        std::fs::write(
+            &local_path,
+            serde_json::to_string(&json!({
+                "type": "session_meta",
+                "payload": { "id": "local-session", "cwd": "/tmp/local" }
+            }))
+            .unwrap()
+                + "\n",
+        )
+        .unwrap();
+
+        std::thread::sleep(Duration::from_millis(5));
+
+        let exported_path = exported_sessions.join("rollout-exported.jsonl");
+        std::fs::write(
+            &exported_path,
+            serde_json::to_string(&json!({
+                "type": "session_meta",
+                "payload": { "id": "exported-session", "cwd": "/tmp/exported" }
+            }))
+            .unwrap()
+                + "\n",
+        )
+        .unwrap();
+
+        let previous_codex_home = env::var_os("CODEX_HOME");
+        let previous_dirs = env::var_os("SIVTR_CODEX_SESSION_DIRS");
+        env::set_var("CODEX_HOME", &codex_home);
+        env::set_var("SIVTR_CODEX_SESSION_DIRS", exported_root.join("sessions"));
+
+        let sessions = CodexProvider.list_recent_sessions(None).unwrap();
+
+        match previous_codex_home {
+            Some(value) => env::set_var("CODEX_HOME", value),
+            None => env::remove_var("CODEX_HOME"),
+        }
+        match previous_dirs {
+            Some(value) => env::set_var("SIVTR_CODEX_SESSION_DIRS", value),
+            None => env::remove_var("SIVTR_CODEX_SESSION_DIRS"),
+        }
+
+        assert_eq!(sessions.len(), 2);
+        assert_eq!(sessions[0].id.as_deref(), Some("exported-session"));
+        assert_eq!(sessions[1].id.as_deref(), Some("local-session"));
+        assert_eq!(sessions[0].path, exported_path);
+        assert_eq!(sessions[1].path, local_path);
+    }
+
+    #[test]
+    fn parses_session_when_last_json_line_is_still_incomplete() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"type":"session_meta","payload":{"id":"abc","cwd":"/tmp/repo"}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"text":"hello"}]}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"text":"done"}]}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"text":"partial"#,
+        )
+        .unwrap();
+
+        let session = CodexProvider.parse_session_file(&path).unwrap();
+
+        assert_eq!(session.id.as_deref(), Some("abc"));
+        assert_eq!(session.blocks.len(), 2);
+        assert_eq!(session.blocks[0].text, "hello");
+        assert_eq!(session.blocks[1].text, "done");
     }
 }

--- a/crates/sivtr-core/src/codex.rs
+++ b/crates/sivtr-core/src/codex.rs
@@ -1,12 +1,14 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use serde_json::Value;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use crate::ai::{
-    extract_content_text, list_recent_jsonl_sessions, parse_jsonl_meta, parse_jsonl_session,
-    pretty_json_string, pretty_json_value, push_block, AgentBlockKind, AgentProvider, AgentSession,
-    AgentSessionInfo, AgentSessionMeta, AgentSessionProvider,
+    extract_content_text, jsonl_files, list_recent_jsonl_sessions, normalize_path_for_match,
+    parse_jsonl_meta, parse_jsonl_session, pretty_json_string, pretty_json_value, push_block,
+    AgentBlockKind, AgentProvider, AgentSession, AgentSessionInfo, AgentSessionMeta,
+    AgentSessionProvider,
 };
 use crate::config::SivtrConfig;
 
@@ -25,8 +27,28 @@ impl AgentSessionProvider for CodexProvider {
         let mut sessions = Vec::new();
 
         for root in configured_codex_session_dirs() {
-            for path in jsonl_files(&root)? {
-                let meta = parse_session_meta(&path)?;
+            let paths = match jsonl_files(&root) {
+                Ok(paths) => paths,
+                Err(error) => {
+                    eprintln!(
+                        "sivtr: warning: failed to read Codex session dir {}: {error:#}",
+                        root.display()
+                    );
+                    continue;
+                }
+            };
+
+            for path in paths {
+                let meta = match parse_session_meta(&path) {
+                    Ok(meta) => meta,
+                    Err(error) => {
+                        eprintln!(
+                            "sivtr: warning: failed to parse Codex session metadata {}: {error:#}",
+                            path.display()
+                        );
+                        continue;
+                    }
+                };
                 if let Some(wanted) = wanted.as_deref() {
                     let matches_cwd = meta
                         .cwd
@@ -55,17 +77,7 @@ impl AgentSessionProvider for CodexProvider {
     }
 
     fn parse_session_file(&self, path: &Path) -> Result<AgentSession> {
-        let session = parse_jsonl_session(path, PROVIDER_NAME, apply_event)?;
-        if !session.blocks.is_empty() {
-            return Ok(session);
-        }
-
-        let fallback = parse_jsonl_session(path, PROVIDER_NAME, apply_event_with_event_fallback)?;
-        if !fallback.blocks.is_empty() {
-            return Ok(fallback);
-        }
-
-        Ok(session)
+        parse_jsonl_session(path, PROVIDER_NAME, apply_event_with_event_fallback)
     }
 
     fn find_session_by_id(&self, id: &str) -> Result<Option<PathBuf>> {
@@ -149,29 +161,6 @@ fn parse_session_meta(path: &Path) -> Result<AgentSessionMeta> {
             .and_then(Value::as_str)
             .map(str::to_string);
     })
-}
-
-fn apply_event(session: &mut AgentSession, value: &Value) {
-    let timestamp = value
-        .get("timestamp")
-        .and_then(Value::as_str)
-        .map(str::to_string);
-    let payload = value.get("payload").unwrap_or(&Value::Null);
-
-    match value.get("type").and_then(Value::as_str) {
-        Some("session_meta") => {
-            session.id = payload
-                .get("id")
-                .and_then(Value::as_str)
-                .map(str::to_string);
-            session.cwd = payload
-                .get("cwd")
-                .and_then(Value::as_str)
-                .map(str::to_string);
-        }
-        Some("response_item") => apply_response_item(session, payload, timestamp),
-        _ => {}
-    }
 }
 
 fn apply_event_with_event_fallback(session: &mut AgentSession, value: &Value) {
@@ -299,47 +288,15 @@ fn find_current_thread_session() -> Result<Option<PathBuf>> {
 }
 
 fn dedup_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
     let mut deduped = Vec::new();
     for path in paths {
-        if deduped.iter().any(|existing| existing == &path) {
+        if !seen.insert(normalize_path_for_match(&path)) {
             continue;
         }
         deduped.push(path);
     }
     deduped
-}
-
-fn jsonl_files(root: &Path) -> Result<Vec<PathBuf>> {
-    if !root.exists() {
-        return Ok(Vec::new());
-    }
-
-    let mut files = Vec::new();
-    collect_jsonl_files(root, &mut files)?;
-    Ok(files)
-}
-
-fn collect_jsonl_files(dir: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
-    for entry in
-        std::fs::read_dir(dir).with_context(|| format!("Failed to read {}", dir.display()))?
-    {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_dir() {
-            collect_jsonl_files(&path, files)?;
-        } else if path.extension().and_then(|ext| ext.to_str()) == Some("jsonl") {
-            files.push(path);
-        }
-    }
-    Ok(())
-}
-
-fn normalize_path_for_match(path: &Path) -> String {
-    path.canonicalize()
-        .unwrap_or_else(|_| path.to_path_buf())
-        .to_string_lossy()
-        .replace('/', "\\")
-        .to_lowercase()
 }
 
 #[cfg(test)]

--- a/crates/sivtr-core/src/codex.rs
+++ b/crates/sivtr-core/src/codex.rs
@@ -332,6 +332,7 @@ mod tests {
         format_blocks, normalize_path_for_match, select_blocks, AgentBlockKind, AgentSelection,
         AgentSessionProvider,
     };
+    use crate::config::SivtrConfig;
     use serde_json::json;
     use std::path::Path;
     use std::{
@@ -528,13 +529,6 @@ mod tests {
         let _guard = env_lock();
         let temp = tempfile::tempdir().unwrap();
         let config_home = temp.path().join("config-home");
-        let config_dir = config_home.join("sivtr");
-        fs::create_dir_all(&config_dir).unwrap();
-        fs::write(
-            config_dir.join("config.toml"),
-            "[codex]\nsession_dirs = [\"/tmp/from-config\", \"/tmp/shared\"]\n",
-        )
-        .unwrap();
 
         let previous_xdg_config_home = env::var_os("XDG_CONFIG_HOME");
         let previous_appdata = env::var_os("APPDATA");
@@ -544,12 +538,28 @@ mod tests {
         if cfg!(windows) {
             env::set_var("APPDATA", &config_home);
         }
+        let config_path = SivtrConfig::config_path().unwrap();
+        let previous_config_bytes = fs::read(&config_path).ok();
+        if let Some(parent) = config_path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(
+            &config_path,
+            "[codex]\nsession_dirs = [\"/tmp/from-config\", \"/tmp/shared\"]\n",
+        )
+        .unwrap();
         env::set_var(
             "SIVTR_CODEX_SESSION_DIRS",
             format!("/tmp/from-env{separator}/tmp/shared"),
         );
 
         let dirs = configured_codex_session_dirs();
+
+        if let Some(bytes) = previous_config_bytes {
+            fs::write(&config_path, bytes).unwrap();
+        } else {
+            let _ = fs::remove_file(&config_path);
+        }
 
         match previous_xdg_config_home {
             Some(value) => env::set_var("XDG_CONFIG_HOME", value),

--- a/crates/sivtr-core/src/codex.rs
+++ b/crates/sivtr-core/src/codex.rs
@@ -55,7 +55,17 @@ impl AgentSessionProvider for CodexProvider {
     }
 
     fn parse_session_file(&self, path: &Path) -> Result<AgentSession> {
-        parse_jsonl_session(path, PROVIDER_NAME, apply_event)
+        let session = parse_jsonl_session(path, PROVIDER_NAME, apply_event)?;
+        if !session.blocks.is_empty() {
+            return Ok(session);
+        }
+
+        let fallback = parse_jsonl_session(path, PROVIDER_NAME, apply_event_with_event_fallback)?;
+        if !fallback.blocks.is_empty() {
+            return Ok(fallback);
+        }
+
+        Ok(session)
     }
 
     fn find_session_by_id(&self, id: &str) -> Result<Option<PathBuf>> {
@@ -162,6 +172,30 @@ fn apply_event(session: &mut AgentSession, value: &Value) {
     }
 }
 
+fn apply_event_with_event_fallback(session: &mut AgentSession, value: &Value) {
+    let timestamp = value
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let payload = value.get("payload").unwrap_or(&Value::Null);
+
+    match value.get("type").and_then(Value::as_str) {
+        Some("session_meta") => {
+            session.id = payload
+                .get("id")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            session.cwd = payload
+                .get("cwd")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+        }
+        Some("response_item") => apply_response_item(session, payload, timestamp.clone()),
+        Some("event_msg") => apply_event_msg(session, payload, timestamp),
+        _ => {}
+    }
+}
+
 fn apply_response_item(session: &mut AgentSession, payload: &Value, timestamp: Option<String>) {
     match payload.get("type").and_then(Value::as_str) {
         Some("message") => {
@@ -204,6 +238,31 @@ fn apply_response_item(session: &mut AgentSession, payload: &Value, timestamp: O
                 .unwrap_or_default()
                 .to_string(),
         ),
+        _ => {}
+    }
+}
+
+fn apply_event_msg(session: &mut AgentSession, payload: &Value, timestamp: Option<String>) {
+    match payload.get("type").and_then(Value::as_str) {
+        Some("user_message") => push_block(
+            session,
+            AgentBlockKind::User,
+            timestamp,
+            None,
+            extract_content_text(payload.get("message").unwrap_or(&Value::Null)),
+        ),
+        Some("agent_message") => {
+            if payload.get("phase").and_then(Value::as_str) == Some("commentary") {
+                return;
+            }
+            push_block(
+                session,
+                AgentBlockKind::Assistant,
+                timestamp,
+                None,
+                extract_content_text(payload.get("message").unwrap_or(&Value::Null)),
+            );
+        }
         _ => {}
     }
 }
@@ -541,5 +600,51 @@ mod tests {
         assert_eq!(session.blocks.len(), 2);
         assert_eq!(session.blocks[0].text, "hello");
         assert_eq!(session.blocks[1].text, "done");
+    }
+
+    #[test]
+    fn falls_back_to_event_messages_when_response_items_are_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"type":"session_meta","payload":{"id":"abc","cwd":"/tmp/repo"}}
+{"type":"event_msg","payload":{"type":"user_message","message":"hello from event"}}
+{"type":"event_msg","payload":{"type":"agent_message","phase":"commentary","message":"working"}}
+{"type":"event_msg","payload":{"type":"agent_message","phase":"final_answer","message":"done from event"}}
+"#,
+        )
+        .unwrap();
+
+        let session = CodexProvider.parse_session_file(&path).unwrap();
+
+        assert_eq!(session.id.as_deref(), Some("abc"));
+        assert_eq!(session.blocks.len(), 2);
+        assert_eq!(session.blocks[0].kind, AgentBlockKind::User);
+        assert_eq!(session.blocks[0].text, "hello from event");
+        assert_eq!(session.blocks[1].kind, AgentBlockKind::Assistant);
+        assert_eq!(session.blocks[1].text, "done from event");
+    }
+
+    #[test]
+    fn response_items_remain_primary_over_event_messages() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"type":"session_meta","payload":{"id":"abc"}}
+{"type":"event_msg","payload":{"type":"user_message","message":"event user"}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"text":"response user"}]}}
+{"type":"event_msg","payload":{"type":"agent_message","phase":"final_answer","message":"event answer"}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"text":"response answer"}]}}
+"#,
+        )
+        .unwrap();
+
+        let session = CodexProvider.parse_session_file(&path).unwrap();
+
+        assert_eq!(session.blocks.len(), 2);
+        assert_eq!(session.blocks[0].text, "response user");
+        assert_eq!(session.blocks[1].text, "response answer");
     }
 }

--- a/crates/sivtr-core/src/codex.rs
+++ b/crates/sivtr-core/src/codex.rs
@@ -119,6 +119,10 @@ pub fn local_codex_sessions_dir() -> PathBuf {
 pub fn configured_codex_session_dirs() -> Vec<PathBuf> {
     let mut dirs = vec![local_codex_sessions_dir()];
 
+    if let Ok(config) = SivtrConfig::load() {
+        dirs.extend(config.codex.session_dirs);
+    }
+
     if let Ok(extra) = std::env::var("SIVTR_CODEX_SESSION_DIRS") {
         let separator = if cfg!(windows) { ';' } else { ':' };
         dirs.extend(
@@ -128,8 +132,6 @@ pub fn configured_codex_session_dirs() -> Vec<PathBuf> {
                 .filter(|entry| !entry.is_empty())
                 .map(PathBuf::from),
         );
-    } else if let Ok(config) = SivtrConfig::load() {
-        dirs.extend(config.codex.session_dirs);
     }
 
     dedup_paths(dirs)
@@ -347,7 +349,7 @@ mod tests {
         format_blocks, select_blocks, AgentBlockKind, AgentSelection, AgentSessionProvider,
     };
     use serde_json::json;
-    use std::{env, path::PathBuf, time::Duration};
+    use std::{env, fs, path::PathBuf, time::Duration};
 
     #[test]
     fn parses_codex_rollout_messages_and_tools() {
@@ -509,6 +511,48 @@ mod tests {
         assert_eq!(
             dirs.iter()
                 .filter(|path| *path == &PathBuf::from("/tmp/a"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn configured_codex_session_dirs_combines_env_and_config_entries() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_home = temp.path().join("config-home");
+        let config_dir = config_home.join("sivtr");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(
+            config_dir.join("config.toml"),
+            "[codex]\nsession_dirs = [\"/tmp/from-config\", \"/tmp/shared\"]\n",
+        )
+        .unwrap();
+
+        let previous_xdg_config_home = env::var_os("XDG_CONFIG_HOME");
+        let previous_extra_dirs = env::var_os("SIVTR_CODEX_SESSION_DIRS");
+        let separator = if cfg!(windows) { ";" } else { ":" };
+        env::set_var("XDG_CONFIG_HOME", &config_home);
+        env::set_var(
+            "SIVTR_CODEX_SESSION_DIRS",
+            format!("/tmp/from-env{separator}/tmp/shared"),
+        );
+
+        let dirs = configured_codex_session_dirs();
+
+        match previous_xdg_config_home {
+            Some(value) => env::set_var("XDG_CONFIG_HOME", value),
+            None => env::remove_var("XDG_CONFIG_HOME"),
+        }
+        match previous_extra_dirs {
+            Some(value) => env::set_var("SIVTR_CODEX_SESSION_DIRS", value),
+            None => env::remove_var("SIVTR_CODEX_SESSION_DIRS"),
+        }
+
+        assert!(dirs.contains(&PathBuf::from("/tmp/from-config")));
+        assert!(dirs.contains(&PathBuf::from("/tmp/from-env")));
+        assert_eq!(
+            dirs.iter()
+                .filter(|path| *path == &PathBuf::from("/tmp/shared"))
                 .count(),
             1
         );

--- a/crates/sivtr-core/src/codex.rs
+++ b/crates/sivtr-core/src/codex.rs
@@ -329,9 +329,11 @@ fn dedup_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
 mod tests {
     use super::{configured_codex_session_dirs, CodexProvider};
     use crate::ai::{
-        format_blocks, select_blocks, AgentBlockKind, AgentSelection, AgentSessionProvider,
+        format_blocks, normalize_path_for_match, select_blocks, AgentBlockKind, AgentSelection,
+        AgentSessionProvider,
     };
     use serde_json::json;
+    use std::path::Path;
     use std::{
         env, fs,
         path::PathBuf,
@@ -341,7 +343,22 @@ mod tests {
 
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn contains_path(dirs: &[PathBuf], expected: &str) -> bool {
+        let expected = normalize_path_for_match(Path::new(expected));
+        dirs.iter()
+            .any(|path| normalize_path_for_match(path) == expected)
+    }
+
+    fn count_path(dirs: &[PathBuf], expected: &str) -> usize {
+        let expected = normalize_path_for_match(Path::new(expected));
+        dirs.iter()
+            .filter(|path| normalize_path_for_match(path) == expected)
+            .count()
     }
 
     #[test]
@@ -501,14 +518,9 @@ mod tests {
             None => env::remove_var("SIVTR_CODEX_SESSION_DIRS"),
         }
 
-        assert!(dirs.contains(&PathBuf::from("/tmp/a")));
-        assert!(dirs.contains(&PathBuf::from("/tmp/b")));
-        assert_eq!(
-            dirs.iter()
-                .filter(|path| *path == &PathBuf::from("/tmp/a"))
-                .count(),
-            1
-        );
+        assert!(contains_path(&dirs, "/tmp/a"));
+        assert!(contains_path(&dirs, "/tmp/b"));
+        assert_eq!(count_path(&dirs, "/tmp/a"), 1);
     }
 
     #[test]
@@ -525,9 +537,13 @@ mod tests {
         .unwrap();
 
         let previous_xdg_config_home = env::var_os("XDG_CONFIG_HOME");
+        let previous_appdata = env::var_os("APPDATA");
         let previous_extra_dirs = env::var_os("SIVTR_CODEX_SESSION_DIRS");
         let separator = if cfg!(windows) { ";" } else { ":" };
         env::set_var("XDG_CONFIG_HOME", &config_home);
+        if cfg!(windows) {
+            env::set_var("APPDATA", &config_home);
+        }
         env::set_var(
             "SIVTR_CODEX_SESSION_DIRS",
             format!("/tmp/from-env{separator}/tmp/shared"),
@@ -539,19 +555,18 @@ mod tests {
             Some(value) => env::set_var("XDG_CONFIG_HOME", value),
             None => env::remove_var("XDG_CONFIG_HOME"),
         }
+        match previous_appdata {
+            Some(value) => env::set_var("APPDATA", value),
+            None => env::remove_var("APPDATA"),
+        }
         match previous_extra_dirs {
             Some(value) => env::set_var("SIVTR_CODEX_SESSION_DIRS", value),
             None => env::remove_var("SIVTR_CODEX_SESSION_DIRS"),
         }
 
-        assert!(dirs.contains(&PathBuf::from("/tmp/from-config")));
-        assert!(dirs.contains(&PathBuf::from("/tmp/from-env")));
-        assert_eq!(
-            dirs.iter()
-                .filter(|path| *path == &PathBuf::from("/tmp/shared"))
-                .count(),
-            1
-        );
+        assert!(contains_path(&dirs, "/tmp/from-config"));
+        assert!(contains_path(&dirs, "/tmp/from-env"));
+        assert_eq!(count_path(&dirs, "/tmp/shared"), 1);
     }
 
     #[test]

--- a/crates/sivtr-core/src/codex.rs
+++ b/crates/sivtr-core/src/codex.rs
@@ -432,7 +432,11 @@ mod tests {
     #[test]
     fn configured_codex_session_dirs_reads_env_override_once() {
         let previous = env::var_os("SIVTR_CODEX_SESSION_DIRS");
-        env::set_var("SIVTR_CODEX_SESSION_DIRS", "/tmp/a:/tmp/b:/tmp/a");
+        let separator = if cfg!(windows) { ";" } else { ":" };
+        env::set_var(
+            "SIVTR_CODEX_SESSION_DIRS",
+            format!("/tmp/a{separator}/tmp/b{separator}/tmp/a"),
+        );
 
         let dirs = configured_codex_session_dirs();
 

--- a/crates/sivtr-core/src/config/mod.rs
+++ b/crates/sivtr-core/src/config/mod.rs
@@ -16,6 +16,8 @@ pub struct SivtrConfig {
     pub history: HistoryConfig,
     /// Copy command settings.
     pub copy: CopyConfig,
+    /// Codex session settings.
+    pub codex: CodexConfig,
     /// Global hotkey settings.
     pub hotkey: HotkeyConfig,
 }
@@ -77,6 +79,14 @@ impl CopyConfig {
     pub fn prompt_values(&self) -> impl Iterator<Item = &String> {
         self.legacy_prompt_presets.iter().chain(self.prompts.iter())
     }
+}
+
+/// Codex session configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CodexConfig {
+    /// Additional directories that contain exported Codex session JSONL trees.
+    pub session_dirs: Vec<PathBuf>,
 }
 
 /// Global hotkey configuration.
@@ -218,5 +228,21 @@ mod tests {
 
         assert!(toml.contains("[hotkey]"));
         assert!(toml.contains("chord = \"alt+y\""));
+    }
+
+    #[test]
+    fn serializes_codex_config() {
+        let config = SivtrConfig {
+            codex: CodexConfig {
+                session_dirs: vec![PathBuf::from("/srv/sivtr/root-codex/sessions")],
+            },
+            ..SivtrConfig::default()
+        };
+
+        let toml = to_toml_string(&config).unwrap();
+
+        assert!(toml.contains("[codex]"));
+        assert!(toml.contains("session_dirs = ["));
+        assert!(toml.contains("/srv/sivtr/root-codex/sessions"));
     }
 }

--- a/docs-site/src/content/docs/reference/config-file.md
+++ b/docs-site/src/content/docs/reference/config-file.md
@@ -109,6 +109,8 @@ session_dirs = []
 | --- | --- | --- | --- |
 | `session_dirs` | string array | `[]` | Extra exported Codex `sessions` directories to browse with `copy codex --pick` |
 
+On macOS, a typical shared path is `/Users/Shared/sivtr/root-codex/sessions`.
+
 ## hotkey
 
 ```toml

--- a/docs-site/src/content/docs/reference/config-file.md
+++ b/docs-site/src/content/docs/reference/config-file.md
@@ -32,6 +32,9 @@ max_entries = 0
 [copy]
 prompts = ["PS C:\\repo> ", "dev>"]
 
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+
 [hotkey]
 chord = "alt+y"
 ```
@@ -94,6 +97,17 @@ prompts = []
 | `prompts` | string array | `[]` | Prompt profiles or literal prefixes used when detecting command lines |
 
 `prompt_presets` is a legacy field and is not serialized by the current config writer.
+
+## codex
+
+```toml
+[codex]
+session_dirs = []
+```
+
+| Key | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `session_dirs` | string array | `[]` | Extra exported Codex `sessions` directories to browse with `copy codex --pick` |
 
 ## hotkey
 

--- a/docs-site/src/content/docs/usage/codex-capture.md
+++ b/docs-site/src/content/docs/usage/codex-capture.md
@@ -105,6 +105,11 @@ sivtr codex export --dest /Users/Shared/sivtr/root-codex --watch
 session_dirs = ["/Users/Shared/sivtr/root-codex/sessions"]
 ```
 
+Quick one-line checks:
+
+- export side: `rm -rf /Users/Shared/sivtr/root-codex-smoke && sivtr codex export --dest /Users/Shared/sivtr/root-codex-smoke && find /Users/Shared/sivtr/root-codex-smoke -maxdepth 2 -type f | sed -n '1,5p'`
+- read side after configuring `[codex].session_dirs`: `sivtr copy codex --pick`
+
 ## Windows hotkey
 
 On Windows, the hotkey daemon opens the AI session picker for the project directory where it was started:

--- a/docs-site/src/content/docs/usage/codex-capture.md
+++ b/docs-site/src/content/docs/usage/codex-capture.md
@@ -93,6 +93,18 @@ Then consume it from another account:
 session_dirs = ["/srv/sivtr/root-codex/sessions"]
 ```
 
+On macOS, `/Users/Shared/sivtr/root-codex` is a good shared location between
+local accounts:
+
+```bash
+sivtr codex export --dest /Users/Shared/sivtr/root-codex --watch
+```
+
+```toml
+[codex]
+session_dirs = ["/Users/Shared/sivtr/root-codex/sessions"]
+```
+
 ## Windows hotkey
 
 On Windows, the hotkey daemon opens the AI session picker for the project directory where it was started:

--- a/docs-site/src/content/docs/usage/codex-capture.md
+++ b/docs-site/src/content/docs/usage/codex-capture.md
@@ -3,7 +3,9 @@ title: Codex Capture
 description: Copy useful blocks from the current Codex session.
 ---
 
-`sivtr copy codex` reads Codex rollout JSONL files from `~/.codex/sessions`. By default it chooses the newest session whose `cwd` matches the current working directory.
+`sivtr copy codex` reads Codex rollout JSONL files from `~/.codex/sessions`. If the current shell exports `CODEX_THREAD_ID`, `sivtr` prefers that exact local session first. Otherwise it chooses the newest local session whose `cwd` matches the current working directory.
+
+If another account publishes a read-only mirror with `sivtr codex export --dest ...`, add that mirrored `sessions` directory to `[codex].session_dirs` so explicit `--pick` browsing can read it without elevated privileges.
 
 Use `--session N` to select the Nth newest recorded session, or `--session ID` to match a session id / id prefix explicitly.
 
@@ -67,11 +69,29 @@ sivtr copy codex out --print
 sivtr copy codex --session 2 --pick
 sivtr copy codex --pick
 sivtr copy codex out --pick
+sivtr copy codex --pick  # includes mirrored session trees from [codex].session_dirs
 ```
 
 The plain CLI picker starts with the session list, then lets you choose one or more units from that session. Press `t` to open the Vim-style view. In Codex views, `T` toggles tool content when an alternate full view is available.
 
 Context-aware launchers such as the Windows hotkey and VS Code extension first open the newest non-empty session for the current workspace. If that session is missing or empty, they fall back to the session list.
+
+Shared/mirrored session trees only participate in explicit `--pick` browsing. Implicit current-session lookup stays local so another account's exported history does not override the current user's active Codex workflow.
+
+## Mirror sessions for another account
+
+Create a shared mirror from the source account:
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex --watch
+```
+
+Then consume it from another account:
+
+```toml
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+```
 
 ## Windows hotkey
 

--- a/docs-site/src/content/docs/usage/configuration.md
+++ b/docs-site/src/content/docs/usage/configuration.md
@@ -36,6 +36,9 @@ max_entries = 0
 [copy]
 prompts = []
 
+[codex]
+session_dirs = []
+
 [hotkey]
 chord = "alt+y"
 ```
@@ -62,3 +65,18 @@ prompts = ["dev>", "repo $", "PS C:\\repo>"]
 ```
 
 This helps command-block parsing identify the command input lines in session logs.
+
+## Shared Codex session trees
+
+Add shared exported session trees when another account publishes a read-only copy:
+
+```toml
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+```
+
+Create that shared tree from the source account with:
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex
+```

--- a/docs-site/src/content/docs/usage/configuration.md
+++ b/docs-site/src/content/docs/usage/configuration.md
@@ -80,3 +80,10 @@ Create that shared tree from the source account with:
 ```bash
 sivtr codex export --dest /srv/sivtr/root-codex
 ```
+
+On macOS, a shared path under `/Users/Shared` works well:
+
+```toml
+[codex]
+session_dirs = ["/Users/Shared/sivtr/root-codex/sessions"]
+```

--- a/docs-site/src/content/docs/zh-cn/reference/config-file.md
+++ b/docs-site/src/content/docs/zh-cn/reference/config-file.md
@@ -109,6 +109,8 @@ session_dirs = []
 | --- | --- | --- | --- |
 | `session_dirs` | string array | `[]` | 额外的导出 Codex `sessions` 目录，可供 `copy codex --pick` 浏览 |
 
+在 macOS 上，常见的共享路径可以是 `/Users/Shared/sivtr/root-codex/sessions`。
+
 ## hotkey
 
 ```toml

--- a/docs-site/src/content/docs/zh-cn/reference/config-file.md
+++ b/docs-site/src/content/docs/zh-cn/reference/config-file.md
@@ -32,6 +32,9 @@ max_entries = 0
 [copy]
 prompts = ["PS C:\\repo> ", "dev>"]
 
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+
 [hotkey]
 chord = "alt+y"
 ```
@@ -94,6 +97,17 @@ prompts = []
 | `prompts` | string array | `[]` | 检测命令行时使用的 prompt 配置或字面前缀 |
 
 `prompt_presets` 是旧字段，当前配置写入器不会序列化它。
+
+## codex
+
+```toml
+[codex]
+session_dirs = []
+```
+
+| 键 | 类型 | 默认值 | 含义 |
+| --- | --- | --- | --- |
+| `session_dirs` | string array | `[]` | 额外的导出 Codex `sessions` 目录，可供 `copy codex --pick` 浏览 |
 
 ## hotkey
 

--- a/docs-site/src/content/docs/zh-cn/usage/codex-capture.md
+++ b/docs-site/src/content/docs/zh-cn/usage/codex-capture.md
@@ -105,6 +105,11 @@ sivtr codex export --dest /Users/Shared/sivtr/root-codex --watch
 session_dirs = ["/Users/Shared/sivtr/root-codex/sessions"]
 ```
 
+可直接复制的一行验证命令：
+
+- 导出侧：`rm -rf /Users/Shared/sivtr/root-codex-smoke && sivtr codex export --dest /Users/Shared/sivtr/root-codex-smoke && find /Users/Shared/sivtr/root-codex-smoke -maxdepth 2 -type f | sed -n '1,5p'`
+- 读取侧（在 `[codex].session_dirs` 配好之后）：`sivtr copy codex --pick`
+
 ## Windows 热键
 
 在 Windows 上，热键守护进程会为启动它的项目目录打开 Codex 选择器：

--- a/docs-site/src/content/docs/zh-cn/usage/codex-capture.md
+++ b/docs-site/src/content/docs/zh-cn/usage/codex-capture.md
@@ -3,7 +3,9 @@ title: Codex 捕获
 description: 从当前 Codex 会话复制有用块。
 ---
 
-`sivtr copy codex` 会读取 `~/.codex/sessions` 下的 Codex rollout JSONL 文件。默认选择 `cwd` 与当前工作目录匹配的最新会话。
+`sivtr copy codex` 会读取 `~/.codex/sessions` 下的 Codex rollout JSONL 文件。如果当前 shell 暴露了 `CODEX_THREAD_ID`，`sivtr` 会优先匹配这个本地精确会话；否则默认选择 `cwd` 与当前工作目录匹配的最新本地会话。
+
+如果另一个账号先用 `sivtr codex export --dest ...` 发布了只读镜像，就把镜像后的 `sessions` 目录加入 `[codex].session_dirs`。这样显式 `--pick` 浏览就能在不提权的前提下读取它。
 
 用 `--session N` 可以显式选择第 N 新的已记录会话；用 `--session ID` 可以按会话 id 或 id 前缀匹配。
 
@@ -67,11 +69,29 @@ sivtr copy codex out --print
 sivtr copy codex --session 2 --pick
 sivtr copy codex --pick
 sivtr copy codex out --pick
+sivtr copy codex --pick  # 同时浏览 [codex].session_dirs 里的共享镜像会话
 ```
 
 普通 CLI 选择器会先显示会话列表，进入某个会话后再选择一个或多个单元。按 `t` 打开 Vim 风格视图。在 Codex 视图里，如果存在替代完整视图，`T` 可以切换工具内容。
 
 Windows 热键和 VS Code 插件这类带上下文的入口会先打开当前 workspace 下最新的非空会话。如果这个会话不存在或为空，再退回到会话列表。
+
+共享/镜像会话树只参与显式 `--pick` 浏览。隐式“当前会话”解析仍然只看本地会话，避免另一个账号导出的历史抢占当前用户的 Codex 工作流。
+
+## 为另一个账号镜像会话
+
+先在源账号侧持续发布镜像树：
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex --watch
+```
+
+再在另一个账号的配置里引用镜像目录：
+
+```toml
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+```
 
 ## Windows 热键
 

--- a/docs-site/src/content/docs/zh-cn/usage/codex-capture.md
+++ b/docs-site/src/content/docs/zh-cn/usage/codex-capture.md
@@ -93,6 +93,18 @@ sivtr codex export --dest /srv/sivtr/root-codex --watch
 session_dirs = ["/srv/sivtr/root-codex/sessions"]
 ```
 
+在 macOS 上，`/Users/Shared/sivtr/root-codex` 很适合作为不同本地账号之间
+共享的只读目录：
+
+```bash
+sivtr codex export --dest /Users/Shared/sivtr/root-codex --watch
+```
+
+```toml
+[codex]
+session_dirs = ["/Users/Shared/sivtr/root-codex/sessions"]
+```
+
 ## Windows 热键
 
 在 Windows 上，热键守护进程会为启动它的项目目录打开 Codex 选择器：

--- a/docs-site/src/content/docs/zh-cn/usage/configuration.md
+++ b/docs-site/src/content/docs/zh-cn/usage/configuration.md
@@ -80,3 +80,10 @@ session_dirs = ["/srv/sivtr/root-codex/sessions"]
 ```bash
 sivtr codex export --dest /srv/sivtr/root-codex
 ```
+
+在 macOS 上，推荐把共享目录放在 `/Users/Shared` 下：
+
+```toml
+[codex]
+session_dirs = ["/Users/Shared/sivtr/root-codex/sessions"]
+```

--- a/docs-site/src/content/docs/zh-cn/usage/configuration.md
+++ b/docs-site/src/content/docs/zh-cn/usage/configuration.md
@@ -36,6 +36,9 @@ max_entries = 0
 [copy]
 prompts = []
 
+[codex]
+session_dirs = []
+
 [hotkey]
 chord = "alt+y"
 ```
@@ -62,3 +65,18 @@ prompts = ["dev>", "repo $", "PS C:\\repo>"]
 ```
 
 这有助于命令块解析识别会话日志里的命令输入行。
+
+## 共享 Codex 会话树
+
+当另一个账号发布了只读副本时，可以把共享导出的会话树加入配置：
+
+```toml
+[codex]
+session_dirs = ["/srv/sivtr/root-codex/sessions"]
+```
+
+源账号可以这样创建共享树：
+
+```bash
+sivtr codex export --dest /srv/sivtr/root-codex
+```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -457,13 +457,17 @@ pub struct HotkeyServeArgs {
 
 #[derive(Args, Debug, Clone)]
 pub struct HotkeyPickAgentArgs {
-    /// Working directory used to resolve current AI sessions
+    /// Working directory used for launching the picker process
     #[arg(long, value_name = "PATH")]
     pub cwd: PathBuf,
 
     /// AI provider sessions to show
     #[arg(long, default_value_t = HotkeyProviderSelection::default(), value_name = "PROVIDER")]
     pub provider: HotkeyProviderSelection,
+
+    /// Restrict the picker to sessions whose cwd matches `--cwd`
+    #[arg(long, default_value_t = false)]
+    pub current_session: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -817,6 +821,27 @@ mod tests {
             Some(Commands::HotkeyPickAgent(args)) => {
                 assert_eq!(args.cwd, PathBuf::from("."));
                 assert_eq!(args.provider, HotkeyProviderSelection::default());
+                assert!(!args.current_session);
+            }
+            _ => panic!("expected hotkey-pick-agent command"),
+        }
+    }
+
+    #[test]
+    fn hotkey_pick_agent_accepts_current_session_flag() {
+        let cli = Cli::try_parse_from([
+            "sivtr",
+            "hotkey-pick-agent",
+            "--cwd",
+            ".",
+            "--current-session",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::HotkeyPickAgent(args)) => {
+                assert_eq!(args.cwd, PathBuf::from("."));
+                assert!(args.current_session);
             }
             _ => panic!("expected hotkey-pick-agent command"),
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -585,8 +585,12 @@ pub struct CodexExportArgs {
     pub watch: bool,
 
     /// Seconds between sync passes when `--watch` is enabled
-    #[arg(long, value_name = "SECONDS", default_value_t = 2, requires = "watch")]
+    #[arg(long, value_name = "SECONDS", default_value_t = 1, requires = "watch")]
     pub interval: u64,
+
+    /// Milliseconds between sync passes when `--watch` is enabled (overrides `--interval`)
+    #[arg(long, value_name = "MILLISECONDS", requires = "watch")]
+    pub interval_ms: Option<u64>,
 }
 
 #[cfg(test)]
@@ -841,6 +845,34 @@ mod tests {
                     assert_eq!(args.limit, 5);
                     assert!(args.watch);
                     assert_eq!(args.interval, 3);
+                    assert_eq!(args.interval_ms, None);
+                }
+            },
+            _ => panic!("expected codex export command"),
+        }
+    }
+
+    #[test]
+    fn codex_export_accepts_millisecond_interval() {
+        let cli = Cli::try_parse_from([
+            "sivtr",
+            "codex",
+            "export",
+            "--dest",
+            "/tmp/shared-codex",
+            "--watch",
+            "--interval-ms",
+            "250",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::Codex(cmd)) => match cmd.action {
+                CodexAction::Export(args) => {
+                    assert_eq!(args.dest, PathBuf::from("/tmp/shared-codex"));
+                    assert!(args.watch);
+                    assert_eq!(args.interval, 1);
+                    assert_eq!(args.interval_ms, Some(250));
                 }
             },
             _ => panic!("expected codex export command"),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -264,6 +264,9 @@ pub enum Commands {
     #[command(after_help = HOTKEY_AFTER_HELP)]
     Hotkey(HotkeyCommand),
 
+    /// Export local Codex session files into a shared read-only tree
+    Codex(CodexCommand),
+
     /// Clear session logs
     Clear(ClearArgs),
 
@@ -555,6 +558,37 @@ pub enum AgentCopyMode {
     All(AgentCopyArgs),
 }
 
+#[derive(Parser, Debug)]
+pub struct CodexCommand {
+    #[command(subcommand)]
+    pub action: CodexAction,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum CodexAction {
+    /// Export local Codex rollout JSONL files into a target directory
+    Export(CodexExportArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct CodexExportArgs {
+    /// Destination directory that will receive a sessions/ tree copy
+    #[arg(long, value_name = "PATH")]
+    pub dest: PathBuf,
+
+    /// Keep only the newest N session files; `0` means export all
+    #[arg(long, value_name = "N", default_value_t = 0)]
+    pub limit: usize,
+
+    /// Continue mirroring local sessions into the destination tree
+    #[arg(long, default_value_t = false)]
+    pub watch: bool,
+
+    /// Seconds between sync passes when `--watch` is enabled
+    #[arg(long, value_name = "SECONDS", default_value_t = 2, requires = "watch")]
+    pub interval: u64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -781,6 +815,35 @@ mod tests {
                 assert_eq!(args.provider, HotkeyProviderSelection::default());
             }
             _ => panic!("expected hotkey-pick-agent command"),
+        }
+    }
+
+    #[test]
+    fn codex_export_accepts_destination_and_watch_flags() {
+        let cli = Cli::try_parse_from([
+            "sivtr",
+            "codex",
+            "export",
+            "--dest",
+            "/tmp/shared-codex",
+            "--limit",
+            "5",
+            "--watch",
+            "--interval",
+            "3",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::Codex(cmd)) => match cmd.action {
+                CodexAction::Export(args) => {
+                    assert_eq!(args.dest, PathBuf::from("/tmp/shared-codex"));
+                    assert_eq!(args.limit, 5);
+                    assert!(args.watch);
+                    assert_eq!(args.interval, 3);
+                }
+            },
+            _ => panic!("expected codex export command"),
         }
     }
 

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -162,16 +162,18 @@ fn remove_stale_exported_files_inner(
     Ok(())
 }
 
+#[cfg(unix)]
 fn set_shared_read_permissions(path: &Path) -> Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
+    use std::os::unix::fs::PermissionsExt;
 
-        let mode = if path.is_dir() { 0o755 } else { 0o644 };
-        fs::set_permissions(path, fs::Permissions::from_mode(mode))
-            .with_context(|| format!("Failed to chmod {}", path.display()))?;
-    }
+    let mode = if path.is_dir() { 0o755 } else { 0o644 };
+    fs::set_permissions(path, fs::Permissions::from_mode(mode))
+        .with_context(|| format!("Failed to chmod {}", path.display()))?;
+    Ok(())
+}
 
+#[cfg(not(unix))]
+fn set_shared_read_permissions(_path: &Path) -> Result<()> {
     Ok(())
 }
 
@@ -193,10 +195,10 @@ fn set_shared_read_permissions_recursive(root: &Path, path: &Path) -> Result<()>
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        collect_session_files, copy_session_file_atomically, export_once,
-        set_shared_read_permissions_recursive,
-    };
+    #[cfg(unix)]
+    use super::set_shared_read_permissions_recursive;
+    use super::{collect_session_files, copy_session_file_atomically, export_once};
+    #[cfg(unix)]
     use std::path::Path;
 
     #[test]

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -68,7 +68,9 @@ fn export_once(source_root: &Path, target_root: &Path, limit: usize) -> Result<u
 
     let mut kept = HashSet::new();
     let mut seen_dirs = HashSet::new();
-    for source in &files {
+    // Copy oldest -> newest so exported mtimes preserve true recency.
+    // Copying newest first would make older files appear newer in the shared tree.
+    for source in files.iter().rev() {
         let relative = source
             .strip_prefix(source_root)
             .with_context(|| format!("Failed to relativize {}", source.display()))?;
@@ -344,6 +346,36 @@ mod tests {
 
         assert!(target_root.join("2026/05/08/newest.jsonl").exists());
         assert!(!target_root.join("2026/05/08/older.jsonl").exists());
+    }
+
+    #[test]
+    fn export_once_preserves_newest_order_in_target_tree() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_root = dir.path().join("source");
+        let target_root = dir.path().join("target").join("sessions");
+        let nested = source_root.join("2026/05/08");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let older = nested.join("older.jsonl");
+        let newer = nested.join("newer.jsonl");
+        std::fs::write(&older, "{\"type\":\"session_meta\",\"payload\":{\"id\":\"older\"}}\n")
+            .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        std::fs::write(&newer, "{\"type\":\"session_meta\",\"payload\":{\"id\":\"newer\"}}\n")
+            .unwrap();
+
+        export_once(&source_root, &target_root, 0).unwrap();
+
+        let exported = collect_session_files(&target_root, 0).unwrap();
+        assert_eq!(exported.len(), 2);
+        assert_eq!(
+            exported[0].file_name().and_then(|name| name.to_str()),
+            Some("newer.jsonl")
+        );
+        assert_eq!(
+            exported[1].file_name().and_then(|name| name.to_str()),
+            Some("older.jsonl")
+        );
     }
 
     #[test]

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -380,11 +380,17 @@ mod tests {
 
         let older = nested.join("older.jsonl");
         let newer = nested.join("newer.jsonl");
-        std::fs::write(&older, "{\"type\":\"session_meta\",\"payload\":{\"id\":\"older\"}}\n")
-            .unwrap();
+        std::fs::write(
+            &older,
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"older\"}}\n",
+        )
+        .unwrap();
         std::thread::sleep(std::time::Duration::from_millis(5));
-        std::fs::write(&newer, "{\"type\":\"session_meta\",\"payload\":{\"id\":\"newer\"}}\n")
-            .unwrap();
+        std::fs::write(
+            &newer,
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"newer\"}}\n",
+        )
+        .unwrap();
 
         export_once(&source_root, &target_root, 0).unwrap();
 

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -49,6 +49,7 @@ fn export_once(source_root: &Path, target_root: &Path, limit: usize) -> Result<u
     set_shared_read_permissions(target_root)?;
 
     let mut kept = HashSet::new();
+    let mut seen_dirs = HashSet::new();
     for source in &files {
         let relative = source
             .strip_prefix(source_root)
@@ -57,14 +58,16 @@ fn export_once(source_root: &Path, target_root: &Path, limit: usize) -> Result<u
 
         let target = target_root.join(relative);
         if let Some(parent) = target.parent() {
-            fs::create_dir_all(parent)
-                .with_context(|| format!("Failed to create {}", parent.display()))?;
-            set_shared_read_permissions_recursive(target_root, parent)?;
+            if seen_dirs.insert(parent.to_path_buf()) {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("Failed to create {}", parent.display()))?;
+                set_shared_read_permissions_recursive(target_root, parent)?;
+            }
         }
         copy_session_file_atomically(source, &target)?;
     }
 
-    remove_stale_exported_files(target_root, &kept)?;
+    remove_stale_exported_files(target_root, &kept);
     Ok(files.len())
 }
 
@@ -121,27 +124,62 @@ fn copy_session_file_atomically(source: &Path, target: &Path) -> Result<()> {
     Ok(())
 }
 
-fn remove_stale_exported_files(root: &Path, kept: &HashSet<PathBuf>) -> Result<()> {
+fn remove_stale_exported_files(root: &Path, kept: &HashSet<PathBuf>) {
     if !root.exists() {
-        return Ok(());
+        return;
     }
 
-    remove_stale_exported_files_inner(root, root, kept)
+    remove_stale_exported_files_inner(root, root, kept);
 }
 
-fn remove_stale_exported_files_inner(
-    root: &Path,
-    dir: &Path,
-    kept: &HashSet<PathBuf>,
-) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("Failed to read {}", dir.display()))? {
-        let entry = entry?;
+fn remove_stale_exported_files_inner(root: &Path, dir: &Path, kept: &HashSet<PathBuf>) {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) => {
+            eprintln!(
+                "sivtr: warning: failed to read {} during stale export cleanup: {}",
+                dir.display(),
+                err
+            );
+            return;
+        }
+    };
+
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) => {
+                eprintln!(
+                    "sivtr: warning: failed to inspect an entry under {}: {}",
+                    dir.display(),
+                    err
+                );
+                continue;
+            }
+        };
         let path = entry.path();
         if path.is_dir() {
-            remove_stale_exported_files_inner(root, &path, kept)?;
-            if fs::read_dir(&path)?.next().is_none() {
-                fs::remove_dir(&path)
-                    .with_context(|| format!("Failed to remove {}", path.display()))?;
+            remove_stale_exported_files_inner(root, &path, kept);
+
+            match fs::read_dir(&path) {
+                Ok(mut children) => {
+                    if children.next().is_none() {
+                        if let Err(err) = fs::remove_dir(&path) {
+                            eprintln!(
+                                "sivtr: warning: failed to remove empty export directory {}: {}",
+                                path.display(),
+                                err
+                            );
+                        }
+                    }
+                }
+                Err(err) => {
+                    eprintln!(
+                        "sivtr: warning: failed to re-read {} for cleanup: {}",
+                        path.display(),
+                        err
+                    );
+                }
             }
             continue;
         }
@@ -150,16 +188,27 @@ fn remove_stale_exported_files_inner(
             continue;
         }
 
-        let relative = path
-            .strip_prefix(root)
-            .with_context(|| format!("Failed to relativize {}", path.display()))?;
+        let relative = match path.strip_prefix(root) {
+            Ok(relative) => relative,
+            Err(err) => {
+                eprintln!(
+                    "sivtr: warning: failed to relativize {}: {}",
+                    path.display(),
+                    err
+                );
+                continue;
+            }
+        };
         if !kept.contains(relative) {
-            fs::remove_file(&path)
-                .with_context(|| format!("Failed to remove stale export {}", path.display()))?;
+            if let Err(err) = fs::remove_file(&path) {
+                eprintln!(
+                    "sivtr: warning: failed to remove stale export {}: {}",
+                    path.display(),
+                    err
+                );
+            }
         }
     }
-
-    Ok(())
 }
 
 #[cfg(unix)]

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -21,6 +21,10 @@ fn export(args: CodexExportArgs) -> Result<()> {
     }
 
     let target_root = args.dest.join("sessions");
+    let watch_interval = args
+        .watch
+        .then(|| resolve_watch_interval(&args))
+        .transpose()?;
 
     loop {
         let copied = export_once(&source_root, &target_root, args.limit)?;
@@ -30,12 +34,26 @@ fn export(args: CodexExportArgs) -> Result<()> {
             target_root.display()
         );
 
-        if !args.watch {
+        let Some(watch_interval) = watch_interval else {
             return Ok(());
-        }
-
-        thread::sleep(Duration::from_secs(args.interval));
+        };
+        thread::sleep(watch_interval);
     }
+}
+
+fn resolve_watch_interval(args: &CodexExportArgs) -> Result<Duration> {
+    if let Some(interval_ms) = args.interval_ms {
+        if interval_ms == 0 {
+            anyhow::bail!("`--interval-ms` must be greater than 0 when `--watch` is enabled");
+        }
+        return Ok(Duration::from_millis(interval_ms));
+    }
+
+    if args.interval == 0 {
+        anyhow::bail!("`--interval` must be greater than 0 when `--watch` is enabled");
+    }
+
+    Ok(Duration::from_secs(args.interval))
 }
 
 fn export_once(source_root: &Path, target_root: &Path, limit: usize) -> Result<usize> {
@@ -246,9 +264,14 @@ fn set_shared_read_permissions_recursive(root: &Path, path: &Path) -> Result<()>
 mod tests {
     #[cfg(unix)]
     use super::set_shared_read_permissions_recursive;
-    use super::{collect_session_files, copy_session_file_atomically, export_once};
+    use super::{
+        collect_session_files, copy_session_file_atomically, export_once, resolve_watch_interval,
+    };
+    use crate::cli::CodexExportArgs;
     #[cfg(unix)]
     use std::path::Path;
+    use std::path::PathBuf;
+    use std::time::Duration;
 
     #[test]
     fn collect_session_files_sorts_newest_first() {
@@ -342,5 +365,65 @@ mod tests {
 
         assert_eq!(std::fs::read_to_string(&target).unwrap(), "new data\n");
         assert!(!dir.path().join("target.jsonl.tmp").exists());
+    }
+
+    #[test]
+    fn resolve_watch_interval_defaults_to_seconds() {
+        let args = CodexExportArgs {
+            dest: PathBuf::from("/tmp/shared-codex"),
+            limit: 0,
+            watch: true,
+            interval: 2,
+            interval_ms: None,
+        };
+
+        let interval = resolve_watch_interval(&args).unwrap();
+        assert_eq!(interval, Duration::from_secs(2));
+    }
+
+    #[test]
+    fn resolve_watch_interval_prefers_milliseconds_override() {
+        let args = CodexExportArgs {
+            dest: PathBuf::from("/tmp/shared-codex"),
+            limit: 0,
+            watch: true,
+            interval: 10,
+            interval_ms: Some(250),
+        };
+
+        let interval = resolve_watch_interval(&args).unwrap();
+        assert_eq!(interval, Duration::from_millis(250));
+    }
+
+    #[test]
+    fn resolve_watch_interval_rejects_zero_seconds() {
+        let args = CodexExportArgs {
+            dest: PathBuf::from("/tmp/shared-codex"),
+            limit: 0,
+            watch: true,
+            interval: 0,
+            interval_ms: None,
+        };
+
+        let error = resolve_watch_interval(&args).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("`--interval` must be greater than 0"));
+    }
+
+    #[test]
+    fn resolve_watch_interval_rejects_zero_milliseconds() {
+        let args = CodexExportArgs {
+            dest: PathBuf::from("/tmp/shared-codex"),
+            limit: 0,
+            watch: true,
+            interval: 1,
+            interval_ms: Some(0),
+        };
+
+        let error = resolve_watch_interval(&args).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("`--interval-ms` must be greater than 0"));
     }
 }

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -131,14 +131,7 @@ fn copy_session_file_atomically(source: &Path, target: &Path) -> Result<()> {
         )
     })?;
     set_shared_read_permissions(&temp)?;
-
-    if target.exists() {
-        fs::remove_file(target)
-            .with_context(|| format!("Failed to replace {}", target.display()))?;
-    }
-
     fs::rename(&temp, target).with_context(|| format!("Failed to publish {}", target.display()))?;
-    set_shared_read_permissions(target)?;
     Ok(())
 }
 

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -1,0 +1,295 @@
+use crate::cli::{CodexAction, CodexCommand, CodexExportArgs};
+use anyhow::{Context, Result};
+use sivtr_core::codex::local_codex_sessions_dir;
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
+use std::time::SystemTime;
+
+pub fn execute(command: CodexCommand) -> Result<()> {
+    match command.action {
+        CodexAction::Export(args) => export(args),
+    }
+}
+
+fn export(args: CodexExportArgs) -> Result<()> {
+    let source_root = local_codex_sessions_dir();
+    if !source_root.exists() {
+        anyhow::bail!("No local Codex sessions found at {}", source_root.display());
+    }
+
+    let target_root = args.dest.join("sessions");
+
+    loop {
+        let copied = export_once(&source_root, &target_root, args.limit)?;
+        eprintln!(
+            "sivtr: mirrored {} Codex session file(s) to {}",
+            copied,
+            target_root.display()
+        );
+
+        if !args.watch {
+            return Ok(());
+        }
+
+        thread::sleep(Duration::from_secs(args.interval));
+    }
+}
+
+fn export_once(source_root: &Path, target_root: &Path, limit: usize) -> Result<usize> {
+    let files = collect_session_files(source_root, limit)?;
+    if files.is_empty() {
+        anyhow::bail!("No local Codex sessions found at {}", source_root.display());
+    }
+
+    fs::create_dir_all(target_root)
+        .with_context(|| format!("Failed to create {}", target_root.display()))?;
+    set_shared_read_permissions(target_root)?;
+
+    let mut kept = HashSet::new();
+    for source in &files {
+        let relative = source
+            .strip_prefix(source_root)
+            .with_context(|| format!("Failed to relativize {}", source.display()))?;
+        kept.insert(relative.to_path_buf());
+
+        let target = target_root.join(relative);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create {}", parent.display()))?;
+            set_shared_read_permissions_recursive(target_root, parent)?;
+        }
+        copy_session_file_atomically(source, &target)?;
+    }
+
+    remove_stale_exported_files(target_root, &kept)?;
+    Ok(files.len())
+}
+
+fn collect_session_files(root: &Path, limit: usize) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    collect_jsonl_files(root, &mut files)?;
+    files.sort_by_key(|path| modified_time(path).unwrap_or(SystemTime::UNIX_EPOCH));
+    files.reverse();
+    if limit > 0 {
+        files.truncate(limit);
+    }
+    Ok(files)
+}
+
+fn collect_jsonl_files(root: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(root).with_context(|| format!("Failed to read {}", root.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_jsonl_files(&path, files)?;
+        } else if path.extension().and_then(|ext| ext.to_str()) == Some("jsonl") {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn modified_time(path: &Path) -> Result<SystemTime> {
+    Ok(fs::metadata(path)?.modified()?)
+}
+
+fn copy_session_file_atomically(source: &Path, target: &Path) -> Result<()> {
+    let temp = target.with_extension("jsonl.tmp");
+    if temp.exists() {
+        fs::remove_file(&temp).with_context(|| format!("Failed to remove {}", temp.display()))?;
+    }
+
+    fs::copy(source, &temp).with_context(|| {
+        format!(
+            "Failed to copy Codex session from {} to {}",
+            source.display(),
+            temp.display()
+        )
+    })?;
+    set_shared_read_permissions(&temp)?;
+
+    if target.exists() {
+        fs::remove_file(target)
+            .with_context(|| format!("Failed to replace {}", target.display()))?;
+    }
+
+    fs::rename(&temp, target).with_context(|| format!("Failed to publish {}", target.display()))?;
+    set_shared_read_permissions(target)?;
+    Ok(())
+}
+
+fn remove_stale_exported_files(root: &Path, kept: &HashSet<PathBuf>) -> Result<()> {
+    if !root.exists() {
+        return Ok(());
+    }
+
+    remove_stale_exported_files_inner(root, root, kept)
+}
+
+fn remove_stale_exported_files_inner(
+    root: &Path,
+    dir: &Path,
+    kept: &HashSet<PathBuf>,
+) -> Result<()> {
+    for entry in fs::read_dir(dir).with_context(|| format!("Failed to read {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            remove_stale_exported_files_inner(root, &path, kept)?;
+            if fs::read_dir(&path)?.next().is_none() {
+                fs::remove_dir(&path)
+                    .with_context(|| format!("Failed to remove {}", path.display()))?;
+            }
+            continue;
+        }
+
+        if path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
+            continue;
+        }
+
+        let relative = path
+            .strip_prefix(root)
+            .with_context(|| format!("Failed to relativize {}", path.display()))?;
+        if !kept.contains(relative) {
+            fs::remove_file(&path)
+                .with_context(|| format!("Failed to remove stale export {}", path.display()))?;
+        }
+    }
+
+    Ok(())
+}
+
+fn set_shared_read_permissions(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mode = if path.is_dir() { 0o755 } else { 0o644 };
+        fs::set_permissions(path, fs::Permissions::from_mode(mode))
+            .with_context(|| format!("Failed to chmod {}", path.display()))?;
+    }
+
+    Ok(())
+}
+
+fn set_shared_read_permissions_recursive(root: &Path, path: &Path) -> Result<()> {
+    let relative = path
+        .strip_prefix(root)
+        .with_context(|| format!("Failed to relativize {}", path.display()))?;
+
+    let mut current = root.to_path_buf();
+    set_shared_read_permissions(&current)?;
+
+    for component in relative.components() {
+        current.push(component.as_os_str());
+        set_shared_read_permissions(&current)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        collect_session_files, copy_session_file_atomically, export_once,
+        set_shared_read_permissions_recursive,
+    };
+    use std::path::Path;
+
+    #[test]
+    fn collect_session_files_sorts_newest_first() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("a.jsonl");
+        let second = dir.path().join("b.jsonl");
+        std::fs::write(&first, "{}\n").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        std::fs::write(&second, "{}\n").unwrap();
+
+        let files = collect_session_files(dir.path(), 0).unwrap();
+
+        assert_eq!(files, vec![second, first]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn shared_permissions_are_applied_to_nested_export_directories() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("sessions");
+        let nested = root.join(Path::new("2026/05/07"));
+        std::fs::create_dir_all(&nested).unwrap();
+
+        set_shared_read_permissions_recursive(&root, &nested).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&root).unwrap().permissions().mode() & 0o777,
+            0o755
+        );
+        assert_eq!(
+            std::fs::metadata(root.join("2026"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o755
+        );
+        assert_eq!(
+            std::fs::metadata(root.join("2026/05"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o755
+        );
+        assert_eq!(
+            std::fs::metadata(&nested).unwrap().permissions().mode() & 0o777,
+            0o755
+        );
+    }
+
+    #[test]
+    fn export_once_removes_stale_files_outside_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_root = dir.path().join("source");
+        let target_root = dir.path().join("target").join("sessions");
+        let nested = source_root.join("2026/05/08");
+        std::fs::create_dir_all(&nested).unwrap();
+
+        let newest = nested.join("newest.jsonl");
+        let older = nested.join("older.jsonl");
+        std::fs::write(
+            &older,
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"older\"}}\n",
+        )
+        .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        std::fs::write(
+            &newest,
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"newest\"}}\n",
+        )
+        .unwrap();
+
+        export_once(&source_root, &target_root, 1).unwrap();
+
+        assert!(target_root.join("2026/05/08/newest.jsonl").exists());
+        assert!(!target_root.join("2026/05/08/older.jsonl").exists());
+    }
+
+    #[test]
+    fn atomic_copy_replaces_existing_file_contents() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.jsonl");
+        let target = dir.path().join("target.jsonl");
+        std::fs::write(&source, "new data\n").unwrap();
+        std::fs::write(&target, "old data\n").unwrap();
+
+        copy_session_file_atomically(&source, &target).unwrap();
+
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "new data\n");
+        assert!(!dir.path().join("target.jsonl.tmp").exists());
+    }
+}

--- a/src/commands/codex.rs
+++ b/src/commands/codex.rs
@@ -134,7 +134,29 @@ fn copy_session_file_atomically(source: &Path, target: &Path) -> Result<()> {
     })?;
     set_shared_read_permissions(&temp)?;
     fs::rename(&temp, target).with_context(|| format!("Failed to publish {}", target.display()))?;
+    preserve_source_modified_time(source, target);
     Ok(())
+}
+
+fn preserve_source_modified_time(source: &Path, target: &Path) {
+    let modified = match fs::metadata(source).and_then(|metadata| metadata.modified()) {
+        Ok(modified) => modified,
+        Err(_) => return,
+    };
+
+    let file = match fs::OpenOptions::new().write(true).open(target) {
+        Ok(file) => file,
+        Err(_) => return,
+    };
+
+    if let Err(error) = file.set_times(fs::FileTimes::new().set_modified(modified)) {
+        eprintln!(
+            "sivtr: warning: failed to preserve mtime from {} to {}: {}",
+            source.display(),
+            target.display(),
+            error
+        );
+    }
 }
 
 fn remove_stale_exported_files(root: &Path, kept: &HashSet<PathBuf>) {

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -25,7 +25,7 @@ use crate::tui::terminal::{init as init_tui, restore as restore_tui};
 use picker::{run_picker, run_single_picker, PickEntry};
 
 pub(crate) const PICK_CANCELLED_MESSAGE: &str = "Pick cancelled";
-const PICK_LIMIT: usize = 50;
+const COMMAND_PICK_LIMIT: usize = 50;
 const PICK_PREVIEW_LINES: usize = 8;
 
 pub(crate) fn is_pick_cancelled(error: &anyhow::Error) -> bool {
@@ -410,7 +410,6 @@ fn pick_agent_sessions_content_on_terminal(
         )?);
     }
     choices.sort_by(|a, b| b.modified.cmp(&a.modified));
-    choices.truncate(PICK_LIMIT);
 
     if choices.is_empty() {
         anyhow::bail!("No AI sessions with selectable content found");
@@ -464,7 +463,6 @@ fn build_current_agent_session_choices(
     }
 
     choices.sort_by(|a, b| b.modified.cmp(&a.modified));
-    choices.truncate(PICK_LIMIT);
     Ok(choices)
 }
 
@@ -544,7 +542,7 @@ fn build_agent_session_choices(
 ) -> Result<Vec<AgentSessionChoice>> {
     let mut choices = Vec::new();
 
-    for info in sessions.iter().take(PICK_LIMIT) {
+    for info in sessions {
         let session = source.parse_session_file(&info.path)?;
         if let Some(choice) = build_agent_session_choice(source, info, session, selection_mode) {
             choices.push(choice);
@@ -573,7 +571,6 @@ fn build_agent_session_choice(
     let dialogue_titles = units
         .iter()
         .rev()
-        .take(PICK_LIMIT)
         .map(|unit| build_text_preview(&unit.plain))
         .collect();
 
@@ -1219,7 +1216,7 @@ fn render_prompt_override(prompt: &str, command: &str) -> String {
 
 fn pick_selection(blocks: &[IndexedCommandBlock]) -> Result<CommandSelection> {
     let total = blocks.len();
-    let shown = total.min(PICK_LIMIT);
+    let shown = total.min(COMMAND_PICK_LIMIT);
     let entries: Vec<PickEntry> = blocks
         .iter()
         .rev()
@@ -1530,7 +1527,6 @@ fn build_agent_session_pick_entries(
 ) -> Result<Vec<PickEntry>> {
     sessions
         .iter()
-        .take(PICK_LIMIT)
         .enumerate()
         .map(|(idx, session)| build_agent_session_pick_entry(source, idx, session))
         .collect()
@@ -1912,7 +1908,6 @@ fn build_text_pick_entries(units: &[TextPair]) -> Vec<PickEntry> {
     units
         .iter()
         .rev()
-        .take(PICK_LIMIT)
         .enumerate()
         .map(|(offset, unit)| PickEntry {
             recent: offset + 1,
@@ -2644,6 +2639,47 @@ mod tests {
         assert_eq!(choices.len(), 2);
         assert_eq!(choices[0].title, "[Codex] new task  [new]");
         assert_eq!(choices[1].title, "[Codex] old task  [old]");
+    }
+
+    #[test]
+    fn current_agent_picker_does_not_truncate_large_session_lists() {
+        let cwd = PathBuf::from("d:\\repo");
+        let infos = (0..60)
+            .map(|idx| AgentSessionInfo {
+                path: PathBuf::from(format!("session-{idx}.jsonl")),
+                id: Some(format!("s{idx}")),
+                cwd: Some(cwd.display().to_string()),
+                modified: SystemTime::UNIX_EPOCH + Duration::from_secs((idx + 1) as u64),
+            })
+            .collect();
+        let source = FakeAgentSource {
+            require_cwd: true,
+            infos,
+        };
+        let sources: Vec<Box<dyn AgentSessionProvider>> = vec![Box::new(source)];
+
+        let choices =
+            build_current_agent_session_choices(&sources, &cwd, AgentSelection::LastTurn).unwrap();
+
+        assert_eq!(choices.len(), 60);
+        assert_eq!(choices[0].title, "[Codex] session-59 task  [session-]");
+        assert_eq!(choices[59].title, "[Codex] session-0 task  [session-]");
+    }
+
+    #[test]
+    fn agent_text_picker_entries_include_all_units() {
+        let units = (0..75)
+            .map(|idx| TextPair {
+                plain: format!("unit {idx}"),
+                ansi: String::new(),
+            })
+            .collect::<Vec<_>>();
+
+        let entries = super::build_text_pick_entries(&units);
+
+        assert_eq!(entries.len(), 75);
+        assert_eq!(entries[0].preview, "unit 74");
+        assert_eq!(entries[74].preview, "unit 0");
     }
 
     #[test]

--- a/src/commands/hotkey.rs
+++ b/src/commands/hotkey.rs
@@ -59,7 +59,7 @@ pub fn pick_agent(args: &HotkeyPickAgentArgs) -> Result<()> {
         let providers = args.provider.providers();
         copy::execute_agent_picker(AgentPickerRequest {
             providers: &providers,
-            pick_current_session: true,
+            pick_current_session: args.current_session,
             selection_mode: AgentSelection::LastTurn,
             print_full: false,
             regex: None,
@@ -475,6 +475,7 @@ fn spawn_picker_terminal(cwd: &str, provider: HotkeyProviderSelection) -> Result
         .arg("hotkey-pick-agent")
         .arg("--cwd")
         .arg(&cwd)
+        .arg("--current-session")
         .arg("--provider")
         .arg(provider.as_str())
         .creation_flags(CREATE_NEW_CONSOLE)

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod browse;
 pub mod capture_history;
 pub mod clear;
+pub mod codex;
 pub mod command_block_selector;
 pub mod config;
 pub mod copy;

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,9 @@ fn run() -> Result<()> {
         Some(Commands::Hotkey(cmd)) => {
             commands::hotkey::execute(cmd)?;
         }
+        Some(Commands::Codex(cmd)) => {
+            commands::codex::execute(cmd)?;
+        }
         Some(Commands::Config(cfg_cmd)) => {
             commands::config::execute(cfg_cmd)?;
         }


### PR DESCRIPTION
## Title: fix(codex): mirror and expose complete cross-account Codex sessions

### 1. Context & Motivation (Context)
- **Issue:** Fixes #5
- **Problem:** Cross-account picker flow was incomplete: session discovery was cwd-gated by default in the hotkey entrypoint, picker lists were truncated, and shared session dirs could be masked when env overrides replaced config dirs.
- **Trade-offs:** The picker now defaults to full-session scope (better completeness) and keeps cwd-filtering as explicit opt-in (`--current-session`). This can show larger lists, but avoids dropping valid sessions.

### 2. Implementation Details (Implementation)
- Added Codex shared session mirroring (`sivtr codex export`) with watch mode, ms-level interval support, and best-effort stale cleanup/permissions handling.
- Updated Codex session dir resolution to merge local + config + env directories; added event fallback parsing for mixed transcript shapes.
- Updated picker scope semantics by introducing `hotkey-pick-agent --current-session`; default picker now enumerates complete provider sessions and removes AI session/dialog truncation.
- **Note:** Windows daemon behavior remains backward-compatible by passing `--current-session` explicitly from the daemon path.

### 3. Testing Strategies (Validation)
- [x] Added Unit Tests for Codex session dir merge, watch interval validation, event fallback parsing, and non-truncated picker lists
- [x] Ran Integration Test Suite against Linux dev environment (`cargo test`)
- [x] Verified backward compatibility for Windows hotkey flow via explicit daemon argument path
- **Benchmark:** N/A (functional correctness and visibility fix)
