### PR TITLE
feat(macos): sync unix capture path and init helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ It is not a terminal emulator and not a multiplexer. It is a companion tool for 
 - Pipe any command into a searchable, selectable output viewer.
 - Record shell command blocks and copy recent inputs, outputs, or bare commands.
 - Read Codex session JSONL files and copy useful user, assistant, or tool blocks.
-- Open an AI session picker from VS Code with one shortcut.
+- Open a Codex picker from VS Code with one shortcut.
 - Filter copied text with regex and line ranges.
 - Keep a local SQLite history for later search.
 - Compare recent command outputs while iterating on tests and builds.
@@ -69,7 +69,7 @@ Install the VS Code bridge from the Marketplace:
 ariestar.sivtr-vscode
 ```
 
-The extension launches the AI session picker from the current workspace. If the `sivtr` CLI is missing, it offers to run `cargo install sivtr` in a visible terminal.
+The extension launches the Codex picker from the current workspace. If the `sivtr` CLI is missing, it offers to run `cargo install sivtr` in a visible terminal.
 
 ## Quick Start
 
@@ -149,9 +149,7 @@ sivtr copy out --lines 10:40
 
 ### Reuse Codex Sessions
 
-`sivtr copy codex` reads Codex rollout JSONL files from `~/.codex/sessions` and chooses the newest session whose `cwd` matches your current directory.
-
-Use `--session N` to open the Nth newest recorded session, or `--session ID` to match a session id / id prefix explicitly.
+`sivtr copy codex` reads Codex rollout JSONL files from `~/.codex/sessions`. When you run it inside an active `codex` or `codex resume` shell, it prefers that exact session id first. Otherwise it chooses the newest session whose `cwd` matches your current directory. Use `--session N` to target the Nth newest recorded session, or `--session ID` to target a specific session id / id prefix.
 
 ```bash
 sivtr copy codex        # latest completed user + assistant turn
@@ -163,16 +161,20 @@ sivtr copy codex in     # latest user message
 sivtr copy codex tool   # latest tool output
 sivtr copy codex all    # parsed session
 sivtr copy codex --session 2 --pick
+sivtr copy codex all --max-blocks 0
+sivtr copy codex all --max-blocks 10000
 ```
 
 Progress commentary is filtered by default, so `sivtr copy codex out` returns the final assistant reply instead of intermediate status updates.
+
+Large Codex transcripts are capped to the latest `10000` parsed blocks by default for robustness. Set `[codex].max_blocks = 0` in config or pass `--max-blocks 0` for a full import.
 
 ### VS Code Shortcut
 
 The VS Code extension contributes:
 
 ```text
-Sivtr: Pick AI Session
+Sivtr: Pick Codex Turn
 ```
 
 Default keybinding:
@@ -193,6 +195,9 @@ sivtr hotkey-pick-codex --cwd .
 and `sivtr` prefers the active `codex` / `codex resume` session when one is
 available.
 
+On macOS, the same VS Code shortcut works as the default picker shortcut when
+the editor has focus.
+
 ### Linux Shortcut Setup
 
 Linux does not currently ship a default global `sivtr` hotkey outside VS Code.
@@ -209,45 +214,42 @@ Reasons:
 Recommended Linux setups:
 
 - VS Code: use the built-in `Alt+Y` command binding.
-- tmux: install a helper that binds `prefix + y` to the current pane's working
-  directory:
-
-```bash
-sivtr init tmux
-tmux source-file ~/.tmux.conf
-```
-
-The generated block is:
+- tmux: bind a key to the current pane's working directory:
 
 ```tmux
 bind-key y new-window -c "#{pane_current_path}" "sivtr hotkey-pick-codex --cwd '#{pane_current_path}'"
 ```
 
-- Terminal / desktop environment: generate a launcher for the current project:
+- Terminal / desktop environment: create a custom shortcut that launches
+  `sivtr hotkey-pick-codex --cwd <project-path>` in a terminal for the project
+  you want to inspect.
+
+### macOS Shortcut Setup
+
+macOS does not currently ship a built-in `sivtr` global hotkey daemon. The
+recommended default is the VS Code shortcut above.
+
+For a project-local Terminal launcher plus a LaunchAgent wrapper, generate the
+helper files on macOS:
 
 ```bash
-sivtr init linux-shortcut
+sivtr init macos-shortcut
 ```
 
 This writes:
 
 - `~/.local/bin/sivtr-pick-codex`
-- `~/.local/share/applications/sivtr-pick-codex.desktop`
+- `~/Library/LaunchAgents/dev.sivtr.pick-codex.plist`
 
-The launcher opens a terminal and runs:
+You can:
 
-```bash
-sivtr hotkey-pick-codex --cwd "<project-path>"
-```
+- run `~/.local/bin/sivtr-pick-codex` directly;
+- load the LaunchAgent with `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.sivtr.pick-codex.plist`;
+- keep using the VS Code command for the most reliable shortcut-driven flow.
 
-Typical Linux usage examples:
-
-- GNOME / KDE: bind your desktop shortcut to `~/.local/bin/sivtr-pick-codex`.
-- Plain terminal launcher: run `~/.local/bin/sivtr-pick-codex`.
-- Manual one-off command: `sivtr hotkey-pick-codex --cwd /path/to/project`.
 ### Windows Global Hotkey
 
-On Windows, the hotkey daemon can open the AI session picker from anywhere:
+On Windows, the hotkey daemon can open the Codex picker from anywhere:
 
 ```bash
 sivtr hotkey start
@@ -268,9 +270,9 @@ The default shortcut is `alt+y`.
 | `sivtr diff <left> <right>` | Compare recent command blocks. |
 | `sivtr history` | List, search, and show captured output history. |
 | `sivtr config` | Manage the TOML config file. |
-| `sivtr init <target>` | Generate shell integration or Linux shortcut helpers. |
+| `sivtr init <shell>` | Generate shell integration for command-block capture. |
 | `sivtr import` | Open the current session log. |
-| `sivtr hotkey` | Manage the Windows AI session picker hotkey. |
+| `sivtr hotkey` | Manage the Windows Codex picker hotkey. |
 | `sivtr clear` | Clear session logs. |
 
 ## TUI Keys
@@ -322,7 +324,7 @@ sivtr/
 |- crates/sivtr-core/    # Capture, parsing, buffers, selection, search, history, export
 |- src/                  # CLI, TUI, commands, hotkey integration
 |- docs-site/            # Astro/Starlight documentation site
-|- editors/vscode/       # VS Code extension bridge for the AI session picker
+|- editors/vscode/       # VS Code extension bridge for the Codex picker
 `- .github/workflows/    # CI and release automation
 ```
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,11 @@ You can:
 - load the LaunchAgent with `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.sivtr.pick-codex.plist`;
 - keep using the VS Code command for the most reliable shortcut-driven flow.
 
+Quick one-line checks:
+
+- generate and open the picker once: `sivtr init macos-shortcut && ~/.local/bin/sivtr-pick-codex`
+- generate and load the LaunchAgent wrapper: `sivtr init macos-shortcut && launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.sivtr.pick-codex.plist`
+
 ### Windows Global Hotkey
 
 On Windows, the hotkey daemon can open the Codex picker from anywhere:

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ On Linux, this VS Code shortcut works as the default picker shortcut when the
 editor has focus. The extension runs:
 
 ```bash
-sivtr hotkey-pick-codex --cwd .
+sivtr hotkey-pick-agent --cwd . --provider all
 ```
 
 and `sivtr` prefers the active `codex` / `codex resume` session when one is
@@ -217,11 +217,11 @@ Recommended Linux setups:
 - tmux: bind a key to the current pane's working directory:
 
 ```tmux
-bind-key y new-window -c "#{pane_current_path}" "sivtr hotkey-pick-codex --cwd '#{pane_current_path}'"
+bind-key y new-window -c "#{pane_current_path}" "sivtr copy codex all --pick"
 ```
 
 - Terminal / desktop environment: create a custom shortcut that launches
-  `sivtr hotkey-pick-codex --cwd <project-path>` in a terminal for the project
+  `cd <project-path> && sivtr copy codex all --pick` in a terminal for the project
   you want to inspect.
 
 ### macOS Shortcut Setup

--- a/README.md
+++ b/README.md
@@ -217,11 +217,11 @@ Recommended Linux setups:
 - tmux: bind a key to the current pane's working directory:
 
 ```tmux
-bind-key y new-window -c "#{pane_current_path}" "sivtr copy codex all --pick"
+bind-key y new-window -c "#{pane_current_path}" "sivtr copy codex --pick"
 ```
 
 - Terminal / desktop environment: create a custom shortcut that launches
-  `cd <project-path> && sivtr copy codex all --pick` in a terminal for the project
+  `cd <project-path> && sivtr copy codex --pick` in a terminal for the project
   you want to inspect.
 
 ### macOS Shortcut Setup

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ It is not a terminal emulator and not a multiplexer. It is a companion tool for 
 - Pipe any command into a searchable, selectable output viewer.
 - Record shell command blocks and copy recent inputs, outputs, or bare commands.
 - Read Codex session JSONL files and copy useful user, assistant, or tool blocks.
-- Open a Codex picker from VS Code with one shortcut.
+- Open an AI session picker from VS Code with one shortcut.
 - Filter copied text with regex and line ranges.
 - Keep a local SQLite history for later search.
 - Compare recent command outputs while iterating on tests and builds.
@@ -69,7 +69,7 @@ Install the VS Code bridge from the Marketplace:
 ariestar.sivtr-vscode
 ```
 
-The extension launches the Codex picker from the current workspace. If the `sivtr` CLI is missing, it offers to run `cargo install sivtr` in a visible terminal.
+The extension launches the AI session picker from the current workspace. If the `sivtr` CLI is missing, it offers to run `cargo install sivtr` in a visible terminal.
 
 ## Quick Start
 
@@ -174,7 +174,7 @@ Large Codex transcripts are capped to the latest `10000` parsed blocks by defaul
 The VS Code extension contributes:
 
 ```text
-Sivtr: Pick Codex Turn
+Sivtr: Pick AI Session
 ```
 
 Default keybinding:
@@ -254,7 +254,7 @@ Quick one-line checks:
 
 ### Windows Global Hotkey
 
-On Windows, the hotkey daemon can open the Codex picker from anywhere:
+On Windows, the hotkey daemon can open the AI session picker from anywhere:
 
 ```bash
 sivtr hotkey start
@@ -277,7 +277,7 @@ The default shortcut is `alt+y`.
 | `sivtr config` | Manage the TOML config file. |
 | `sivtr init <shell>` | Generate shell integration for command-block capture. |
 | `sivtr import` | Open the current session log. |
-| `sivtr hotkey` | Manage the Windows Codex picker hotkey. |
+| `sivtr hotkey` | Manage the Windows AI session picker hotkey. |
 | `sivtr clear` | Clear session logs. |
 
 ## TUI Keys
@@ -329,7 +329,7 @@ sivtr/
 |- crates/sivtr-core/    # Capture, parsing, buffers, selection, search, history, export
 |- src/                  # CLI, TUI, commands, hotkey integration
 |- docs-site/            # Astro/Starlight documentation site
-|- editors/vscode/       # VS Code extension bridge for the Codex picker
+|- editors/vscode/       # VS Code extension bridge for the AI session picker
 `- .github/workflows/    # CI and release automation
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -242,6 +242,11 @@ sivtr init macos-shortcut
 - 用 `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.sivtr.pick-codex.plist` 加载 LaunchAgent；
 - 继续使用 VS Code 命令，作为最稳定的快捷键驱动入口。
 
+可直接复制的一行验证命令：
+
+- 生成并立即打开 picker：`sivtr init macos-shortcut && ~/.local/bin/sivtr-pick-codex`
+- 生成并加载 LaunchAgent 包装：`sivtr init macos-shortcut && launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.sivtr.pick-codex.plist`
+
 ### Windows 全局热键
 
 Windows 上可以启动全局热键守护进程：

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -189,7 +189,7 @@ Alt+Y
 Codex picker 快捷键。插件实际执行的是：
 
 ```bash
-sivtr hotkey-pick-codex --cwd .
+sivtr hotkey-pick-agent --cwd . --provider all
 ```
 
 如果当前终端正运行在活动中的 `codex` 或 `codex resume` 会话里，
@@ -212,11 +212,11 @@ Linux 目前没有提供 VS Code 之外的默认全局 `sivtr` 热键。
 - tmux：给当前 pane 目录绑定一个快捷键：
 
 ```tmux
-bind-key y new-window -c "#{pane_current_path}" "sivtr hotkey-pick-codex --cwd '#{pane_current_path}'"
+bind-key y new-window -c "#{pane_current_path}" "sivtr copy codex all --pick"
 ```
 
 - 终端或桌面环境：手动创建一个自定义快捷键，在终端中执行
-  `sivtr hotkey-pick-codex --cwd <project-path>`。
+  `cd <project-path> && sivtr copy codex all --pick`。
 
 ### Windows 全局热键
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -195,6 +195,9 @@ sivtr hotkey-pick-agent --cwd . --provider all
 如果当前终端正运行在活动中的 `codex` 或 `codex resume` 会话里，
 `sivtr` 会优先使用这个精确会话。
 
+在 macOS 上，当焦点位于 VS Code 编辑器时，这个快捷键同样是默认的
+picker 快捷键。
+
 ### Linux 快捷键设置
 
 Linux 目前没有提供 VS Code 之外的默认全局 `sivtr` 热键。
@@ -217,6 +220,27 @@ bind-key y new-window -c "#{pane_current_path}" "sivtr copy codex --pick"
 
 - 终端或桌面环境：手动创建一个自定义快捷键，在终端中执行
   `cd <project-path> && sivtr copy codex --pick`。
+
+### macOS 快捷键设置
+
+macOS 目前没有内置的 `sivtr` 全局热键守护进程。推荐默认使用上面的 VS Code 快捷键。
+
+如果你想在 VS Code 之外通过 Terminal 启动项目级 picker，可以在 macOS 上生成 launcher 和 LaunchAgent 包装：
+
+```bash
+sivtr init macos-shortcut
+```
+
+它会写入：
+
+- `~/.local/bin/sivtr-pick-codex`
+- `~/Library/LaunchAgents/dev.sivtr.pick-codex.plist`
+
+你可以：
+
+- 直接运行 `~/.local/bin/sivtr-pick-codex`；
+- 用 `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.sivtr.pick-codex.plist` 加载 LaunchAgent；
+- 继续使用 VS Code 命令，作为最稳定的快捷键驱动入口。
 
 ### Windows 全局热键
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -212,11 +212,11 @@ Linux 目前没有提供 VS Code 之外的默认全局 `sivtr` 热键。
 - tmux：给当前 pane 目录绑定一个快捷键：
 
 ```tmux
-bind-key y new-window -c "#{pane_current_path}" "sivtr copy codex all --pick"
+bind-key y new-window -c "#{pane_current_path}" "sivtr copy codex --pick"
 ```
 
 - 终端或桌面环境：手动创建一个自定义快捷键，在终端中执行
-  `cd <project-path> && sivtr copy codex all --pick`。
+  `cd <project-path> && sivtr copy codex --pick`。
 
 ### Windows 全局热键
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -42,7 +42,7 @@
 - 把任意命令输出通过管道送入可搜索、可选择的浏览器。
 - 记录 shell 命令块，之后复制最近的输入、输出或纯命令。
 - 读取 Codex 的 JSONL 会话文件，复制用户消息、助手回复或工具输出。
-- 在 VS Code 中用一个快捷键打开 AI session picker。
+- 在 VS Code 中用一个快捷键打开 Codex picker。
 - 支持用正则和行号范围过滤复制内容。
 - 用本地 SQLite 保存历史，之后可以检索。
 - 迭代测试和构建时，对比最近几次命令输出。
@@ -69,7 +69,7 @@ VS Code 插件：
 ariestar.sivtr-vscode
 ```
 
-插件会从当前 workspace 启动 AI session picker。如果没有安装 `sivtr` CLI，它会提示你是否在可见终端里运行 `cargo install sivtr`。
+插件会从当前 workspace 启动 Codex picker。如果没有安装 `sivtr` CLI，它会提示你是否在可见终端里运行 `cargo install sivtr`。
 
 ## 快速开始
 
@@ -149,9 +149,7 @@ sivtr copy out --lines 10:40
 
 ### 复用 Codex 会话
 
-`sivtr copy codex` 会读取 `~/.codex/sessions` 下的 Codex rollout JSONL 文件，并优先选择 `cwd` 与当前目录匹配的最新会话。
-
-用 `--session N` 可以显式选择第 N 新的已记录会话；用 `--session ID` 可以按会话 id 或 id 前缀匹配。
+`sivtr copy codex` 会读取 `~/.codex/sessions` 下的 Codex rollout JSONL 文件。如果当前 shell 正运行在活动中的 `codex` 或 `codex resume` 会话里，它会优先使用这个精确会话 id；否则会优先选择 `cwd` 与当前目录匹配的最新会话。
 
 ```bash
 sivtr copy codex        # 最近一轮用户消息 + 助手回复
@@ -163,16 +161,20 @@ sivtr copy codex in     # 最近用户消息
 sivtr copy codex tool   # 最近工具输出
 sivtr copy codex all    # 整个解析后的会话
 sivtr copy codex --session 2 --pick
+sivtr copy codex all --max-blocks 0
+sivtr copy codex all --max-blocks 10000
 ```
 
 默认会过滤过程性 commentary，所以 `sivtr copy codex out` 更倾向返回最终助手回复，而不是中间状态更新。
+
+为避免超大 Codex transcript 让导入或 picker 变慢，默认只保留最近 `10000` 个解析后的 block。若要全量导入，可在配置里设置 `[codex].max_blocks = 0`，或在命令行传 `--max-blocks 0`。
 
 ### VS Code 快捷键
 
 VS Code 插件提供命令：
 
 ```text
-Sivtr: Pick AI Session
+Sivtr: Pick Codex Turn
 ```
 
 默认快捷键：
@@ -207,41 +209,15 @@ Linux 目前没有提供 VS Code 之外的默认全局 `sivtr` 热键。
 推荐的 Linux 设置方式：
 
 - VS Code：直接使用内置的 `Alt+Y`。
-- tmux：安装一个把 `prefix + y` 绑定到当前 pane 目录的 helper：
-
-```bash
-sivtr init tmux
-tmux source-file ~/.tmux.conf
-```
-
-生成的配置块是：
+- tmux：给当前 pane 目录绑定一个快捷键：
 
 ```tmux
 bind-key y new-window -c "#{pane_current_path}" "sivtr hotkey-pick-codex --cwd '#{pane_current_path}'"
 ```
 
-- 终端或桌面环境：为当前项目生成一个 launcher：
+- 终端或桌面环境：手动创建一个自定义快捷键，在终端中执行
+  `sivtr hotkey-pick-codex --cwd <project-path>`。
 
-```bash
-sivtr init linux-shortcut
-```
-
-它会写入：
-
-- `~/.local/bin/sivtr-pick-codex`
-- `~/.local/share/applications/sivtr-pick-codex.desktop`
-
-这个 launcher 会打开一个终端，并执行：
-
-```bash
-sivtr hotkey-pick-codex --cwd "<project-path>"
-```
-
-常见 Linux 使用示例：
-
-- GNOME / KDE：把 `~/.local/bin/sivtr-pick-codex` 绑定到你的桌面快捷键。
-- 纯终端启动：直接运行 `~/.local/bin/sivtr-pick-codex`。
-- 一次性手动执行：`sivtr hotkey-pick-codex --cwd /path/to/project`。
 ### Windows 全局热键
 
 Windows 上可以启动全局热键守护进程：
@@ -265,9 +241,9 @@ sivtr hotkey stop
 | `sivtr diff <left> <right>` | 对比最近命令输出。 |
 | `sivtr history` | 列出、搜索、查看输出历史。 |
 | `sivtr config` | 管理 TOML 配置。 |
-| `sivtr init <target>` | 生成 shell 集成或 Linux 快捷键 helper。 |
+| `sivtr init <shell>` | 生成命令块捕获所需的 shell 集成。 |
 | `sivtr import` | 打开当前 session log。 |
-| `sivtr hotkey` | 管理 Windows AI session picker 热键。 |
+| `sivtr hotkey` | 管理 Windows Codex picker 热键。 |
 | `sivtr clear` | 清空 session logs。 |
 
 ## TUI 按键
@@ -319,7 +295,7 @@ sivtr/
 |- crates/sivtr-core/    # 捕获、解析、缓冲区、选择、搜索、历史、导出
 |- src/                  # CLI、TUI、命令、热键集成
 |- docs-site/            # Astro/Starlight 文档站
-|- editors/vscode/       # AI session picker 的 VS Code 插件桥接
+|- editors/vscode/       # Codex picker 的 VS Code 插件桥接
 `- .github/workflows/    # CI 和发布自动化
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -42,7 +42,7 @@
 - 把任意命令输出通过管道送入可搜索、可选择的浏览器。
 - 记录 shell 命令块，之后复制最近的输入、输出或纯命令。
 - 读取 Codex 的 JSONL 会话文件，复制用户消息、助手回复或工具输出。
-- 在 VS Code 中用一个快捷键打开 Codex picker。
+- 在 VS Code 中用一个快捷键打开 AI session picker。
 - 支持用正则和行号范围过滤复制内容。
 - 用本地 SQLite 保存历史，之后可以检索。
 - 迭代测试和构建时，对比最近几次命令输出。
@@ -69,7 +69,7 @@ VS Code 插件：
 ariestar.sivtr-vscode
 ```
 
-插件会从当前 workspace 启动 Codex picker。如果没有安装 `sivtr` CLI，它会提示你是否在可见终端里运行 `cargo install sivtr`。
+插件会从当前 workspace 启动 AI session picker。如果没有安装 `sivtr` CLI，它会提示你是否在可见终端里运行 `cargo install sivtr`。
 
 ## 快速开始
 
@@ -174,7 +174,7 @@ sivtr copy codex all --max-blocks 10000
 VS Code 插件提供命令：
 
 ```text
-Sivtr: Pick Codex Turn
+Sivtr: Pick AI Session
 ```
 
 默认快捷键：
@@ -186,7 +186,7 @@ Alt+Y
 你可以改成 `Ctrl+Y`，但它通常会覆盖编辑器的 Redo。
 
 在 Linux 上，当焦点位于 VS Code 编辑器时，这个快捷键就是默认的
-Codex picker 快捷键。插件实际执行的是：
+AI session picker 快捷键。插件实际执行的是：
 
 ```bash
 sivtr hotkey-pick-agent --cwd . --provider all
@@ -272,7 +272,7 @@ sivtr hotkey stop
 | `sivtr config` | 管理 TOML 配置。 |
 | `sivtr init <shell>` | 生成命令块捕获所需的 shell 集成。 |
 | `sivtr import` | 打开当前 session log。 |
-| `sivtr hotkey` | 管理 Windows Codex picker 热键。 |
+| `sivtr hotkey` | 管理 Windows AI session picker 热键。 |
 | `sivtr clear` | 清空 session logs。 |
 
 ## TUI 按键
@@ -324,7 +324,7 @@ sivtr/
 |- crates/sivtr-core/    # 捕获、解析、缓冲区、选择、搜索、历史、导出
 |- src/                  # CLI、TUI、命令、热键集成
 |- docs-site/            # Astro/Starlight 文档站
-|- editors/vscode/       # Codex picker 的 VS Code 插件桥接
+|- editors/vscode/       # AI session picker 的 VS Code 插件桥接
 `- .github/workflows/    # CI 和发布自动化
 ```
 

--- a/crates/sivtr-core/src/capture/scrollback.rs
+++ b/crates/sivtr-core/src/capture/scrollback.rs
@@ -85,6 +85,11 @@ fn session_pid_from_path(path: &Path) -> Option<u32> {
         .and_then(|rest| rest.strip_suffix(".state"))
     {
         pid
+    } else if let Some(pid) = name
+        .strip_prefix("session_")
+        .and_then(|rest| rest.strip_suffix(".capture"))
+    {
+        pid
     } else {
         return None;
     };
@@ -121,6 +126,15 @@ fn process_is_alive(pid: u32) -> bool {
 /// Get the flush state file path (derived from session log path).
 pub fn flush_state_path() -> std::path::PathBuf {
     session_log_path().with_extension("state")
+}
+
+/// Get the per-command capture file path used by Unix shell hooks.
+pub fn capture_file_path() -> std::path::PathBuf {
+    if let Ok(path) = env::var("SIVTR_CAPTURE_FILE") {
+        return PathBuf::from(path);
+    }
+
+    session_log_path().with_extension("capture")
 }
 
 /// Read the current session log populated by the shell hook.
@@ -354,6 +368,10 @@ mod tests {
         assert_eq!(session_pid_from_path(Path::new("session_42.log")), Some(42));
         assert_eq!(
             session_pid_from_path(Path::new("session_42.state")),
+            Some(42)
+        );
+        assert_eq!(
+            session_pid_from_path(Path::new("session_42.capture")),
             Some(42)
         );
         assert_eq!(session_pid_from_path(Path::new("session.log")), None);

--- a/docs-site/src/content/docs/reference/cli.md
+++ b/docs-site/src/content/docs/reference/cli.md
@@ -62,6 +62,9 @@ Supported shell names:
 - `zsh`
 - `nushell`
 - `nu`
+- `tmux`
+- `linux-shortcut`
+- `macos-shortcut`
 
 ## copy
 

--- a/docs-site/src/content/docs/usage/hotkey.md
+++ b/docs-site/src/content/docs/usage/hotkey.md
@@ -73,7 +73,7 @@ picker.
 
 ## Linux setups
 
-Use one of these Linux-specific entry points instead of a built-in global
+Use one of these platform-specific entry points instead of a built-in global
 daemon:
 
 - VS Code: use the extension command bound to `Alt+Y` by default.
@@ -95,3 +95,17 @@ sivtr init linux-shortcut
 This writes `~/.local/bin/sivtr-pick-codex` plus a desktop entry at
 `~/.local/share/applications/sivtr-pick-codex.desktop`. Bind your desktop
 shortcut to the script, or run it directly from a terminal.
+
+- macOS: generate a Terminal launcher plus a LaunchAgent wrapper:
+
+```bash
+sivtr init macos-shortcut
+```
+
+This writes `~/.local/bin/sivtr-pick-codex` and
+`~/Library/LaunchAgents/dev.sivtr.pick-codex.plist`. Run the script directly,
+or load the LaunchAgent with:
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.sivtr.pick-codex.plist
+```

--- a/docs-site/src/content/docs/usage/hotkey.md
+++ b/docs-site/src/content/docs/usage/hotkey.md
@@ -109,3 +109,8 @@ or load the LaunchAgent with:
 ```bash
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.sivtr.pick-codex.plist
 ```
+
+Quick one-line checks:
+
+- generate and open the picker once: `sivtr init macos-shortcut && ~/.local/bin/sivtr-pick-codex`
+- generate and load the LaunchAgent wrapper: `sivtr init macos-shortcut && launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.sivtr.pick-codex.plist`

--- a/docs-site/src/content/docs/zh-cn/reference/cli.md
+++ b/docs-site/src/content/docs/zh-cn/reference/cli.md
@@ -62,6 +62,9 @@ sivtr init <SHELL>
 - `zsh`
 - `nushell`
 - `nu`
+- `tmux`
+- `linux-shortcut`
+- `macos-shortcut`
 
 ## copy
 

--- a/docs-site/src/content/docs/zh-cn/usage/hotkey.md
+++ b/docs-site/src/content/docs/zh-cn/usage/hotkey.md
@@ -90,3 +90,17 @@ sivtr init linux-shortcut
 
 它会写入 `~/.local/bin/sivtr-pick-codex`，以及
 `~/.local/share/applications/sivtr-pick-codex.desktop`。你可以把桌面快捷键绑定到这个脚本，或者直接在终端里运行它。
+
+- macOS：生成 Terminal launcher 和 LaunchAgent 包装：
+
+```bash
+sivtr init macos-shortcut
+```
+
+它会写入 `~/.local/bin/sivtr-pick-codex` 和
+`~/Library/LaunchAgents/dev.sivtr.pick-codex.plist`。你可以直接运行这个脚本，
+或者通过下面的命令加载 LaunchAgent：
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.sivtr.pick-codex.plist
+```

--- a/docs-site/src/content/docs/zh-cn/usage/hotkey.md
+++ b/docs-site/src/content/docs/zh-cn/usage/hotkey.md
@@ -104,3 +104,8 @@ sivtr init macos-shortcut
 ```bash
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.sivtr.pick-codex.plist
 ```
+
+可直接复制的一行验证命令：
+
+- 生成并立即打开 picker：`sivtr init macos-shortcut && ~/.local/bin/sivtr-pick-codex`
+- 生成并加载 LaunchAgent 包装：`sivtr init macos-shortcut && launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.sivtr.pick-codex.plist`

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -19,7 +19,7 @@ The extension opens a VS Code terminal in the current workspace and runs the
 context-aware Codex picker:
 
 ```bash
-sivtr hotkey-pick-codex --cwd .
+sivtr hotkey-pick-agent --cwd . --provider all
 ```
 
 If the terminal was opened from a live `codex resume` session, `sivtr` prefers
@@ -40,7 +40,7 @@ If you want a Terminal-based launcher outside VS Code, run
 | Setting | Default | Purpose |
 | --- | --- | --- |
 | `sivtr.command` | `sivtr` | Command used to launch sivtr |
-| `sivtr.args` | `["hotkey-pick-codex", "--cwd", "."]` | Arguments passed to sivtr |
+| `sivtr.args` | `["hotkey-pick-agent", "--cwd", ".", "--provider", "all"]` | Arguments passed to sivtr |
 | `sivtr.reuseTerminal` | `true` | Reuse the existing sivtr terminal |
 | `sivtr.closeTerminalOnSuccess` | `true` | Close the sivtr terminal when the picker exits successfully |
 | `sivtr.terminalName` | `sivtr` | Terminal name |

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -35,6 +35,12 @@ On macOS, the same VS Code shortcut is also the recommended default shortcut.
 If you want a Terminal-based launcher outside VS Code, run
 `sivtr init macos-shortcut` on the Mac host.
 
+Quick one-line fallback outside VS Code:
+
+```bash
+sivtr init macos-shortcut && ~/.local/bin/sivtr-pick-codex
+```
+
 ## Settings
 
 | Setting | Default | Purpose |

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,6 +1,6 @@
 # sivtr VS Code extension
 
-Launch the sivtr AI session picker from VS Code.
+Launch the sivtr Codex picker from VS Code.
 
 ## Usage
 
@@ -13,21 +13,34 @@ cargo install sivtr
 If `sivtr` is missing, the extension will offer to open a terminal and run that
 install command.
 
-Run `Sivtr: Pick AI Session` from the command palette, or press `Alt+Y`.
+Run `Sivtr: Pick Codex Turn` from the command palette, or press `Alt+Y`.
 
 The extension opens a VS Code terminal in the current workspace and runs the
-context-aware AI session picker:
+context-aware Codex picker:
 
 ```bash
-sivtr hotkey-pick-agent --cwd . --provider all
+sivtr hotkey-pick-codex --cwd .
 ```
+
+If the terminal was opened from a live `codex resume` session, `sivtr` prefers
+that exact session id first. Otherwise it falls back to the newest non-empty
+session whose `cwd` matches the workspace.
+
+On Linux, this VS Code keybinding is the recommended default shortcut. `sivtr`
+does not currently provide a desktop-wide global hotkey on Linux outside VS
+Code because global shortcut registration and terminal launching are not
+portable across Wayland, X11, and terminal-only environments.
+
+On macOS, the same VS Code shortcut is also the recommended default shortcut.
+If you want a Terminal-based launcher outside VS Code, run
+`sivtr init macos-shortcut` on the Mac host.
 
 ## Settings
 
 | Setting | Default | Purpose |
 | --- | --- | --- |
 | `sivtr.command` | `sivtr` | Command used to launch sivtr |
-| `sivtr.args` | `["hotkey-pick-agent", "--cwd", ".", "--provider", "all"]` | Arguments passed to sivtr |
+| `sivtr.args` | `["hotkey-pick-codex", "--cwd", "."]` | Arguments passed to sivtr |
 | `sivtr.reuseTerminal` | `true` | Reuse the existing sivtr terminal |
 | `sivtr.closeTerminalOnSuccess` | `true` | Close the sivtr terminal when the picker exits successfully |
 | `sivtr.terminalName` | `sivtr` | Terminal name |

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,6 +1,6 @@
 # sivtr VS Code extension
 
-Launch the sivtr Codex picker from VS Code.
+Launch the sivtr AI session picker from VS Code.
 
 ## Usage
 
@@ -13,10 +13,10 @@ cargo install sivtr
 If `sivtr` is missing, the extension will offer to open a terminal and run that
 install command.
 
-Run `Sivtr: Pick Codex Turn` from the command palette, or press `Alt+Y`.
+Run `Sivtr: Pick AI Session` from the command palette, or press `Alt+Y`.
 
 The extension opens a VS Code terminal in the current workspace and runs the
-context-aware Codex picker:
+context-aware AI session picker:
 
 ```bash
 sivtr hotkey-pick-agent --cwd . --provider all

--- a/src/commands/browse.rs
+++ b/src/commands/browse.rs
@@ -1,5 +1,7 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
+use sivtr_core::config::SivtrConfig;
 use sivtr_core::export::editor;
+use sivtr_core::history::{store::CaptureSource, HistoryStore};
 
 use crate::app::{App, StatusMessage};
 use crate::tui;
@@ -7,6 +9,8 @@ use crate::tui;
 /// Shared TUI event loop with external editor support.
 /// Used by both `pipe` and `run` commands.
 pub fn run_tui(app: &mut App, start_at_bottom: bool) -> Result<()> {
+    ensure_tui_stdout()?;
+
     let mut terminal = tui::terminal::init()?;
     let size = terminal.size()?;
     app.buffer
@@ -65,4 +69,109 @@ pub fn run_tui(app: &mut App, start_at_bottom: bool) -> Result<()> {
 
     tui::terminal::restore(&mut terminal)?;
     Ok(())
+}
+
+pub(crate) fn record_history(
+    config: &SivtrConfig,
+    content: &str,
+    command: Option<&str>,
+    source: CaptureSource,
+) {
+    if let Err(error) = try_record_history(config, content, command, source) {
+        eprintln!("sivtr: failed to save history: {error:#}");
+    }
+}
+
+fn ensure_tui_stdout() -> Result<()> {
+    if atty::is(atty::Stream::Stdout) {
+        return Ok(());
+    }
+
+    bail!(
+        "sivtr: TUI mode requires an interactive terminal\n  hint: run inside a terminal or set `general.open_mode = \"editor\"` in config"
+    )
+}
+
+fn try_record_history(
+    config: &SivtrConfig,
+    content: &str,
+    command: Option<&str>,
+    source: CaptureSource,
+) -> Result<()> {
+    if !config.history.auto_save || content.trim().is_empty() {
+        return Ok(());
+    }
+
+    let store = HistoryStore::open_default()?;
+    try_record_history_with_store(&store, config, content, command, source)
+}
+
+fn try_record_history_with_store(
+    store: &HistoryStore,
+    config: &SivtrConfig,
+    content: &str,
+    command: Option<&str>,
+    source: CaptureSource,
+) -> Result<()> {
+    if !config.history.auto_save || content.trim().is_empty() {
+        return Ok(());
+    }
+
+    store.insert(content, command, source)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ensure_tui_stdout, try_record_history_with_store};
+    use sivtr_core::config::SivtrConfig;
+    use sivtr_core::history::{store::CaptureSource, HistoryStore};
+
+    #[test]
+    fn records_history_when_auto_save_is_enabled() {
+        let store = HistoryStore::open_memory().unwrap();
+        let config = SivtrConfig::default();
+
+        try_record_history_with_store(
+            &store,
+            &config,
+            "hello world",
+            Some("echo hello"),
+            CaptureSource::Run,
+        )
+        .unwrap();
+
+        let entries = store.list_recent(10).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].command.as_deref(), Some("echo hello"));
+        assert_eq!(entries[0].source, "run");
+    }
+
+    #[test]
+    fn skips_history_when_auto_save_is_disabled() {
+        let store = HistoryStore::open_memory().unwrap();
+        let mut config = SivtrConfig::default();
+        config.history.auto_save = false;
+
+        try_record_history_with_store(
+            &store,
+            &config,
+            "hello world",
+            Some("echo hello"),
+            CaptureSource::Run,
+        )
+        .unwrap();
+
+        let entries = store.list_recent(10).unwrap();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn rejects_non_interactive_tui_stdout() {
+        let error = ensure_tui_stdout().unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("TUI mode requires an interactive terminal"));
+    }
 }

--- a/src/commands/clear.rs
+++ b/src/commands/clear.rs
@@ -18,6 +18,7 @@ pub fn execute(clear_all: bool) -> Result<()> {
 
     let log = scrollback::session_log_path();
     let state = scrollback::flush_state_path();
+    let capture = scrollback::capture_file_path();
 
     let mut cleared = false;
 
@@ -25,7 +26,7 @@ pub fn execute(clear_all: bool) -> Result<()> {
         fs::remove_file(&log)?;
         cleared = true;
     }
-    for f in [&state] {
+    for f in [&state, &capture] {
         if f.exists() {
             let _ = fs::remove_file(f);
         }
@@ -81,7 +82,8 @@ fn is_session_artifact(path: &Path) -> bool {
     };
 
     (name == "session.log" || name == "session.state")
-        || (name.starts_with("session_") && (name.ends_with(".log") || name.ends_with(".state")))
+        || (name.starts_with("session_")
+            && (name.ends_with(".log") || name.ends_with(".state") || name.ends_with(".capture")))
 }
 
 #[cfg(test)]
@@ -95,6 +97,7 @@ mod tests {
         assert!(is_session_artifact(Path::new("session.state")));
         assert!(is_session_artifact(Path::new("session_1234.log")));
         assert!(is_session_artifact(Path::new("session_1234.state")));
+        assert!(is_session_artifact(Path::new("session_1234.capture")));
         assert!(!is_session_artifact(Path::new("config.toml")));
         assert!(!is_session_artifact(Path::new("history.db")));
     }

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -15,7 +15,7 @@ pub fn execute(cmd: ConfigCommand) -> Result<()> {
                 let content = std::fs::read_to_string(&path)?;
                 println!("{content}");
             } else {
-                println!("(file does not exist 鈥?using defaults)");
+                println!("(file does not exist - using defaults)");
                 println!();
                 let config = SivtrConfig::default();
                 let content = sivtr_core::config::to_toml_string(&config)?;

--- a/src/commands/flush.rs
+++ b/src/commands/flush.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use std::env;
+#[cfg(not(windows))]
 use std::fs;
 
 use sivtr_core::capture::scrollback;

--- a/src/commands/flush.rs
+++ b/src/commands/flush.rs
@@ -115,6 +115,7 @@ fn append_entry_from_output(
     session::save_state(state_path, &state)
 }
 
+#[cfg_attr(windows, allow(dead_code))]
 fn trim_trailing_prompt_artifact(output: String, prompt: &str) -> String {
     let prompt_last_line = SessionEntry::new(prompt, "", "")
         .prompt

--- a/src/commands/flush.rs
+++ b/src/commands/flush.rs
@@ -1,11 +1,8 @@
 use anyhow::Result;
-
-#[cfg(windows)]
 use std::env;
+use std::fs;
 
-#[cfg(windows)]
 use sivtr_core::capture::scrollback;
-#[cfg(windows)]
 use sivtr_core::session::{self, SessionEntry, SessionState};
 
 /// Flush: read console buffer, append new content to session.log.
@@ -27,10 +24,6 @@ fn do_flush() -> Result<()> {
         }
 
         let current_lines: Vec<&str> = snapshot.content.lines().collect();
-
-        let state_path = scrollback::flush_state_path();
-        let mut state = load_state_lossy(&state_path);
-
         let prompt = env::var("SIVTR_LAST_PROMPT").unwrap_or_default();
         let command = env::var("SIVTR_LAST_COMMAND").unwrap_or_default();
         let command_id = env::var("SIVTR_LAST_COMMAND_ID").ok();
@@ -40,31 +33,52 @@ fn do_flush() -> Result<()> {
             &current_lines,
             snapshot.width,
         );
-
-        if should_append_entry(&state, command_id.as_deref(), &command) {
-            let entry = SessionEntry::new(prompt, command.clone(), output);
-            session::append_entry(&scrollback::session_log_path(), &entry)?;
-            state.last_command_id = command_id;
-            state.last_command = Some(command);
-        }
-
-        session::save_state(&state_path, &state)?;
+        append_entry_from_output(
+            &scrollback::session_log_path(),
+            &scrollback::flush_state_path(),
+            prompt,
+            command,
+            command_id,
+            output,
+        )?;
     }
 
     #[cfg(not(windows))]
     {
-        // Non-Windows: no-op for now (tmux/zellij have native capture)
+        let capture_path = scrollback::capture_file_path();
+        if !capture_path.exists() {
+            return Ok(());
+        }
+
+        let output = String::from_utf8_lossy(&fs::read(&capture_path)?).into_owned();
+        let _ = fs::remove_file(&capture_path);
+
+        if output.trim().is_empty() {
+            return Ok(());
+        }
+
+        let prompt = env::var("SIVTR_LAST_PROMPT").unwrap_or_default();
+        let command = env::var("SIVTR_LAST_COMMAND").unwrap_or_default();
+        let command_id = env::var("SIVTR_LAST_COMMAND_ID").ok();
+        let output = trim_trailing_prompt_artifact(output, &prompt);
+
+        append_entry_from_output(
+            &scrollback::session_log_path(),
+            &scrollback::flush_state_path(),
+            prompt,
+            command,
+            command_id,
+            output,
+        )?;
     }
 
     Ok(())
 }
 
-#[cfg(windows)]
 fn load_state_lossy(path: &std::path::Path) -> SessionState {
     session::load_state(path).unwrap_or_default()
 }
 
-#[cfg(windows)]
 fn should_append_entry(state: &SessionState, command_id: Option<&str>, command: &str) -> bool {
     if command.trim().is_empty() {
         return false;
@@ -78,4 +92,154 @@ fn should_append_entry(state: &SessionState, command_id: Option<&str>, command: 
     }
 
     state.last_command.as_deref() != Some(command)
+}
+
+fn append_entry_from_output(
+    session_log_path: &std::path::Path,
+    state_path: &std::path::Path,
+    prompt: String,
+    command: String,
+    command_id: Option<String>,
+    output: String,
+) -> Result<()> {
+    let mut state = load_state_lossy(state_path);
+
+    if should_append_entry(&state, command_id.as_deref(), &command) {
+        let entry = SessionEntry::new(prompt, command.clone(), output);
+        session::append_entry(session_log_path, &entry)?;
+        state.last_command_id = command_id;
+        state.last_command = Some(command);
+    }
+
+    session::save_state(state_path, &state)
+}
+
+fn trim_trailing_prompt_artifact(output: String, prompt: &str) -> String {
+    let prompt_last_line = SessionEntry::new(prompt, "", "")
+        .prompt
+        .lines()
+        .last()
+        .unwrap_or_default()
+        .trim_end()
+        .to_string();
+    if prompt_last_line.is_empty() {
+        return output;
+    }
+
+    let mut raw_lines: Vec<&str> = output.lines().collect();
+    let Some(last_raw_line) = raw_lines.last().copied() else {
+        return output;
+    };
+
+    if !last_raw_line.contains('\x1b') && !last_raw_line.contains('\r') {
+        return output;
+    }
+
+    let last_plain_line = SessionEntry::new("", "", last_raw_line)
+        .output
+        .trim()
+        .to_string();
+    if last_plain_line.is_empty() || prompt_last_line.ends_with(&last_plain_line) {
+        raw_lines.pop();
+        return raw_lines.join("\n");
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{append_entry_from_output, should_append_entry, trim_trailing_prompt_artifact};
+    use sivtr_core::session::{self, SessionState};
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_test_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("sivtr-{name}-{}-{nanos}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn appends_structured_entry_for_capture_output() {
+        let dir = unique_test_dir("flush");
+        let log_path = dir.join("session_1.log");
+        let state_path = dir.join("session_1.state");
+
+        append_entry_from_output(
+            &log_path,
+            &state_path,
+            "repo on main\n❯  ".to_string(),
+            "cargo test".to_string(),
+            Some("42".to_string()),
+            "\u{1b}[32mok\u{1b}[0m\n".to_string(),
+        )
+        .unwrap();
+
+        let entries = session::load_entries(&log_path).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].command, "cargo test");
+        assert_eq!(entries[0].prompt, "repo on main\n❯  ");
+        assert_eq!(entries[0].output, "ok");
+        assert_eq!(
+            entries[0].output_ansi.as_deref(),
+            Some("\u{1b}[32mok\u{1b}[0m")
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn skips_duplicate_command_id_when_state_matches() {
+        let dir = unique_test_dir("flush-state");
+        let log_path = dir.join("session_1.log");
+        let state_path = dir.join("session_1.state");
+
+        append_entry_from_output(
+            &log_path,
+            &state_path,
+            "repo> ".to_string(),
+            "cargo test".to_string(),
+            Some("99".to_string()),
+            "ok".to_string(),
+        )
+        .unwrap();
+        append_entry_from_output(
+            &log_path,
+            &state_path,
+            "repo> ".to_string(),
+            "cargo test".to_string(),
+            Some("99".to_string()),
+            "still ok".to_string(),
+        )
+        .unwrap();
+
+        let entries = session::load_entries(&log_path).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].output, "ok");
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn rejects_empty_commands_even_without_command_id() {
+        let state = SessionState::default();
+        assert!(!should_append_entry(&state, None, ""));
+        assert!(!should_append_entry(&state, Some("7"), "   "));
+    }
+
+    #[test]
+    fn trims_trailing_prompt_artifact_from_zsh_capture() {
+        let prompt = "jacob-NucBox-EVO-X2# ";
+        let output = "hello from zsh\n\u{1b}[1m\u{1b}[7m#\u{1b}[27m\u{1b}[1m\u{1b}[0m \r \r";
+
+        assert_eq!(
+            trim_trailing_prompt_artifact(output.to_string(), prompt),
+            "hello from zsh"
+        );
+    }
 }

--- a/src/commands/flush.rs
+++ b/src/commands/flush.rs
@@ -131,10 +131,6 @@ fn trim_trailing_prompt_artifact(output: String, prompt: &str) -> String {
         return output;
     };
 
-    if !last_raw_line.contains('\x1b') && !last_raw_line.contains('\r') {
-        return output;
-    }
-
     let last_plain_line = SessionEntry::new("", "", last_raw_line)
         .output
         .trim()
@@ -240,6 +236,17 @@ mod tests {
         assert_eq!(
             trim_trailing_prompt_artifact(output.to_string(), prompt),
             "hello from zsh"
+        );
+    }
+
+    #[test]
+    fn trims_plain_text_prompt_suffix_from_capture() {
+        let prompt = "repo> ";
+        let output = "build complete\nrepo>";
+
+        assert_eq!(
+            trim_trailing_prompt_artifact(output.to_string(), prompt),
+            "build complete"
         );
     }
 }

--- a/src/commands/import.rs
+++ b/src/commands/import.rs
@@ -3,6 +3,7 @@ use sivtr_core::buffer::Buffer;
 use sivtr_core::capture::scrollback;
 use sivtr_core::config::{OpenMode, SivtrConfig};
 use sivtr_core::export::editor;
+use sivtr_core::history::store::CaptureSource;
 use sivtr_core::parse;
 
 use super::browse;
@@ -19,6 +20,7 @@ pub fn execute() -> Result<()> {
             }
 
             let config = SivtrConfig::load().unwrap_or_default();
+            browse::record_history(&config, &raw, Some("sivtr import"), CaptureSource::Import);
 
             match config.general.open_mode {
                 OpenMode::Editor => {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -188,7 +188,7 @@ const TMUX_MARKER_START: &str = "# >>> sivtr tmux shortcut >>>";
 const TMUX_MARKER_END: &str = "# <<< sivtr tmux shortcut <<<";
 #[cfg(unix)]
 const TMUX_HOOK: &str = r##"# >>> sivtr tmux shortcut >>>
-bind-key y new-window -c "#{pane_current_path}" "sivtr copy codex all --pick"
+bind-key y new-window -c "#{pane_current_path}" "sivtr copy codex --pick"
 # <<< sivtr tmux shortcut <<<
 "##;
 
@@ -632,7 +632,7 @@ fn render_linux_shortcut_script(cwd: &Path, terminal: Option<&str>) -> String {
 
 #[cfg(unix)]
 fn build_terminal_launch_command(terminal: &str) -> String {
-    let picker = "cd \"$PROJECT_CWD\"; exec sivtr copy codex all --pick";
+    let picker = "cd \"$PROJECT_CWD\"; exec sivtr copy codex --pick";
     match terminal {
         "gnome-terminal" => format!("exec gnome-terminal -- bash -lc '{picker}'"),
         "konsole" => format!("exec konsole --noclose -e bash -lc '{picker}'"),
@@ -662,7 +662,7 @@ fn write_macos_shortcut_script(path: &Path, cwd: &Path) -> Result<()> {
 fn render_macos_shortcut_script(cwd: &Path) -> String {
     let cwd = shell_single_quote(&cwd.to_string_lossy());
     format!(
-        "#!/usr/bin/env bash\nset -euo pipefail\nexport PROJECT_CWD='{cwd}'\ncd \"$PROJECT_CWD\"\nexec sivtr copy codex all --pick\n"
+        "#!/usr/bin/env bash\nset -euo pipefail\nexport PROJECT_CWD='{cwd}'\ncd \"$PROJECT_CWD\"\nexec sivtr copy codex --pick\n"
     )
 }
 
@@ -748,9 +748,9 @@ mod tests {
     };
     use super::{
         desktop_exec_quote, render_macos_shortcut_plist, render_macos_shortcut_script,
-        update_existing_hook, xml_escape, BASH_HOOK, BASH_SPEC,
-        LEGACY_POWERSHELL_HOOK, MACOS_SHORTCUT_LABEL, NUSHELL_HOOK, NUSHELL_SPEC, POWERSHELL_HOOK,
-        POWERSHELL_SPEC, ZSH_HOOK, ZSH_SPEC,
+        update_existing_hook, xml_escape, BASH_HOOK, BASH_SPEC, LEGACY_POWERSHELL_HOOK,
+        MACOS_SHORTCUT_LABEL, NUSHELL_HOOK, NUSHELL_SPEC, POWERSHELL_HOOK, POWERSHELL_SPEC,
+        ZSH_HOOK, ZSH_SPEC,
     };
     use std::path::Path;
 
@@ -842,7 +842,7 @@ mod tests {
         let command = build_terminal_launch_command("gnome-terminal");
 
         assert!(command.contains("gnome-terminal"));
-        assert!(command.contains("cd \"$PROJECT_CWD\"; exec sivtr copy codex all --pick"));
+        assert!(command.contains("cd \"$PROJECT_CWD\"; exec sivtr copy codex --pick"));
     }
 
     #[cfg(unix)]
@@ -857,7 +857,7 @@ mod tests {
         let script = render_linux_shortcut_script(Path::new("/tmp/project"), Some("xterm"));
 
         assert!(script.contains("export PROJECT_CWD='/tmp/project'"));
-        assert!(script.contains("cd \"$PROJECT_CWD\"; exec sivtr copy codex all --pick"));
+        assert!(script.contains("cd \"$PROJECT_CWD\"; exec sivtr copy codex --pick"));
     }
 
     #[test]
@@ -881,7 +881,7 @@ mod tests {
         let script = render_macos_shortcut_script(Path::new("/tmp/project"));
 
         assert!(script.contains("export PROJECT_CWD='/tmp/project'"));
-        assert!(script.contains("exec sivtr copy codex all --pick"));
+        assert!(script.contains("exec sivtr copy codex --pick"));
     }
 
     #[test]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -64,7 +64,29 @@ if [[ -n "${APPDATA:-}" ]]; then
 else
   export SIVTR_SESSION_LOG="${XDG_STATE_HOME:-$HOME/.local/state}/sivtr/session_$$.log"
 fi
+export SIVTR_CAPTURE_FILE="${SIVTR_SESSION_LOG%.log}.capture"
+mkdir -p "${SIVTR_SESSION_LOG%/*}"
+__sivtr_capture_active=0
+__sivtr_prompt_phase=0
+__sivtr_restore_capture() {
+  if [[ "${__sivtr_capture_active:-0}" -eq 1 ]]; then
+    exec 1>&19 2>&20
+    exec 19>&- 20>&-
+    __sivtr_capture_active=0
+  fi
+}
+__sivtr_preexec() {
+  [[ "${__sivtr_prompt_phase:-0}" -eq 1 ]] && return
+  [[ "${__sivtr_capture_active:-0}" -eq 1 ]] && return
+  : >| "$SIVTR_CAPTURE_FILE"
+  exec 19>&1 20>&2
+  exec > >(tee "$SIVTR_CAPTURE_FILE" >&19) 2>&1
+  __sivtr_capture_active=1
+}
 __sivtr_precmd() {
+  local exit_status=$?
+  __sivtr_prompt_phase=1
+  __sivtr_restore_capture
   local hist_entry
   hist_entry="$(HISTTIMEFORMAT= history 1)"
   if [[ $hist_entry =~ ^[[:space:]]*([0-9]+)[[:space:]]+(.*)$ ]]; then
@@ -73,7 +95,10 @@ __sivtr_precmd() {
   fi
   export SIVTR_LAST_PROMPT="${PS1@P}"
   sivtr flush >/dev/null 2>&1 || true
+  __sivtr_prompt_phase=0
+  return $exit_status
 }
+trap '__sivtr_preexec' DEBUG
 if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
   if [[ " ${PROMPT_COMMAND[*]} " != *" __sivtr_precmd "* ]]; then
     PROMPT_COMMAND=(__sivtr_precmd "${PROMPT_COMMAND[@]}")
@@ -97,13 +122,41 @@ if [[ -n "${APPDATA:-}" ]]; then
 else
   export SIVTR_SESSION_LOG="${XDG_STATE_HOME:-$HOME/.local/state}/sivtr/session_$$.log"
 fi
+export SIVTR_CAPTURE_FILE="${SIVTR_SESSION_LOG%.log}.capture"
+mkdir -p "${SIVTR_SESSION_LOG%/*}"
+typeset -ga preexec_functions precmd_functions
+typeset -g __sivtr_capture_active=0
+typeset -gi __sivtr_stdout_fd=-1 __sivtr_stderr_fd=-1
+_sivtr_restore_capture() {
+  if (( __sivtr_capture_active )); then
+    exec 1>&$__sivtr_stdout_fd
+    exec 2>&$__sivtr_stderr_fd
+    exec {__sivtr_stdout_fd}>&-
+    exec {__sivtr_stderr_fd}>&-
+    __sivtr_capture_active=0
+  fi
+}
+_sivtr_preexec() {
+  (( __sivtr_capture_active )) && return
+  : >| "$SIVTR_CAPTURE_FILE"
+  exec {__sivtr_stdout_fd}>&1
+  exec {__sivtr_stderr_fd}>&2
+  exec > >(tee "$SIVTR_CAPTURE_FILE" >&$__sivtr_stdout_fd) 2>&1
+  __sivtr_capture_active=1
+}
 _sivtr_precmd() {
+  local exit_status=$?
+  _sivtr_restore_capture
   export SIVTR_LAST_COMMAND="$(fc -ln -1)"
   export SIVTR_LAST_COMMAND_ID="$HISTCMD"
   export SIVTR_LAST_PROMPT="$(print -P "$PROMPT")"
   sivtr flush >/dev/null 2>&1 || true
+  return $exit_status
 }
-if (( ${precmd_functions[(I)_sivtr_precmd]} == 0 )); then
+if [[ " ${preexec_functions[*]:-} " != *" _sivtr_preexec "* ]]; then
+  preexec_functions=(_sivtr_preexec $preexec_functions)
+fi
+if [[ " ${precmd_functions[*]:-} " != *" _sivtr_precmd "* ]]; then
   precmd_functions=(_sivtr_precmd $precmd_functions)
 fi
 # <<< sivtr shell integration <<<
@@ -129,11 +182,11 @@ if (($env.SIVTR_PROMPT_WRAPPED? | default false) != true) {
 # <<< sivtr shell integration <<<
 "#;
 
-#[cfg(unix)]
+#[cfg_attr(not(unix), allow(dead_code))]
 const TMUX_MARKER_START: &str = "# >>> sivtr tmux shortcut >>>";
-#[cfg(unix)]
+#[cfg_attr(not(unix), allow(dead_code))]
 const TMUX_MARKER_END: &str = "# <<< sivtr tmux shortcut <<<";
-#[cfg(unix)]
+#[cfg_attr(not(unix), allow(dead_code))]
 const TMUX_HOOK: &str = r##"# >>> sivtr tmux shortcut >>>
 bind-key y new-window -c "#{pane_current_path}" "sivtr hotkey-pick-codex --cwd '#{pane_current_path}'"
 # <<< sivtr tmux shortcut <<<
@@ -175,7 +228,7 @@ const NUSHELL_SPEC: HookSpec = HookSpec {
     legacy_hook: None,
 };
 
-#[cfg(unix)]
+#[cfg_attr(not(unix), allow(dead_code))]
 const TMUX_SPEC: HookSpec = HookSpec {
     hook: TMUX_HOOK,
     marker_start: TMUX_MARKER_START,
@@ -184,6 +237,9 @@ const TMUX_SPEC: HookSpec = HookSpec {
     legacy_marker_end: TMUX_MARKER_END,
     legacy_hook: None,
 };
+
+#[cfg_attr(not(unix), allow(dead_code))]
+const MACOS_SHORTCUT_LABEL: &str = "dev.sivtr.pick-codex";
 
 enum InstallStatus {
     Installed,
@@ -200,11 +256,14 @@ pub fn execute(shell: &str) -> Result<()> {
         "nu" | "nushell" => install_single_shell_hook(&nushell_config_path()?, &NUSHELL_SPEC),
         "tmux" => install_tmux_shortcut(),
         "linux-shortcut" => install_linux_shortcut(),
+        "macos-shortcut" => install_macos_shortcut(),
         _ => {
             eprintln!(
-                "sivtr: supported targets are powershell, bash, zsh, nushell, tmux, linux-shortcut"
+                "sivtr: supported targets are powershell, bash, zsh, nushell, tmux, linux-shortcut, macos-shortcut"
             );
-            eprintln!("  usage: sivtr init <powershell|bash|zsh|nushell|tmux|linux-shortcut>");
+            eprintln!(
+                "  usage: sivtr init <powershell|bash|zsh|nushell|tmux|linux-shortcut|macos-shortcut>"
+            );
             std::process::exit(1);
         }
     }?;
@@ -281,7 +340,9 @@ fn install_tmux_shortcut() -> Result<()> {
 
 #[cfg(not(unix))]
 fn install_tmux_shortcut() -> Result<()> {
-    anyhow::bail!("`sivtr init tmux` is only supported on Unix-like systems");
+    Err(anyhow::anyhow!(
+        "`sivtr init tmux` is only supported on Unix-like systems"
+    ))
 }
 
 #[cfg(unix)]
@@ -316,7 +377,51 @@ fn install_linux_shortcut() -> Result<()> {
 
 #[cfg(not(unix))]
 fn install_linux_shortcut() -> Result<()> {
-    anyhow::bail!("`sivtr init linux-shortcut` is only supported on Unix-like systems");
+    Err(anyhow::anyhow!(
+        "`sivtr init linux-shortcut` is only supported on Unix-like systems"
+    ))
+}
+
+#[cfg(unix)]
+fn install_macos_shortcut() -> Result<()> {
+    if !cfg!(target_os = "macos") {
+        return Err(anyhow::anyhow!(
+            "`sivtr init macos-shortcut` must be run on macOS"
+        ));
+    }
+
+    let home = dirs::home_dir().context("Failed to resolve home directory")?;
+    let bin_dir = home.join(".local").join("bin");
+    let launch_agents_dir = home.join("Library").join("LaunchAgents");
+    fs::create_dir_all(&bin_dir)?;
+    fs::create_dir_all(&launch_agents_dir)?;
+
+    let cwd = std::env::current_dir().context("Failed to resolve current directory")?;
+    let script_path = bin_dir.join("sivtr-pick-codex");
+    let plist_path = launch_agents_dir.join(format!("{MACOS_SHORTCUT_LABEL}.plist"));
+
+    write_macos_shortcut_script(&script_path, &cwd)?;
+    write_macos_shortcut_plist(&plist_path, &script_path)?;
+
+    eprintln!("sivtr: installed macOS shortcut launcher");
+    eprintln!("  script: {}", script_path.display());
+    eprintln!("  agent:  {}", plist_path.display());
+    eprintln!(
+        "  load with: launchctl bootstrap gui/$(id -u) {}",
+        plist_path.display()
+    );
+    eprintln!(
+        "  run manually: osascript -e 'tell application \"Terminal\" to do script \"{}\"'",
+        shell_double_quote(&script_path.to_string_lossy())
+    );
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn install_macos_shortcut() -> Result<()> {
+    Err(anyhow::anyhow!(
+        "`sivtr init macos-shortcut` is only supported on macOS"
+    ))
 }
 
 fn print_install_summary(installed: &[String], updated: &[String]) {
@@ -338,19 +443,16 @@ fn maybe_start_hotkey() -> Result<()> {
     #[cfg(windows)]
     {
         if !atty::is(atty::Stream::Stdin) {
-            eprintln!("sivtr: start the AI session hotkey later with `sivtr hotkey start`");
+            eprintln!("sivtr: start the Codex hotkey later with `sivtr hotkey start`");
             return Ok(());
         }
 
         if prompt_start_hotkey()? {
             crate::commands::hotkey::execute(HotkeyCommand {
-                action: Some(HotkeyAction::Start(HotkeyStartArgs {
-                    chord: None,
-                    provider: Default::default(),
-                })),
+                action: Some(HotkeyAction::Start(HotkeyStartArgs { chord: None })),
             })?;
         } else {
-            eprintln!("sivtr: start the AI session hotkey later with `sivtr hotkey start`");
+            eprintln!("sivtr: start the Codex hotkey later with `sivtr hotkey start`");
         }
     }
 
@@ -359,7 +461,7 @@ fn maybe_start_hotkey() -> Result<()> {
 
 #[cfg(windows)]
 fn prompt_start_hotkey() -> Result<bool> {
-    eprint!("sivtr: start the Windows AI session hotkey now? [Y/n] ");
+    eprint!("sivtr: start the Windows Codex hotkey now? [Y/n] ");
     io::stderr().flush()?;
 
     let mut input = String::new();
@@ -415,7 +517,7 @@ fn nushell_config_path() -> Result<PathBuf> {
     Ok(config_dir.join("nushell").join("config.nu"))
 }
 
-#[cfg(unix)]
+#[cfg_attr(not(unix), allow(dead_code))]
 fn tmux_config_path() -> Result<PathBuf> {
     let home = dirs::home_dir().context("Failed to resolve home directory")?;
     Ok(home.join(".tmux.conf"))
@@ -477,7 +579,7 @@ fn update_existing_hook(content: &str, spec: &HookSpec) -> Option<String> {
     None
 }
 
-#[cfg(unix)]
+#[cfg_attr(not(unix), allow(dead_code))]
 fn detect_linux_terminal() -> Option<String> {
     for candidate in [
         "x-terminal-emulator",
@@ -496,7 +598,7 @@ fn detect_linux_terminal() -> Option<String> {
     None
 }
 
-#[cfg(unix)]
+#[cfg_attr(not(unix), allow(dead_code))]
 fn command_exists(name: &str) -> bool {
     std::env::var_os("PATH")
         .map(|paths| {
@@ -508,7 +610,7 @@ fn command_exists(name: &str) -> bool {
         .unwrap_or(false)
 }
 
-#[cfg(unix)]
+#[cfg_attr(not(unix), allow(dead_code))]
 fn write_linux_shortcut_script(path: &Path, cwd: &Path, terminal: Option<&str>) -> Result<()> {
     let script = render_linux_shortcut_script(cwd, terminal);
     fs::write(path, script)?;
@@ -521,7 +623,7 @@ fn write_linux_shortcut_script(path: &Path, cwd: &Path, terminal: Option<&str>) 
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg_attr(not(unix), allow(dead_code))]
 fn render_linux_shortcut_script(cwd: &Path, terminal: Option<&str>) -> String {
     let cwd = shell_single_quote(&cwd.to_string_lossy());
     let launcher = terminal
@@ -534,7 +636,7 @@ fn render_linux_shortcut_script(cwd: &Path, terminal: Option<&str>) -> String {
     format!("#!/usr/bin/env bash\nset -euo pipefail\nexport PROJECT_CWD='{cwd}'\n{launcher}\n")
 }
 
-#[cfg(unix)]
+#[cfg_attr(not(unix), allow(dead_code))]
 fn build_terminal_launch_command(terminal: &str) -> String {
     let picker = "sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\"";
     match terminal {
@@ -549,19 +651,87 @@ fn build_terminal_launch_command(terminal: &str) -> String {
     }
 }
 
-#[cfg(unix)]
+#[cfg_attr(not(unix), allow(dead_code))]
+fn write_macos_shortcut_script(path: &Path, cwd: &Path) -> Result<()> {
+    let script = render_macos_shortcut_script(cwd);
+    fs::write(path, script)?;
+    #[cfg(unix)]
+    {
+        let mut perms = fs::metadata(path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(path, perms)?;
+    }
+    Ok(())
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+fn render_macos_shortcut_script(cwd: &Path) -> String {
+    let cwd = shell_single_quote(&cwd.to_string_lossy());
+    format!(
+        "#!/usr/bin/env bash\nset -euo pipefail\nexport PROJECT_CWD='{cwd}'\ncd \"$PROJECT_CWD\"\nexec sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\"\n"
+    )
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+fn write_macos_shortcut_plist(path: &Path, script_path: &Path) -> Result<()> {
+    let plist = render_macos_shortcut_plist(script_path);
+    fs::write(path, plist)?;
+    Ok(())
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+fn render_macos_shortcut_plist(script_path: &Path) -> String {
+    let script = xml_escape(&script_path.to_string_lossy());
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>{MACOS_SHORTCUT_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/osascript</string>
+    <string>-e</string>
+    <string>tell application "Terminal" to do script "{script}"</string>
+  </array>
+</dict>
+</plist>
+"#
+    )
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
 fn write_linux_shortcut_desktop_entry(path: &Path, script_path: &Path) -> Result<()> {
     let desktop = format!(
         "[Desktop Entry]\nType=Application\nName=Sivtr Pick Codex\nExec={}\nTerminal=false\nCategories=Development;\n",
-        script_path.display()
+        desktop_exec_quote(&script_path.to_string_lossy())
     );
     fs::write(path, desktop)?;
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg_attr(not(unix), allow(dead_code))]
 fn shell_single_quote(value: &str) -> String {
     value.replace('\'', "'\"'\"'")
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+fn desktop_exec_quote(value: &str) -> String {
+    format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+fn shell_double_quote(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+#[cfg_attr(not(unix), allow(dead_code))]
+fn xml_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
 }
 
 fn find_marked_block(
@@ -577,16 +747,13 @@ fn find_marked_block(
 
 #[cfg(test)]
 mod tests {
-    #[cfg(unix)]
     use super::{
-        build_terminal_launch_command, command_exists, render_linux_shortcut_script,
-        shell_single_quote, TMUX_HOOK, TMUX_SPEC,
+        build_terminal_launch_command, command_exists, desktop_exec_quote,
+        render_linux_shortcut_script, render_macos_shortcut_plist, render_macos_shortcut_script,
+        shell_single_quote, update_existing_hook, xml_escape, BASH_HOOK, BASH_SPEC,
+        LEGACY_POWERSHELL_HOOK, MACOS_SHORTCUT_LABEL, NUSHELL_HOOK, NUSHELL_SPEC, POWERSHELL_HOOK,
+        POWERSHELL_SPEC, TMUX_HOOK, TMUX_SPEC, ZSH_HOOK, ZSH_SPEC,
     };
-    use super::{
-        update_existing_hook, BASH_HOOK, BASH_SPEC, LEGACY_POWERSHELL_HOOK, NUSHELL_HOOK,
-        NUSHELL_SPEC, POWERSHELL_HOOK, POWERSHELL_SPEC, ZSH_HOOK, ZSH_SPEC,
-    };
-    #[cfg(unix)]
     use std::path::Path;
 
     #[cfg(windows)]
@@ -629,12 +796,27 @@ mod tests {
     }
 
     #[test]
+    fn bash_hook_sets_up_capture_file_and_debug_trap() {
+        assert!(BASH_HOOK.contains("export SIVTR_CAPTURE_FILE="));
+        assert!(BASH_HOOK.contains("trap '__sivtr_preexec' DEBUG"));
+        assert!(BASH_HOOK.contains("tee \"$SIVTR_CAPTURE_FILE\""));
+    }
+
+    #[test]
     fn replaces_existing_zsh_block() {
         let profile = format!("before\n{ZSH_HOOK}\nafter\n");
         let updated =
             update_existing_hook(&profile, &ZSH_SPEC).expect("zsh hook should be detected");
 
         assert_eq!(updated, profile);
+    }
+
+    #[test]
+    fn zsh_hook_sets_up_preexec_capture() {
+        assert!(ZSH_HOOK.contains("export SIVTR_CAPTURE_FILE="));
+        assert!(ZSH_HOOK.contains("preexec_functions=(_sivtr_preexec"));
+        assert!(ZSH_HOOK.contains("typeset -ga preexec_functions precmd_functions"));
+        assert!(ZSH_HOOK.contains("tee \"$SIVTR_CAPTURE_FILE\""));
     }
 
     #[test]
@@ -646,7 +828,6 @@ mod tests {
         assert_eq!(updated, profile);
     }
 
-    #[cfg(unix)]
     #[test]
     fn replaces_existing_tmux_block() {
         let profile = format!("before\n{TMUX_HOOK}\nafter\n");
@@ -656,7 +837,6 @@ mod tests {
         assert_eq!(updated, profile);
     }
 
-    #[cfg(unix)]
     #[test]
     fn gnome_terminal_launcher_uses_project_cwd() {
         let command = build_terminal_launch_command("gnome-terminal");
@@ -665,13 +845,11 @@ mod tests {
         assert!(command.contains("sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\""));
     }
 
-    #[cfg(unix)]
     #[test]
     fn shell_single_quote_escapes_single_quotes() {
         assert_eq!(shell_single_quote("/tmp/it's"), "/tmp/it'\"'\"'s");
     }
 
-    #[cfg(unix)]
     #[test]
     fn linux_shortcut_script_exports_project_cwd() {
         let script = render_linux_shortcut_script(Path::new("/tmp/project"), Some("xterm"));
@@ -680,7 +858,45 @@ mod tests {
         assert!(script.contains("sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\""));
     }
 
-    #[cfg(unix)]
+    #[test]
+    fn desktop_exec_quote_wraps_paths_with_spaces() {
+        assert_eq!(
+            desktop_exec_quote("/tmp/sivtr desktop/sivtr-pick-codex"),
+            "\"/tmp/sivtr desktop/sivtr-pick-codex\""
+        );
+    }
+
+    #[test]
+    fn desktop_exec_quote_escapes_embedded_quotes_and_backslashes() {
+        assert_eq!(
+            desktop_exec_quote("/tmp/dir \\\"quoted\\\"/sivtr"),
+            "\"/tmp/dir \\\\\\\"quoted\\\\\\\"/sivtr\""
+        );
+    }
+
+    #[test]
+    fn macos_shortcut_script_runs_picker_in_project_cwd() {
+        let script = render_macos_shortcut_script(Path::new("/tmp/project"));
+
+        assert!(script.contains("export PROJECT_CWD='/tmp/project'"));
+        assert!(script.contains("exec sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\""));
+    }
+
+    #[test]
+    fn macos_shortcut_plist_uses_terminal_osascript_launcher() {
+        let plist = render_macos_shortcut_plist(Path::new("/tmp/sivtr-pick-codex"));
+
+        assert!(plist.contains(MACOS_SHORTCUT_LABEL));
+        assert!(plist.contains("/usr/bin/osascript"));
+        assert!(plist.contains("tell application \"Terminal\" to do script"));
+        assert!(plist.contains("/tmp/sivtr-pick-codex"));
+    }
+
+    #[test]
+    fn xml_escape_escapes_special_characters() {
+        assert_eq!(xml_escape("a&b<c>d"), "a&amp;b&lt;c&gt;d");
+    }
+
     #[test]
     fn command_exists_detects_programs_via_path_scan() {
         assert!(command_exists("sh"));

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -340,9 +340,7 @@ fn install_tmux_shortcut() -> Result<()> {
 
 #[cfg(not(unix))]
 fn install_tmux_shortcut() -> Result<()> {
-    Err(anyhow::anyhow!(
-        "`sivtr init tmux` is only supported on Unix-like systems"
-    ))
+    anyhow::bail!("`sivtr init tmux` is only supported on Unix-like systems");
 }
 
 #[cfg(unix)]
@@ -377,9 +375,7 @@ fn install_linux_shortcut() -> Result<()> {
 
 #[cfg(not(unix))]
 fn install_linux_shortcut() -> Result<()> {
-    Err(anyhow::anyhow!(
-        "`sivtr init linux-shortcut` is only supported on Unix-like systems"
-    ))
+    anyhow::bail!("`sivtr init linux-shortcut` is only supported on Unix-like systems");
 }
 
 #[cfg(unix)]
@@ -419,9 +415,7 @@ fn install_macos_shortcut() -> Result<()> {
 
 #[cfg(not(unix))]
 fn install_macos_shortcut() -> Result<()> {
-    Err(anyhow::anyhow!(
-        "`sivtr init macos-shortcut` is only supported on macOS"
-    ))
+    anyhow::bail!("`sivtr init macos-shortcut` is only supported on macOS");
 }
 
 fn print_install_summary(installed: &[String], updated: &[String]) {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -398,7 +398,10 @@ fn maybe_start_hotkey() -> Result<()> {
 
         if prompt_start_hotkey()? {
             crate::commands::hotkey::execute(HotkeyCommand {
-                action: Some(HotkeyAction::Start(HotkeyStartArgs { chord: None })),
+                action: Some(HotkeyAction::Start(HotkeyStartArgs {
+                    chord: None,
+                    provider: Default::default(),
+                })),
             })?;
         } else {
             eprintln!("sivtr: start the Codex hotkey later with `sivtr hotkey start`");
@@ -660,7 +663,7 @@ fn write_linux_shortcut_desktop_entry(path: &Path, script_path: &Path) -> Result
     Ok(())
 }
 
-#[cfg(unix)]
+#[cfg_attr(not(unix), allow(dead_code))]
 fn shell_single_quote(value: &str) -> String {
     value.replace('\'', "'\"'\"'")
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -188,7 +188,7 @@ const TMUX_MARKER_START: &str = "# >>> sivtr tmux shortcut >>>";
 const TMUX_MARKER_END: &str = "# <<< sivtr tmux shortcut <<<";
 #[cfg(unix)]
 const TMUX_HOOK: &str = r##"# >>> sivtr tmux shortcut >>>
-bind-key y new-window -c "#{pane_current_path}" "sivtr hotkey-pick-codex --cwd '#{pane_current_path}'"
+bind-key y new-window -c "#{pane_current_path}" "sivtr copy codex all --pick"
 # <<< sivtr tmux shortcut <<<
 "##;
 
@@ -632,7 +632,7 @@ fn render_linux_shortcut_script(cwd: &Path, terminal: Option<&str>) -> String {
 
 #[cfg(unix)]
 fn build_terminal_launch_command(terminal: &str) -> String {
-    let picker = "sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\"";
+    let picker = "cd \"$PROJECT_CWD\"; exec sivtr copy codex all --pick";
     match terminal {
         "gnome-terminal" => format!("exec gnome-terminal -- bash -lc '{picker}'"),
         "konsole" => format!("exec konsole --noclose -e bash -lc '{picker}'"),
@@ -662,7 +662,7 @@ fn write_macos_shortcut_script(path: &Path, cwd: &Path) -> Result<()> {
 fn render_macos_shortcut_script(cwd: &Path) -> String {
     let cwd = shell_single_quote(&cwd.to_string_lossy());
     format!(
-        "#!/usr/bin/env bash\nset -euo pipefail\nexport PROJECT_CWD='{cwd}'\ncd \"$PROJECT_CWD\"\nexec sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\"\n"
+        "#!/usr/bin/env bash\nset -euo pipefail\nexport PROJECT_CWD='{cwd}'\ncd \"$PROJECT_CWD\"\nexec sivtr copy codex all --pick\n"
     )
 }
 
@@ -842,7 +842,7 @@ mod tests {
         let command = build_terminal_launch_command("gnome-terminal");
 
         assert!(command.contains("gnome-terminal"));
-        assert!(command.contains("sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\""));
+        assert!(command.contains("cd \"$PROJECT_CWD\"; exec sivtr copy codex all --pick"));
     }
 
     #[cfg(unix)]
@@ -857,7 +857,7 @@ mod tests {
         let script = render_linux_shortcut_script(Path::new("/tmp/project"), Some("xterm"));
 
         assert!(script.contains("export PROJECT_CWD='/tmp/project'"));
-        assert!(script.contains("sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\""));
+        assert!(script.contains("cd \"$PROJECT_CWD\"; exec sivtr copy codex all --pick"));
     }
 
     #[test]
@@ -881,7 +881,7 @@ mod tests {
         let script = render_macos_shortcut_script(Path::new("/tmp/project"));
 
         assert!(script.contains("export PROJECT_CWD='/tmp/project'"));
-        assert!(script.contains("exec sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\""));
+        assert!(script.contains("exec sivtr copy codex all --pick"));
     }
 
     #[test]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -66,27 +66,8 @@ else
 fi
 export SIVTR_CAPTURE_FILE="${SIVTR_SESSION_LOG%.log}.capture"
 mkdir -p "${SIVTR_SESSION_LOG%/*}"
-__sivtr_capture_active=0
-__sivtr_prompt_phase=0
-__sivtr_restore_capture() {
-  if [[ "${__sivtr_capture_active:-0}" -eq 1 ]]; then
-    exec 1>&19 2>&20
-    exec 19>&- 20>&-
-    __sivtr_capture_active=0
-  fi
-}
-__sivtr_preexec() {
-  [[ "${__sivtr_prompt_phase:-0}" -eq 1 ]] && return
-  [[ "${__sivtr_capture_active:-0}" -eq 1 ]] && return
-  : >| "$SIVTR_CAPTURE_FILE"
-  exec 19>&1 20>&2
-  exec > >(tee "$SIVTR_CAPTURE_FILE" >&19) 2>&1
-  __sivtr_capture_active=1
-}
 __sivtr_precmd() {
   local exit_status=$?
-  __sivtr_prompt_phase=1
-  __sivtr_restore_capture
   local hist_entry
   hist_entry="$(HISTTIMEFORMAT= history 1)"
   if [[ $hist_entry =~ ^[[:space:]]*([0-9]+)[[:space:]]+(.*)$ ]]; then
@@ -95,10 +76,8 @@ __sivtr_precmd() {
   fi
   export SIVTR_LAST_PROMPT="${PS1@P}"
   sivtr flush >/dev/null 2>&1 || true
-  __sivtr_prompt_phase=0
   return $exit_status
 }
-trap '__sivtr_preexec' DEBUG
 if [[ "$(declare -p PROMPT_COMMAND 2>/dev/null)" == "declare -a"* ]]; then
   if [[ " ${PROMPT_COMMAND[*]} " != *" __sivtr_precmd "* ]]; then
     PROMPT_COMMAND=(__sivtr_precmd "${PROMPT_COMMAND[@]}")
@@ -124,38 +103,14 @@ else
 fi
 export SIVTR_CAPTURE_FILE="${SIVTR_SESSION_LOG%.log}.capture"
 mkdir -p "${SIVTR_SESSION_LOG%/*}"
-typeset -ga preexec_functions precmd_functions
-typeset -g __sivtr_capture_active=0
-typeset -gi __sivtr_stdout_fd=-1 __sivtr_stderr_fd=-1
-_sivtr_restore_capture() {
-  if (( __sivtr_capture_active )); then
-    exec 1>&$__sivtr_stdout_fd
-    exec 2>&$__sivtr_stderr_fd
-    exec {__sivtr_stdout_fd}>&-
-    exec {__sivtr_stderr_fd}>&-
-    __sivtr_capture_active=0
-  fi
-}
-_sivtr_preexec() {
-  (( __sivtr_capture_active )) && return
-  : >| "$SIVTR_CAPTURE_FILE"
-  exec {__sivtr_stdout_fd}>&1
-  exec {__sivtr_stderr_fd}>&2
-  exec > >(tee "$SIVTR_CAPTURE_FILE" >&$__sivtr_stdout_fd) 2>&1
-  __sivtr_capture_active=1
-}
 _sivtr_precmd() {
   local exit_status=$?
-  _sivtr_restore_capture
   export SIVTR_LAST_COMMAND="$(fc -ln -1)"
   export SIVTR_LAST_COMMAND_ID="$HISTCMD"
   export SIVTR_LAST_PROMPT="$(print -P "$PROMPT")"
   sivtr flush >/dev/null 2>&1 || true
   return $exit_status
 }
-if [[ " ${preexec_functions[*]:-} " != *" _sivtr_preexec "* ]]; then
-  preexec_functions=(_sivtr_preexec $preexec_functions)
-fi
 if [[ " ${precmd_functions[*]:-} " != *" _sivtr_precmd "* ]]; then
   precmd_functions=(_sivtr_precmd $precmd_functions)
 fi
@@ -794,10 +749,10 @@ mod tests {
     }
 
     #[test]
-    fn bash_hook_sets_up_capture_file_and_debug_trap() {
+    fn bash_hook_keeps_capture_path_without_tty_redirection() {
         assert!(BASH_HOOK.contains("export SIVTR_CAPTURE_FILE="));
-        assert!(BASH_HOOK.contains("trap '__sivtr_preexec' DEBUG"));
-        assert!(BASH_HOOK.contains("tee \"$SIVTR_CAPTURE_FILE\""));
+        assert!(!BASH_HOOK.contains("trap '__sivtr_preexec' DEBUG"));
+        assert!(!BASH_HOOK.contains("exec > >(tee \"$SIVTR_CAPTURE_FILE\""));
     }
 
     #[test]
@@ -810,11 +765,10 @@ mod tests {
     }
 
     #[test]
-    fn zsh_hook_sets_up_preexec_capture() {
+    fn zsh_hook_keeps_capture_path_without_tty_redirection() {
         assert!(ZSH_HOOK.contains("export SIVTR_CAPTURE_FILE="));
-        assert!(ZSH_HOOK.contains("preexec_functions=(_sivtr_preexec"));
-        assert!(ZSH_HOOK.contains("typeset -ga preexec_functions precmd_functions"));
-        assert!(ZSH_HOOK.contains("tee \"$SIVTR_CAPTURE_FILE\""));
+        assert!(!ZSH_HOOK.contains("preexec_functions=(_sivtr_preexec"));
+        assert!(!ZSH_HOOK.contains("exec > >(tee \"$SIVTR_CAPTURE_FILE\""));
     }
 
     #[test]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -182,11 +182,11 @@ if (($env.SIVTR_PROMPT_WRAPPED? | default false) != true) {
 # <<< sivtr shell integration <<<
 "#;
 
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 const TMUX_MARKER_START: &str = "# >>> sivtr tmux shortcut >>>";
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 const TMUX_MARKER_END: &str = "# <<< sivtr tmux shortcut <<<";
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 const TMUX_HOOK: &str = r##"# >>> sivtr tmux shortcut >>>
 bind-key y new-window -c "#{pane_current_path}" "sivtr hotkey-pick-codex --cwd '#{pane_current_path}'"
 # <<< sivtr tmux shortcut <<<
@@ -228,7 +228,7 @@ const NUSHELL_SPEC: HookSpec = HookSpec {
     legacy_hook: None,
 };
 
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 const TMUX_SPEC: HookSpec = HookSpec {
     hook: TMUX_HOOK,
     marker_start: TMUX_MARKER_START,
@@ -511,7 +511,7 @@ fn nushell_config_path() -> Result<PathBuf> {
     Ok(config_dir.join("nushell").join("config.nu"))
 }
 
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 fn tmux_config_path() -> Result<PathBuf> {
     let home = dirs::home_dir().context("Failed to resolve home directory")?;
     Ok(home.join(".tmux.conf"))
@@ -573,7 +573,7 @@ fn update_existing_hook(content: &str, spec: &HookSpec) -> Option<String> {
     None
 }
 
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 fn detect_linux_terminal() -> Option<String> {
     for candidate in [
         "x-terminal-emulator",
@@ -592,7 +592,7 @@ fn detect_linux_terminal() -> Option<String> {
     None
 }
 
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 fn command_exists(name: &str) -> bool {
     std::env::var_os("PATH")
         .map(|paths| {
@@ -604,7 +604,7 @@ fn command_exists(name: &str) -> bool {
         .unwrap_or(false)
 }
 
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 fn write_linux_shortcut_script(path: &Path, cwd: &Path, terminal: Option<&str>) -> Result<()> {
     let script = render_linux_shortcut_script(cwd, terminal);
     fs::write(path, script)?;
@@ -617,7 +617,7 @@ fn write_linux_shortcut_script(path: &Path, cwd: &Path, terminal: Option<&str>) 
     Ok(())
 }
 
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 fn render_linux_shortcut_script(cwd: &Path, terminal: Option<&str>) -> String {
     let cwd = shell_single_quote(&cwd.to_string_lossy());
     let launcher = terminal
@@ -630,7 +630,7 @@ fn render_linux_shortcut_script(cwd: &Path, terminal: Option<&str>) -> String {
     format!("#!/usr/bin/env bash\nset -euo pipefail\nexport PROJECT_CWD='{cwd}'\n{launcher}\n")
 }
 
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 fn build_terminal_launch_command(terminal: &str) -> String {
     let picker = "sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\"";
     match terminal {
@@ -695,7 +695,7 @@ fn render_macos_shortcut_plist(script_path: &Path) -> String {
     )
 }
 
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 fn write_linux_shortcut_desktop_entry(path: &Path, script_path: &Path) -> Result<()> {
     let desktop = format!(
         "[Desktop Entry]\nType=Application\nName=Sivtr Pick Codex\nExec={}\nTerminal=false\nCategories=Development;\n",
@@ -705,7 +705,7 @@ fn write_linux_shortcut_desktop_entry(path: &Path, script_path: &Path) -> Result
     Ok(())
 }
 
-#[cfg_attr(not(unix), allow(dead_code))]
+#[cfg(unix)]
 fn shell_single_quote(value: &str) -> String {
     value.replace('\'', "'\"'\"'")
 }
@@ -741,12 +741,16 @@ fn find_marked_block(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
     use super::{
-        build_terminal_launch_command, command_exists, desktop_exec_quote,
-        render_linux_shortcut_script, render_macos_shortcut_plist, render_macos_shortcut_script,
-        shell_single_quote, update_existing_hook, xml_escape, BASH_HOOK, BASH_SPEC,
+        build_terminal_launch_command, command_exists, render_linux_shortcut_script,
+        shell_single_quote, TMUX_HOOK, TMUX_SPEC,
+    };
+    use super::{
+        desktop_exec_quote, render_macos_shortcut_plist, render_macos_shortcut_script,
+        update_existing_hook, xml_escape, BASH_HOOK, BASH_SPEC,
         LEGACY_POWERSHELL_HOOK, MACOS_SHORTCUT_LABEL, NUSHELL_HOOK, NUSHELL_SPEC, POWERSHELL_HOOK,
-        POWERSHELL_SPEC, TMUX_HOOK, TMUX_SPEC, ZSH_HOOK, ZSH_SPEC,
+        POWERSHELL_SPEC, ZSH_HOOK, ZSH_SPEC,
     };
     use std::path::Path;
 
@@ -822,6 +826,7 @@ mod tests {
         assert_eq!(updated, profile);
     }
 
+    #[cfg(unix)]
     #[test]
     fn replaces_existing_tmux_block() {
         let profile = format!("before\n{TMUX_HOOK}\nafter\n");
@@ -831,6 +836,7 @@ mod tests {
         assert_eq!(updated, profile);
     }
 
+    #[cfg(unix)]
     #[test]
     fn gnome_terminal_launcher_uses_project_cwd() {
         let command = build_terminal_launch_command("gnome-terminal");
@@ -839,11 +845,13 @@ mod tests {
         assert!(command.contains("sivtr hotkey-pick-codex --cwd \"$PROJECT_CWD\""));
     }
 
+    #[cfg(unix)]
     #[test]
     fn shell_single_quote_escapes_single_quotes() {
         assert_eq!(shell_single_quote("/tmp/it's"), "/tmp/it'\"'\"'s");
     }
 
+    #[cfg(unix)]
     #[test]
     fn linux_shortcut_script_exports_project_cwd() {
         let script = render_linux_shortcut_script(Path::new("/tmp/project"), Some("xterm"));
@@ -891,6 +899,7 @@ mod tests {
         assert_eq!(xml_escape("a&b<c>d"), "a&amp;b&lt;c&gt;d");
     }
 
+    #[cfg(unix)]
     #[test]
     fn command_exists_detects_programs_via_path_scan() {
         assert!(command_exists("sh"));


### PR DESCRIPTION
## 1. Context & Motivation
- **Issue:** Fixes #5
- **Problem:** On Unix/macOS flows, `sivtr flush` only relied on Windows console capture or shell history metadata, so shell output from non-Windows sessions could be incomplete or stale for picker/copy flows.
- **Trade-offs:** This introduces per-command capture file handling in shell hooks and flush processing. It increases transient file I/O (`.capture`) but improves session fidelity and keeps behavior deterministic across Unix shells.

## 2. Implementation Details
- Added Unix capture artifact support in `scrollback` and cleanup paths:
  - recognize `session_<pid>.capture` as a session artifact;
  - expose `capture_file_path()` with `SIVTR_CAPTURE_FILE` override;
  - clear `.capture` files during `sivtr clear` and `clear --all` scanning.
- Extended `flush` non-Windows path to ingest captured command output from `.capture`, trim trailing prompt artifacts, and append structured entries using shared de-duplication state logic.
- Updated shell integration hooks (`bash`/`zsh`) to emit per-command capture files and added regression tests for capture wiring.
- Added supporting docs/readme updates for init targets and picker shortcut usage so Unix/macOS setup instructions match runtime behavior.

## 3. Testing Strategies
- [x] Added/updated unit tests for capture-file parsing, flush behavior, and init hook capture setup.
- [x] Ran `cargo test` on Linux host (`91 passed`).
- [x] Verified backward-compatible command behavior for existing `sivtr init` and `sivtr copy` flows.
