### PR TITLE
refactor(record): preserve canonical work parts

### DIFF
--- a/crates/sivtr-core/src/record/index.rs
+++ b/crates/sivtr-core/src/record/index.rs
@@ -161,6 +161,7 @@ mod tests {
                 output: None,
                 combined: combined.to_string(),
             },
+            parts: Vec::new(),
             payload: WorkPayload::ChatTurn {
                 user: String::new(),
                 assistant: combined.to_string(),

--- a/crates/sivtr-core/src/record/mod.rs
+++ b/crates/sivtr-core/src/record/mod.rs
@@ -5,7 +5,8 @@ pub mod refs;
 pub use index::{WorkRecordIndex, WorkRecordMatch, WorkRecordSearchScope};
 pub use model::{
     chat_turn_ranges, is_real_user_block, ChatMessage, RecordText, RecordTextMode, WorkChannel,
-    WorkOutcome, WorkPayload, WorkRecord, WorkRecordCopyParts, WorkRecordKind, WorkSessionRef,
-    WorkSource, WorkStatus, WorkText, WorkTime, RECORD_SCHEMA_VERSION,
+    WorkOutcome, WorkPart, WorkPartIo, WorkPartKind, WorkPayload, WorkRecord, WorkRecordCopyParts,
+    WorkRecordKind, WorkSessionRef, WorkSource, WorkStatus, WorkText, WorkTime,
+    RECORD_SCHEMA_VERSION,
 };
 pub use refs::{WorkRef, WorkRefTarget};

--- a/crates/sivtr-core/src/record/model.rs
+++ b/crates/sivtr-core/src/record/model.rs
@@ -139,6 +139,40 @@ pub struct WorkText {
     pub combined: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkPartIo {
+    Input,
+    Output,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkPartKind {
+    Prompt,
+    Command,
+    UserMessage,
+    AssistantMessage,
+    ToolCall,
+    ToolOutput,
+    Text,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WorkPart {
+    pub io: WorkPartIo,
+    pub kind: WorkPartKind,
+    pub index_in_record: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub occurred_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ansi: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum WorkPayload {
@@ -179,6 +213,8 @@ pub struct WorkRecord {
     pub status: WorkStatus,
     pub title: String,
     pub text: WorkText,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parts: Vec<WorkPart>,
     pub payload: WorkPayload,
 }
 
@@ -207,6 +243,7 @@ impl WorkRecord {
             Some(_) => WorkOutcome::Failure,
             None => WorkOutcome::Unknown,
         };
+        let parts = terminal_parts(entry, &command, &output);
         let combined = join_nonempty([command.as_str(), output.as_str()]);
 
         Some(Self {
@@ -239,6 +276,7 @@ impl WorkRecord {
                 output: non_empty(Some(output.clone())),
                 combined,
             },
+            parts,
             payload: WorkPayload::TerminalCommand {
                 prompt: entry.prompt.clone(),
                 command,
@@ -265,6 +303,7 @@ impl WorkRecord {
         index: usize,
         blocks: &[AgentBlock],
     ) -> Option<Self> {
+        let parts = agent_parts(blocks);
         let chat_blocks = blocks
             .iter()
             .filter(|block| matches!(block.kind, AgentBlockKind::User | AgentBlockKind::Assistant))
@@ -340,6 +379,7 @@ impl WorkRecord {
                 output: non_empty(Some(assistant.clone())),
                 combined,
             },
+            parts,
             payload: WorkPayload::ChatTurn {
                 user,
                 assistant,
@@ -449,6 +489,7 @@ impl WorkRecord {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn terminal_record_text(
     mode: RecordTextMode,
     prompt: &str,
@@ -625,6 +666,7 @@ fn selected_block_record(
             output,
             combined: text.clone(),
         },
+        parts: agent_parts(std::slice::from_ref(&block)),
         payload: WorkPayload::ChatTurn {
             user: match kind {
                 AgentBlockKind::User => text.clone(),
@@ -688,6 +730,7 @@ fn selected_group_record(
             output: Some(combined.clone()),
             combined: combined.clone(),
         },
+        parts: agent_parts(&blocks),
         payload: WorkPayload::ChatTurn {
             user: String::new(),
             assistant: combined,
@@ -792,6 +835,75 @@ fn preview(text: &str) -> String {
         .collect()
 }
 
+fn terminal_parts(entry: &SessionEntry, command: &str, output: &str) -> Vec<WorkPart> {
+    let mut parts = Vec::new();
+    let prompt = entry.prompt.trim_end_matches(['\r', '\n']);
+    if !prompt.trim().is_empty() {
+        parts.push(WorkPart {
+            io: WorkPartIo::Input,
+            kind: WorkPartKind::Prompt,
+            index_in_record: next_part_index(&parts, WorkPartIo::Input),
+            occurred_at: entry.ended_at.clone(),
+            label: None,
+            text: prompt.to_string(),
+            ansi: entry.prompt_ansi.clone(),
+        });
+    }
+    if !command.is_empty() {
+        parts.push(WorkPart {
+            io: WorkPartIo::Input,
+            kind: WorkPartKind::Command,
+            index_in_record: next_part_index(&parts, WorkPartIo::Input),
+            occurred_at: entry.ended_at.clone(),
+            label: None,
+            text: command.to_string(),
+            ansi: None,
+        });
+    }
+    if !output.is_empty() {
+        parts.push(WorkPart {
+            io: WorkPartIo::Output,
+            kind: WorkPartKind::Text,
+            index_in_record: next_part_index(&parts, WorkPartIo::Output),
+            occurred_at: entry.ended_at.clone(),
+            label: None,
+            text: output.to_string(),
+            ansi: entry.output_ansi.clone(),
+        });
+    }
+    parts
+}
+
+fn agent_parts(blocks: &[AgentBlock]) -> Vec<WorkPart> {
+    let mut parts = Vec::new();
+    for block in blocks {
+        let text = block.text.trim().to_string();
+        if text.is_empty() {
+            continue;
+        }
+        let (io, kind) = match block.kind {
+            AgentBlockKind::User => (WorkPartIo::Input, WorkPartKind::UserMessage),
+            AgentBlockKind::Assistant => (WorkPartIo::Output, WorkPartKind::AssistantMessage),
+            AgentBlockKind::ToolCall => (WorkPartIo::Input, WorkPartKind::ToolCall),
+            AgentBlockKind::ToolOutput => (WorkPartIo::Output, WorkPartKind::ToolOutput),
+        };
+        parts.push(WorkPart {
+            io,
+            kind,
+            index_in_record: next_part_index(&parts, io),
+            occurred_at: block.timestamp.clone(),
+            label: block.label.clone(),
+            text,
+            ansi: None,
+        });
+    }
+    parts
+}
+
+fn next_part_index(parts: &[WorkPart], io: WorkPartIo) -> usize {
+    parts.iter().filter(|part| part.io == io).count() + 1
+}
+
 fn join_nonempty<'a>(texts: impl IntoIterator<Item = &'a str>) -> String {
     texts
         .into_iter()
@@ -832,6 +944,13 @@ mod tests {
         assert_eq!(record.status.exit_code, Some(101));
         assert_eq!(record.text.input.as_deref(), Some("cargo test"));
         assert_eq!(record.text.output.as_deref(), Some("failed"));
+        assert_eq!(record.parts.len(), 3);
+        assert_eq!(record.parts[0].kind, WorkPartKind::Prompt);
+        assert_eq!(record.parts[0].io, WorkPartIo::Input);
+        assert_eq!(record.parts[1].kind, WorkPartKind::Command);
+        assert_eq!(record.parts[1].index_in_record, 2);
+        assert_eq!(record.parts[2].kind, WorkPartKind::Text);
+        assert_eq!(record.parts[2].io, WorkPartIo::Output);
     }
 
     #[test]
@@ -874,6 +993,62 @@ mod tests {
         assert_eq!(
             records[0].time.occurred_at.as_deref(),
             Some("2026-05-23T12:01:00Z")
+        );
+        assert_eq!(records[0].parts.len(), 2);
+        assert_eq!(records[0].parts[0].kind, WorkPartKind::UserMessage);
+        assert_eq!(records[0].parts[1].kind, WorkPartKind::AssistantMessage);
+    }
+
+    #[test]
+    fn chat_turn_records_preserve_tool_parts_without_changing_visible_turn_text() {
+        let session = AgentSession {
+            path: PathBuf::from("codex-session.jsonl"),
+            id: Some("abcdef123456".to_string()),
+            cwd: None,
+            title: None,
+            blocks: vec![
+                AgentBlock {
+                    kind: AgentBlockKind::User,
+                    timestamp: Some("2026-05-23T12:01:00Z".to_string()),
+                    label: None,
+                    text: "implement this".to_string(),
+                },
+                AgentBlock {
+                    kind: AgentBlockKind::ToolCall,
+                    timestamp: Some("2026-05-23T12:01:30Z".to_string()),
+                    label: Some("Bash".to_string()),
+                    text: "{\"command\":\"cargo test\"}".to_string(),
+                },
+                AgentBlock {
+                    kind: AgentBlockKind::ToolOutput,
+                    timestamp: Some("2026-05-23T12:01:45Z".to_string()),
+                    label: None,
+                    text: "ok".to_string(),
+                },
+                AgentBlock {
+                    kind: AgentBlockKind::Assistant,
+                    timestamp: Some("2026-05-23T12:02:00Z".to_string()),
+                    label: None,
+                    text: "done".to_string(),
+                },
+            ],
+        };
+
+        let records = WorkRecord::chat_turns(AgentProvider::Codex, &session);
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].text.input.as_deref(), Some("implement this"));
+        assert_eq!(records[0].text.output.as_deref(), Some("done"));
+        assert_eq!(records[0].parts.len(), 4);
+        assert_eq!(records[0].parts[1].kind, WorkPartKind::ToolCall);
+        assert_eq!(records[0].parts[1].label.as_deref(), Some("Bash"));
+        assert_eq!(records[0].parts[1].io, WorkPartIo::Input);
+        assert_eq!(records[0].parts[2].kind, WorkPartKind::ToolOutput);
+        assert_eq!(records[0].parts[2].io, WorkPartIo::Output);
+        assert_eq!(records[0].parts[3].kind, WorkPartKind::AssistantMessage);
+        assert_eq!(
+            records[0].text.combined,
+            "## User\nimplement this\n\n## Assistant\ndone"
         );
     }
 }

--- a/src/commands/copy/workspace_picker.rs
+++ b/src/commands/copy/workspace_picker.rs
@@ -2804,6 +2804,7 @@ mod tests {
                 output: None,
                 combined: plain.to_string(),
             },
+            parts: Vec::new(),
             payload: WorkPayload::ChatTurn {
                 user: plain.to_string(),
                 assistant: String::new(),

--- a/src/commands/time_filter.rs
+++ b/src/commands/time_filter.rs
@@ -179,7 +179,7 @@ fn parse_unix_timestamp(value: &str) -> Option<DateTime<Utc>> {
         number
     };
     let nanos = if value.len() >= 13 {
-        ((number % 1000).abs() as u32) * 1_000_000
+        (number % 1000).unsigned_abs() as u32 * 1_000_000
     } else {
         0
     };


### PR DESCRIPTION
### 1. Context & Motivation (Context)
- **Issue:** No matching upstream issue currently tracks this slice; this is a follow-up to the record-centric workspace refactor on `main`.
- **Problem:** Provider parsers already normalize tool calls and tool outputs into shared `AgentBlock`s, but `WorkRecord` drops them while constructing canonical chat-turn records. That blocks deeper `i/o/y` traversal because the shared model loses leaf-level structure before `show`, `search`, or the workspace picker can reuse it.
- **Trade-offs:** This PR preserves canonical leaf data now while intentionally keeping the existing `WorkText` contract stable. That avoids a behavior-changing refactor in `show/search/copy`, at the cost of deferring typed part refs and hierarchy-aware CLI traversal to follow-up PRs.

### 2. Implementation Details (Implementation)
- Added `WorkPart`, `WorkPartIo`, and `WorkPartKind` to the shared record model so `WorkRecord` can carry provider-neutral leaf parts without introducing a second storage or query plane.
- Populated `parts` for terminal records and agent records, including `ToolCall` and `ToolOutput` blocks that were previously lost in canonical chat-turn construction.
- Kept visible record text stable for current commands and TUI flows; tests now assert that tool parts are preserved without changing the existing chat-turn `combined` text contract.
- Included a minimal `time_filter` lint fix so the branch passes current `cargo clippy --workspace --all-targets -- -D warnings` on top of latest `main`.
- **Note:** Typed part refs (`.../i/<n>`, `.../o/<n>`) and explicit traversal commands are intentionally left to follow-up PRs so this slice stays focused on model preservation.

### 3. Testing Strategies (Validation)
- [x] Added Unit Tests for `WorkRecord::terminal` and `WorkRecord::chat_turns` (covering prompt/command/output parts and preserved tool-call/tool-output parts)
- [x] Ran Integration Test Suite against the current Rust workspace via `cargo test --workspace`
- [x] Verified backward compatibility with existing record text behavior by asserting chat-turn `combined` text stays unchanged while new parts are preserved
- [x] Ran `cargo clippy --workspace --all-targets -- -D warnings`
