### PR TITLE
docs: align sivtr memory skill with workspace refs

### DIFF
--- a/skills/sivtr-memory/SKILL.md
+++ b/skills/sivtr-memory/SKILL.md
@@ -1,68 +1,36 @@
 ---
 name: sivtr-memory
-description: Use when an agent needs shared local work memory across terminal commands and output, AI conversation history, recent failures, prior decisions, handoff context, recap context, or validation evidence.
+description: "Use when the agent needs shared local work memory across terminal commands and output, AI conversation history, recent failures, prior decisions, handoff context, recap context, or validation evidence. Search sivtr before asking the user to paste logs or repeat what happened earlier."
 ---
 
 # Sivtr Memory
 
-Sivtr is the shared local work memory for this machine.
+Sivtr is shared workspace memory for this machine.
 
-Use it before asking the user to paste logs, repeat decisions, or restate earlier work.
+Use it when the task needs evidence from recent terminal records, AI records, or handoff history.
 
-Core rule:
+Core protocol:
 
-> Search for evidence first. Expand only the smallest relevant context. Ask when memory is missing, ambiguous, stale, or permission is required.
+1. `search` the workspace.
+2. `show` the exact `ref`.
+3. `copy` only when you need the raw block or recent command text.
 
-Memory is evidence, not truth. Verify current files or commands before claiming current state.
+Terms:
 
-## When to Use
+- workspace: the current project directory used to resolve current AI sessions and terminal capture
+- record: one terminal command/output block or one AI turn
+- ref: a stable pointer for a record or one line inside it
 
-Use this skill when the user says or implies any of these:
+Rules:
 
-- "刚才报错了", "the last command failed", "look at the error"
-- "继续", "continue", "接着做", "resume from earlier"
-- "上次怎么说的", "what did we decide before", "why did we choose X"
-- "找一下那个报错", "search previous output", "find the failure"
-- "handoff", "summarize what happened", "write a recap"
-- You need evidence for a claim about recent build/test/lint/deploy output
-- You need prior AI discussion, project decisions, rejected approaches, or debugging trails
+- Search first; do not ask for pasted logs until sivtr has been checked.
+- Prefer `--json` for agent-to-agent or tool-to-tool use.
+- Prefer `show` over copying large history.
+- Use `copy --print` for raw extraction; avoid `--pick` unless the user wants interaction.
+- Treat memory as evidence; verify current files or commands before claiming state.
 
-Also use it proactively during debugging when command output is missing, truncated, or too large for the current context.
+Load only the reference you need:
 
-## First Check
-
-Before relying on sivtr in a new environment, run:
-
-```bash
-sivtr --version
-```
-
-If that fails, the skill cannot retrieve shared memory. Continue with normal shell/file inspection and mention the missing CLI only if it affects the task.
-
-## Default Retrieval Workflow
-
-1. Convert the user's vague reference into a query.
-2. Search with a small limit and JSON output.
-3. Inspect result source/session/dialogue/snippet.
-4. If the snippet is enough, answer with evidence.
-5. If more context is needed, expand with `sivtr copy ... --print` or a narrower second search.
-6. Ask the user only after local memory has been checked and still lacks the needed fact.
-
-## Non-Interactive Safety Rules
-
-- Prefer non-interactive commands: `sivtr search ... --json`, `sivtr copy ... --print`.
-- Do not open TUI pickers (`--pick`, hotkey picker) unless the user explicitly wants interactive selection.
-- Do not run `sivtr clear`, hotkey start/stop, shell init, or config mutation unless the user explicitly asks.
-- `sivtr copy` can affect the clipboard unless `--print` is used. Agents should use `--print` by default.
-- Avoid dumping huge histories into the model. Search narrowly first, then expand only the relevant block/dialogue.
-- If `sivtr` is not installed or no session log exists, say so briefly and continue with normal tools. Do not invent memory results.
-
-## Load References as Needed
-
-References are relative to this skill directory.
-
-- `references/commands.md` — command syntax, JSON handling, and token budget.
-- `references/patterns.md` — common user intents mapped to retrieval steps.
-- `references/evidence.md` — what counts as evidence and how to report it.
-
-Read only the file needed for the current task.
+- `references/commands.md` - command syntax, JSON shape, refs, and time filters
+- `references/patterns.md` - common user intents mapped to retrieval steps
+- `references/evidence.md` - what to trust and how to report it

--- a/skills/sivtr-memory/references/commands.md
+++ b/skills/sivtr-memory/references/commands.md
@@ -1,150 +1,112 @@
 # Command Cookbook
 
-Use these commands as starting points. This file is the single source for `sivtr` command syntax.
-Prefer small, targeted queries over dumping large histories.
+Use this file as the single source for `sivtr` syntax. The recommended path is `search -> show -> copy`.
 
-## Search Commands
+Work records come in two kinds:
 
-### General search
+- `shell` for terminal records
+- `ai` for agent records
 
-```bash
-sivtr search "<case-insensitive-regex>" --json --limit 20
-```
+## Search
 
-### Search terminal + AI memory for common errors
+Start small and stay targeted.
 
 ```bash
-sivtr search "error|failed|panic|Traceback|Exception|exit code|could not compile|FAILED" --json --limit 20
+sivtr search "error|failed|panic|Traceback|Exception|exit code|FAILED" --json -l 20
+sivtr search "decision|TODO|next step|blocked" --scope dialogue --provider codex --json -l 20
+sivtr search "workspace picker" --scope session --json -l 20
+sivtr search "build error" --recent 2h --json -l 20
+sivtr search "panic" --since 2026-05-23T00:00:00Z --until 2026-05-24 --json
 ```
 
-### Rust failures
+Search defaults:
 
-```bash
-sivtr search "error\\[E[0-9]+\\]|panicked|test result: FAILED|could not compile|borrow|lifetime" --json --limit 20
-```
+- current workspace AI sessions
+- current terminal capture, when available
+- case-insensitive regex matching
 
-### JavaScript / TypeScript failures
+Useful flags:
 
-```bash
-sivtr search "TypeError|ReferenceError|TS[0-9]+|npm ERR|pnpm|vite|webpack|ELIFECYCLE|failed" --json --limit 20
-```
+- `--scope content|dialogue|session`
+- `--provider all|codex|claude|opencode|pi`
+- `--cwd PATH`
+- `--recent COUNT|DURATION` such as `20`, `30m`, `2h`, or `7d`
+- `--since TIME` and `--until TIME`
+- `-l, --limit N` with a default of `20`
+- `--json` for machine use
 
-### Python failures
+Time filters accept RFC3339, Unix seconds or milliseconds, `YYYY-MM-DD`, `YYYY-MM-DD HH:MM:SS`, `YYYY-MM-DDTHH:MM:SS`, or relative durations through `--recent`.
 
-```bash
-sivtr search "Traceback|ModuleNotFoundError|ImportError|AssertionError|pytest|FAILED|Exception" --json --limit 20
-```
+## JSON Output
 
-### Previous decisions or AI discussion
+`sivtr search --json` returns a wrapper with:
 
-```bash
-sivtr search "lazy load|workspace TUI|metadata scan|decision|TODO|next step" --json --limit 20
-```
+- `query`
+- `scope`
+- `cwd`
+- `match_count`
+- `results`
 
-### Search titles instead of content
+Each result has:
 
-```bash
-sivtr search "workspace picker" --scope session --json --limit 20
-sivtr search "cargo test" --scope dialogue --json --limit 20
-```
+- `ref`
+- `kind` (`shell` or `ai`)
+- `timestamp`
+- `title.session`
+- `title.dialogue`
+- `content`
 
-### Provider-specific search
-
-```bash
-sivtr search "<query>" --provider codex --json --limit 20
-sivtr search "<query>" --provider claude --json --limit 20
-```
-
-## JSON Handling
-
-Treat `--json` output as structured evidence, not as a free-form transcript.
-
-`sivtr search --json` returns a wrapper with `query`, `scope`, `cwd`,
-`match_count`, and `results`. Inspect these result fields first:
-
-- `ref`: stable reference for follow-up expansion
-- `kind`: `shell` or `ai`
-- `timestamp`: how recent it is
-- `title.session`: session title
-- `title.dialogue`: dialogue or command block title, when available
-- `content`: matched line or extracted content
-
-Expected result item shape:
+Example:
 
 ```json
 {
-  "ref": "terminal/current/12/8",
-  "kind": "shell",
-  "timestamp": "...",
-  "title": {
-    "session": "current shell",
-    "dialogue": "cargo test"
-  },
-  "content": "test result: FAILED"
+  "query": "panic",
+  "scope": "content",
+  "cwd": "/home/shiro/Projects/sivtr",
+  "match_count": 1,
+  "results": [
+    {
+      "ref": "terminal/current/12/8",
+      "kind": "shell",
+      "timestamp": "2026-05-24T10:11:12Z",
+      "title": {
+        "session": "current",
+        "dialogue": "cargo test"
+      },
+      "content": "test result: FAILED"
+    }
+  ]
 }
 ```
 
-Use `ref` for precise follow-up. Do not infer provider/session identity from
-display text when a `ref` is available.
+## Show
 
-## Expansion Commands
-
-Use expansion after search identifies a target. Prefer small, precise expansions.
-
-### Show a matched ref
-
-Use `show` when search returned a `ref` and you need exact content.
+Use `show` to expand an exact ref.
 
 ```bash
-sivtr show "<ref>" --json
-sivtr show "terminal/current/12/8" --json
+sivtr show "terminal/current/12"
+sivtr show "terminal/current/12/8"
+sivtr show "pi/019e4f40/3"
+sivtr show "claude/abcdef12/2/4"
 ```
 
-Refs have this shape:
+Ref shapes:
 
-```text
-source/session[/dialogue[/line]]
-```
+- `terminal/<session>/<record>[/line]`
+- `<provider>/<session>/<turn>[/line]`
 
-### Last command output
+`show --json` returns the same item shape as search results, with exact content for the selected ref or line.
+
+## Copy
+
+Use `copy` when you need the raw text behind recent terminal blocks or a provider session.
+
+Prefer `--print` for agents.
 
 ```bash
 sivtr copy out 1 --print
-```
-
-### Last command input + output
-
-```bash
 sivtr copy 1 --print
-```
-
-### Recent command list only
-
-```bash
 sivtr copy cmd 1..10 --print
 ```
 
-### A small recent range
-
-```bash
-sivtr copy 1..3 --print
-```
-
-Do not copy large ranges unless the task explicitly requires a full transcript.
-
-## Query Construction Tips
-
-- Use the exact tool name when known: `cargo test`, `pytest`, `npm ERR`, `wrangler deploy`.
-- Include high-signal error tokens: `panic`, `Traceback`, `TS2307`, `error[E`, `exit code`.
-- Search for decision words when reconstructing context: `decision`, `defer`, `blocked`, `next step`, `TODO`.
-- Start with `--limit 20`; increase only if the result set is clearly incomplete.
-
-## Token Budget
-
-- Start with `--limit 20` for normal searches.
-- Use `--limit 30` only for handoff or recap work.
-- Narrow the query before increasing the limit.
-- Prefer `sivtr show "<ref>" --json` when search returns a useful ref.
-- Prefer `sivtr copy out 1 --print` for the latest output.
-- Prefer `sivtr copy 1..3 --print` for a small range.
-- Avoid ranges larger than `1..10` unless the task needs a transcript.
+Use interactive picker flags only when the user wants interaction.

--- a/skills/sivtr-memory/references/evidence.md
+++ b/skills/sivtr-memory/references/evidence.md
@@ -2,18 +2,18 @@
 
 Use this file to decide what to trust and how to report it.
 
-## What counts
-
-- Terminal output: strongest for commands, builds, tests, deploys, and errors
-- AI dialogue: useful for intent, prior decisions, and handoff context
-- Current files and tests: required when the answer depends on present reality
-
 ## Strength order
 
 1. Current file or verified command output
 2. Recent terminal evidence
 3. Recent AI discussion
 4. Older memory
+
+## What counts
+
+- Terminal output for commands, builds, tests, deploys, and errors
+- AI dialogue for intent, prior decisions, and handoff context
+- Current files and tests when the answer depends on present reality
 
 ## Rules
 
@@ -31,19 +31,12 @@ Keep the answer short and explicit:
 - what it means
 - what still needs verification
 
-## Anti-patterns
-
-- Asking for pasted logs before checking sivtr
-- Dumping large history into context
-- Calling interactive pickers in automated runs
-- Claiming a test passed without running or retrieving it
-
 ## Minimal response templates
 
 Found terminal evidence:
 
 ```text
-I searched sivtr for "<query>" and found terminal evidence from <source/session>.
+I searched sivtr for "<query>" and found shell evidence from <ref>.
 > <short snippet>
 I will verify against <file/test> before changing code.
 ```
@@ -51,7 +44,7 @@ I will verify against <file/test> before changing code.
 Found prior AI context:
 
 ```text
-I searched sivtr for "<query>" and found prior AI-conversation context.
+I searched sivtr for "<query>" and found ai-record context from <ref>.
 > <short snippet>
 I will treat this as decision history, not proof of current code state.
 ```

--- a/skills/sivtr-memory/references/patterns.md
+++ b/skills/sivtr-memory/references/patterns.md
@@ -1,66 +1,64 @@
 # Patterns
 
-Use this file when you need to turn a vague user request into a retrieval plan.
-Command syntax itself lives in `references/commands.md`.
+Use this file when a user intent needs a retrieval plan. Command syntax lives in `references/commands.md`.
 
 ## Recent failure
 
-When the user says the last command failed, search for the likely error first.
+Search error terms first.
 
-- Start with the error search from `commands.md`
-- Narrow by tool or language if the project is obvious
-- If search returns a useful `ref`, expand it with `sivtr show "<ref>" --json`
-- If there is no useful ref and the latest terminal output matters, expand only the latest output
-- Then inspect the related files and verify locally
+1. Run the error search from `commands.md`.
+2. Narrow by tool or language if the project is obvious.
+3. `show` the strongest ref.
+4. Verify the related file or test before changing code.
 
 ## Continue work
 
-When the user says "continue", reconstruct the active thread before guessing.
+Reconstruct the active thread before guessing.
 
-- Search for `next step`, `TODO`, `blocked`, `decision`, `commit`, `test result`, `passed`, and `failed`
-- Use returned refs to expand only the most relevant dialogue or line
-- If one thread is obvious, summarize it and keep going
-- If more than one thread is plausible, ask the user which one to continue
+1. Search for `next step`, `TODO`, `blocked`, `decision`, `commit`, `test result`, `passed`, and `failed`.
+2. Expand only the most relevant ref.
+3. Summarize the active state, then continue.
+4. Ask which thread to continue only if more than one is plausible.
 
 ## Prior decision
 
-When the user asks why something was chosen earlier:
+Treat memory as intent history, not current code truth.
 
-- Search for the decision terms and related discussion
-- Use refs to expand the relevant prior dialogue when the matched line is too small
-- Treat the result as intent history, not current code truth
-- Verify the code or tests before making a claim about current state
+1. Search for decision terms and related discussion.
+2. Expand the exact prior ref when the snippet is too small.
+3. Verify code or tests before making a claim about current state.
 
 ## Handoff
 
-When another agent needs to continue the work:
+When another agent needs to continue:
 
-- Search for goal, next step, decisions, and validation evidence
-- Expand refs for the few strongest matches
-- Pull only a small command range when refs do not capture the needed terminal context
-- Report goal, current state, evidence, tests, risks, and next step
+1. Search for goal, next step, decisions, and validation evidence.
+2. Expand the few strongest refs.
+3. Report goal, current state, evidence, tests, risks, and next step.
 
 ## Recap
 
-When the user wants a summary of what happened:
+When the user wants a summary:
 
-- Search for successful and failed validation
-- Search for decisions and measurable changes
-- Expand only refs that anchor the timeline
-- Produce a compact timeline with evidence, not a transcript dump
+1. Search for successful and failed validation.
+2. Search for decisions and measurable changes.
+3. Expand only the refs that anchor the timeline.
+4. Return a compact timeline, not a transcript dump.
 
 ## Missing memory
 
-When no useful evidence is found:
+When nothing useful is found:
 
-- Say that sivtr did not find matching local memory
-- State the specific missing fact
-- Either reproduce the issue locally or ask the user for the missing source
+1. Say sivtr did not find matching local memory.
+2. State the specific missing fact.
+3. Reproduce the issue locally or ask for the missing source.
 
-## Permission required
+## Copy only when needed
 
-When the task involves deletion, reset, or config mutation:
+Use `copy` only when the raw block is the useful unit.
 
-- Search for context if helpful
-- Stop before the destructive step
-- Ask for explicit confirmation with the exact target
+- command text for prompts or another tool
+- a small terminal range for a handoff
+- a provider transcript when `show` is not enough
+
+Keep copied ranges small.


### PR DESCRIPTION
 # 改进

  1. 将 `sivtr-memory` 收敛为最小协议，入口只保留 trigger / rules / reference index。
  2. 统一 `search -> show -> copy`，并把 JSON schema、ref 形状、`--recent/--since/--until` 对齐到当前实现。
  3. 把术语改成 `workspace / record / ref`，`patterns` 和 `evidence` 只保留场景映射与证据分级。

---
# 关于workspace
workspace 是稳定身份，cwd 只是当前视角
 具体上：
  workspace 的判定应该优先来自项目根，而不是当前 shell 路径。
  `cwd` 只负责“我现在站在哪个目录里”，不负责定义身份。
  `record/ref` 应该绑定到 workspace 下的稳定记录，不绑定到瞬时路径。
  `search/show/copy` 都应该围绕 workspace 里的 record 运作，`cwd` 只是解析和过滤的上下文。

  主要的目标是让多个 client 在同一个 workspace 里看到同一套稳定记录，而不是被当前目录切换切散。

---
具体的落地改进：
1. 先做 workspace root 解析

  - 新增一个统一函数，比如 resolve_workspace_root(cwd).
  - 优先级建议是：显式配置 > .sivtr-workspace（如果保留的话）> git root > 当前目录。
  - 这个函数只回答“这个 cwd 属于哪个 workspace”，不负责记录内容。

  2. 把 cwd 从“身份”降级成“上下文”

  - search/show/copy 继续收 --cwd，但内部先解析成 workspace root。
  - 以后所有 session/record 的查找都按 workspace root 走，不直接按原始 cwd 走。
  - 这样你在子目录和仓库根目录之间 cd，结果还是同一个 workspace。
  3. 让 record/ref 只绑定稳定对象

  - WorkRef 保持现在这种 terminal/<session>/<record>[/line] / <provider>/<session>/<turn>[/line] 形式。
  - 不把 cwd 塞进 ref。
  - 需要的话，record 里可以保留 cwd 作为元数据，但它只是证据，不是身份。

  4. 搜索索引按 workspace 构建

  - current_work_record_index(...) 里先拿 workspace root，再找该 workspace 下的 terminal + AI 记录。
  - 这样 search -> show -> copy 都是在同一个 workspace 语义里工作。

  5. 文档和 skill 同步改词

  - 文档里把 “session 是工作空间” 这种说法删掉。
  - 改成“workspace 是稳定身份，cwd 只是当前位置”。
  - patterns 里只描述行为，不再描述路径身份。

