### PR TITLE
fix(init): align Linux/macOS shortcut launchers with current picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,10 @@ This writes:
 - `~/.local/bin/sivtr-pick-codex`
 - `~/Library/LaunchAgents/dev.sivtr.pick-codex.plist`
 
+The historical filename stays the same for compatibility, but the generated
+script now opens the provider-neutral AI session picker with the exact `sivtr`
+binary that created it.
+
 You can:
 
 - run `~/.local/bin/sivtr-pick-codex` directly;

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -287,6 +287,8 @@ sivtr init macos-shortcut
 - `~/.local/bin/sivtr-pick-codex`
 - `~/Library/LaunchAgents/dev.sivtr.pick-codex.plist`
 
+历史文件名会为兼容性保留，但生成出来的脚本现在会使用生成它的那一个 `sivtr` 二进制，直接打开 provider-neutral 的 AI session picker。
+
 你可以：
 
 - 直接运行 `~/.local/bin/sivtr-pick-codex`；

--- a/crates/sivtr-core/src/codex.rs
+++ b/crates/sivtr-core/src/codex.rs
@@ -690,8 +690,16 @@ mod tests {
 
         let previous_codex_home = env::var_os("CODEX_HOME");
         let previous_dirs = env::var_os("SIVTR_CODEX_SESSION_DIRS");
+        let previous_xdg_config_home = env::var_os("XDG_CONFIG_HOME");
+        let previous_appdata = env::var_os("APPDATA");
+        let config_home = temp.path().join("config-home");
+        std::fs::create_dir_all(&config_home).unwrap();
         env::set_var("CODEX_HOME", &codex_home);
         env::set_var("SIVTR_CODEX_SESSION_DIRS", exported_root.join("sessions"));
+        env::set_var("XDG_CONFIG_HOME", &config_home);
+        if cfg!(windows) {
+            env::set_var("APPDATA", &config_home);
+        }
 
         let sessions = CodexProvider.list_recent_sessions(None).unwrap();
 
@@ -702,6 +710,14 @@ mod tests {
         match previous_dirs {
             Some(value) => env::set_var("SIVTR_CODEX_SESSION_DIRS", value),
             None => env::remove_var("SIVTR_CODEX_SESSION_DIRS"),
+        }
+        match previous_xdg_config_home {
+            Some(value) => env::set_var("XDG_CONFIG_HOME", value),
+            None => env::remove_var("XDG_CONFIG_HOME"),
+        }
+        match previous_appdata {
+            Some(value) => env::set_var("APPDATA", value),
+            None => env::remove_var("APPDATA"),
         }
 
         assert_eq!(sessions.len(), 2);

--- a/docs-site/src/content/docs/usage/launchers-and-hotkeys.md
+++ b/docs-site/src/content/docs/usage/launchers-and-hotkeys.md
@@ -116,6 +116,10 @@ This writes:
 - `~/.local/bin/sivtr-pick-codex`
 - `~/.local/share/applications/sivtr-pick-codex.desktop`
 
+The historical filename stays the same for compatibility, but the generated
+script now opens the provider-neutral AI session picker with the exact `sivtr`
+binary that created it.
+
 Bind your desktop shortcut to the generated script, or run it directly from a terminal.
 
 ## macOS launcher
@@ -131,12 +135,12 @@ This writes:
 - `~/.local/bin/sivtr-pick-codex`
 - `~/Library/LaunchAgents/dev.sivtr.pick-codex.plist`
 
+The historical filename stays the same for compatibility, but the generated
+script now opens the provider-neutral AI session picker with the exact `sivtr`
+binary that created it.
+
 Run the script directly, or load the LaunchAgent:
 
 ```bash
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.sivtr.pick-codex.plist
 ```
-
-## Current limitation
-
-Some generated shortcut helpers still use the historical Codex-oriented picker command internally. The provider-neutral CLI and Windows hotkey paths are ahead of those generated launcher names. Treat this as a compatibility detail, not as a product boundary: agent-session docs use provider-neutral commands where the CLI already supports them.

--- a/docs-site/src/content/docs/zh-cn/usage/launchers-and-hotkeys.md
+++ b/docs-site/src/content/docs/zh-cn/usage/launchers-and-hotkeys.md
@@ -116,6 +116,8 @@ sivtr init linux-shortcut
 - `~/.local/bin/sivtr-pick-codex`
 - `~/.local/share/applications/sivtr-pick-codex.desktop`
 
+历史文件名会为兼容性保留，但生成出来的脚本现在会使用生成它的那一个 `sivtr` 二进制，直接打开 provider-neutral 的 AI session picker。
+
 把桌面快捷键绑定到生成的脚本，或直接从终端运行它。
 
 ## macOS 启动器
@@ -131,12 +133,10 @@ sivtr init macos-shortcut
 - `~/.local/bin/sivtr-pick-codex`
 - `~/Library/LaunchAgents/dev.sivtr.pick-codex.plist`
 
+历史文件名会为兼容性保留，但生成出来的脚本现在会使用生成它的那一个 `sivtr` 二进制，直接打开 provider-neutral 的 AI session picker。
+
 可以直接运行脚本，或加载 LaunchAgent：
 
 ```bash
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/dev.sivtr.pick-codex.plist
 ```
-
-## 当前限制
-
-部分生成的 shortcut helper 内部仍使用历史上的 Codex-oriented picker 命令。Provider-neutral CLI 和 Windows hotkey 路径已经走在前面。把它当成兼容细节，而不是产品边界；Agent session 文档会在 CLI 已支持的地方使用 provider-neutral 命令。

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -450,9 +450,9 @@ pub enum Commands {
     /// Manage configuration
     Config(ConfigCommand),
 
-    /// Generate shell integration or Linux shortcut helpers
+    /// Generate shell integration or desktop shortcut helpers
     Init {
-        /// Integration target: powershell, bash, zsh, nushell, all, tmux, linux-shortcut
+        /// Integration target: powershell, bash, zsh, nushell, all, tmux, linux-shortcut, macos-shortcut
         #[arg(value_name = "TARGET", allow_hyphen_values = true)]
         target: String,
     },
@@ -912,6 +912,7 @@ pub struct CodexExportArgs {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
 
     #[test]
     fn copy_input_accepts_prompt_override() {
@@ -1433,6 +1434,29 @@ mod tests {
             Some(Commands::Init { target }) => assert_eq!(target, "linux-shortcut"),
             _ => panic!("expected init command"),
         }
+    }
+
+    #[test]
+    fn init_accepts_macos_shortcut_target() {
+        let cli = Cli::try_parse_from(["sivtr", "init", "macos-shortcut"]).unwrap();
+
+        match cli.command {
+            Some(Commands::Init { target }) => assert_eq!(target, "macos-shortcut"),
+            _ => panic!("expected init command"),
+        }
+    }
+
+    #[test]
+    fn init_help_mentions_macos_shortcut_target() {
+        let mut cmd = Cli::command();
+        let init = cmd
+            .find_subcommand_mut("init")
+            .expect("init subcommand should exist");
+        let mut help = Vec::new();
+        init.write_long_help(&mut help).unwrap();
+        let help = String::from_utf8(help).unwrap();
+
+        assert!(help.contains("macos-shortcut"));
     }
 
     #[test]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -370,11 +370,12 @@ fn install_linux_shortcut() -> Result<()> {
     fs::create_dir_all(&applications_dir)?;
 
     let cwd = std::env::current_dir().context("Failed to resolve current directory")?;
+    let sivtr_bin = std::env::current_exe().context("Failed to resolve current executable")?;
     let terminal = detect_linux_terminal();
     let script_path = bin_dir.join("sivtr-pick-codex");
     let desktop_path = applications_dir.join("sivtr-pick-codex.desktop");
 
-    write_linux_shortcut_script(&script_path, &cwd, terminal.as_deref())?;
+    write_linux_shortcut_script(&script_path, &cwd, &sivtr_bin, terminal.as_deref())?;
     write_linux_shortcut_desktop_entry(&desktop_path, &script_path)?;
 
     eprintln!("sivtr: installed Linux shortcut launcher");
@@ -411,10 +412,11 @@ fn install_macos_shortcut() -> Result<()> {
     fs::create_dir_all(&launch_agents_dir)?;
 
     let cwd = std::env::current_dir().context("Failed to resolve current directory")?;
+    let sivtr_bin = std::env::current_exe().context("Failed to resolve current executable")?;
     let script_path = bin_dir.join("sivtr-pick-codex");
     let plist_path = launch_agents_dir.join(format!("{MACOS_SHORTCUT_LABEL}.plist"));
 
-    write_macos_shortcut_script(&script_path, &cwd)?;
+    write_macos_shortcut_script(&script_path, &cwd, &sivtr_bin)?;
     write_macos_shortcut_plist(&plist_path, &script_path)?;
 
     eprintln!("sivtr: installed macOS shortcut launcher");
@@ -626,8 +628,13 @@ fn command_exists(name: &str) -> bool {
 }
 
 #[cfg(unix)]
-fn write_linux_shortcut_script(path: &Path, cwd: &Path, terminal: Option<&str>) -> Result<()> {
-    let script = render_linux_shortcut_script(cwd, terminal);
+fn write_linux_shortcut_script(
+    path: &Path,
+    cwd: &Path,
+    sivtr_bin: &Path,
+    terminal: Option<&str>,
+) -> Result<()> {
+    let script = render_linux_shortcut_script(cwd, sivtr_bin, terminal);
     fs::write(path, script)?;
     #[cfg(unix)]
     {
@@ -639,8 +646,9 @@ fn write_linux_shortcut_script(path: &Path, cwd: &Path, terminal: Option<&str>) 
 }
 
 #[cfg(unix)]
-fn render_linux_shortcut_script(cwd: &Path, terminal: Option<&str>) -> String {
+fn render_linux_shortcut_script(cwd: &Path, sivtr_bin: &Path, terminal: Option<&str>) -> String {
     let cwd = shell_single_quote(&cwd.to_string_lossy());
+    let sivtr_bin = shell_single_quote(&sivtr_bin.to_string_lossy());
     let launcher = terminal
         .map(build_terminal_launch_command)
         .unwrap_or_else(|| {
@@ -648,12 +656,15 @@ fn render_linux_shortcut_script(cwd: &Path, terminal: Option<&str>) -> String {
                 .to_string()
         });
 
-    format!("#!/usr/bin/env bash\nset -euo pipefail\nexport PROJECT_CWD='{cwd}'\n{launcher}\n")
+    format!(
+        "#!/usr/bin/env bash\nset -euo pipefail\nexport PROJECT_CWD='{cwd}'\nexport SIVTR_BIN='{sivtr_bin}'\n{launcher}\n"
+    )
 }
 
 #[cfg(unix)]
 fn build_terminal_launch_command(terminal: &str) -> String {
-    let picker = "cd \"$PROJECT_CWD\"; exec sivtr copy codex --pick";
+    let picker =
+        "cd \"$PROJECT_CWD\"; exec \"$SIVTR_BIN\" hotkey-pick-agent --cwd \"$PROJECT_CWD\" --provider all";
     match terminal {
         "gnome-terminal" => format!("exec gnome-terminal -- bash -lc '{picker}'"),
         "konsole" => format!("exec konsole --noclose -e bash -lc '{picker}'"),
@@ -667,8 +678,8 @@ fn build_terminal_launch_command(terminal: &str) -> String {
 }
 
 #[cfg_attr(not(unix), allow(dead_code))]
-fn write_macos_shortcut_script(path: &Path, cwd: &Path) -> Result<()> {
-    let script = render_macos_shortcut_script(cwd);
+fn write_macos_shortcut_script(path: &Path, cwd: &Path, sivtr_bin: &Path) -> Result<()> {
+    let script = render_macos_shortcut_script(cwd, sivtr_bin);
     fs::write(path, script)?;
     #[cfg(unix)]
     {
@@ -680,10 +691,11 @@ fn write_macos_shortcut_script(path: &Path, cwd: &Path) -> Result<()> {
 }
 
 #[cfg_attr(not(unix), allow(dead_code))]
-fn render_macos_shortcut_script(cwd: &Path) -> String {
+fn render_macos_shortcut_script(cwd: &Path, sivtr_bin: &Path) -> String {
     let cwd = shell_single_quote(&cwd.to_string_lossy());
+    let sivtr_bin = shell_single_quote(&sivtr_bin.to_string_lossy());
     format!(
-        "#!/usr/bin/env bash\nset -euo pipefail\nexport PROJECT_CWD='{cwd}'\ncd \"$PROJECT_CWD\"\nexec sivtr copy codex --pick\n"
+        "#!/usr/bin/env bash\nset -euo pipefail\nexport PROJECT_CWD='{cwd}'\nexport SIVTR_BIN='{sivtr_bin}'\ncd \"$PROJECT_CWD\"\nexec \"$SIVTR_BIN\" hotkey-pick-agent --cwd \"$PROJECT_CWD\" --provider all\n"
     )
 }
 
@@ -862,7 +874,9 @@ mod tests {
         let command = build_terminal_launch_command("gnome-terminal");
 
         assert!(command.contains("gnome-terminal"));
-        assert!(command.contains("cd \"$PROJECT_CWD\"; exec sivtr copy codex --pick"));
+        assert!(command.contains(
+            "cd \"$PROJECT_CWD\"; exec \"$SIVTR_BIN\" hotkey-pick-agent --cwd \"$PROJECT_CWD\" --provider all"
+        ));
     }
 
     #[cfg(unix)]
@@ -874,10 +888,17 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn linux_shortcut_script_exports_project_cwd() {
-        let script = render_linux_shortcut_script(Path::new("/tmp/project"), Some("xterm"));
+        let script = render_linux_shortcut_script(
+            Path::new("/tmp/project"),
+            Path::new("/tmp/bin/sivtr"),
+            Some("xterm"),
+        );
 
         assert!(script.contains("export PROJECT_CWD='/tmp/project'"));
-        assert!(script.contains("cd \"$PROJECT_CWD\"; exec sivtr copy codex --pick"));
+        assert!(script.contains("export SIVTR_BIN='/tmp/bin/sivtr'"));
+        assert!(script.contains(
+            "cd \"$PROJECT_CWD\"; exec \"$SIVTR_BIN\" hotkey-pick-agent --cwd \"$PROJECT_CWD\" --provider all"
+        ));
     }
 
     #[test]
@@ -898,10 +919,14 @@ mod tests {
 
     #[test]
     fn macos_shortcut_script_runs_picker_in_project_cwd() {
-        let script = render_macos_shortcut_script(Path::new("/tmp/project"));
+        let script =
+            render_macos_shortcut_script(Path::new("/tmp/project"), Path::new("/tmp/bin/sivtr"));
 
         assert!(script.contains("export PROJECT_CWD='/tmp/project'"));
-        assert!(script.contains("exec sivtr copy codex --pick"));
+        assert!(script.contains("export SIVTR_BIN='/tmp/bin/sivtr'"));
+        assert!(script.contains(
+            "exec \"$SIVTR_BIN\" hotkey-pick-agent --cwd \"$PROJECT_CWD\" --provider all"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Title: [Fix]: align Linux and macOS shortcut launchers with the current AI session picker

### 1. Context & Motivation (Context)
- **Issue:** Fixes #23
- **Problem:** The generated Linux and macOS shortcut helpers had drifted behind the current picker contract. They still launched a Codex-only flow through a shell-resolved `sivtr` lookup, so launcher behavior depended on PATH state and excluded non-Codex providers. After rebasing onto current `main`, this branch also needed deterministic Codex session-dir test isolation so CI would not read host-level config.
- **Trade-offs:** I kept the historical `sivtr-pick-codex` filenames for backward compatibility instead of renaming launcher artifacts. I also pulled in one minimal test-only prerequisite commit on this branch so the launcher fix can stay green on current `main` without dragging broader record-work changes into this PR.

### 2. Implementation Details (Implementation)
- Updated `src/commands/init.rs` so `sivtr init linux-shortcut` and `sivtr init macos-shortcut` pin `SIVTR_BIN` from `current_exe()` and reuse that exact binary in generated helper scripts.
- Switched generated Linux/macOS launchers from the historical Codex-only picker path to `hotkey-pick-agent --cwd "$PROJECT_CWD" --provider all`, aligning them with the provider-neutral picker contract already used elsewhere.
- Kept compatibility filenames intact while refreshing the generated script contents and the related `init` regression coverage for both Linux and macOS launchers.
- Added deterministic exported-session-dir test isolation in `crates/sivtr-core/src/codex.rs` so Codex directory tests do not read host config during CI or local validation.
- Refreshed the shortcut documentation to describe the compatibility filename and the new provider-neutral launcher behavior.
- **Note:** The branch intentionally stays focused on launcher generation and its test prerequisite. It does not pull in the broader work-record traversal changes from other PRs.

### 3. Testing Strategies (Validation)
- [x] Added Unit Tests for `src/commands/init.rs` and Codex session-dir isolation coverage in `crates/sivtr-core/src/codex.rs`
- [x] Ran Integration Test Suite against Linux host environment: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo build --release`
- [x] Ran real macOS guest validation: `cargo test --workspace`, `cargo build --release`, `./target/release/sivtr init macos-shortcut`, `bash -n ~/.local/bin/sivtr-pick-codex`, `plutil -lint ~/Library/LaunchAgents/dev.sivtr.pick-codex.plist`
- [x] Verified backward compatibility by preserving existing launcher filenames while switching the internal command path and pinned binary resolution
- **Benchmark:** Not applicable