### PR TITLE
feat(record): preserve and traverse canonical work parts (v2 — rebased)

### DIFF
--- a/crates/sivtr-core/src/claude.rs
+++ b/crates/sivtr-core/src/claude.rs
@@ -51,6 +51,9 @@ fn update_meta(meta: &mut AgentSessionMeta, value: &Value) {
     if meta.cwd.is_none() {
         meta.cwd = value.get("cwd").and_then(Value::as_str).map(str::to_string);
     }
+    if meta.title.is_none() {
+        meta.title = event_title(value);
+    }
 }
 
 fn apply_event(session: &mut AgentSession, value: &Value) {
@@ -68,21 +71,7 @@ fn apply_event(session: &mut AgentSession, value: &Value) {
     match value.get("type").and_then(Value::as_str) {
         Some("user") => apply_message(session, value, AgentBlockKind::User, timestamp),
         Some("assistant") => apply_message(session, value, AgentBlockKind::Assistant, timestamp),
-        Some(
-            "permission-mode"
-            | "ai-title"
-            | "file-history-snapshot"
-            | "attachment"
-            | "last-prompt"
-            | "system"
-            | "queue-operation",
-        ) => {}
-        Some(event_type) => {
-            panic!("Unexpected Claude event type: {event_type}");
-        }
-        None => {
-            panic!("Claude event must include type");
-        }
+        _ => {}
     }
 }
 
@@ -96,6 +85,19 @@ fn update_session_meta(session: &mut AgentSession, value: &Value) {
     if session.cwd.is_none() {
         session.cwd = value.get("cwd").and_then(Value::as_str).map(str::to_string);
     }
+    if let Some(title) = event_title(value) {
+        session.title = Some(title);
+    }
+}
+
+fn event_title(value: &Value) -> Option<String> {
+    value
+        .get("customTitle")
+        .or_else(|| value.get("title"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+        .map(str::to_string)
 }
 
 fn apply_message(
@@ -104,10 +106,12 @@ fn apply_message(
     kind: AgentBlockKind,
     timestamp: Option<String>,
 ) {
-    let content = value
+    let Some(content) = value
         .get("message")
         .and_then(|message| message.get("content"))
-        .expect("Claude user/assistant event must include message.content");
+    else {
+        return;
+    };
     push_content_blocks(session, kind, timestamp, content);
 }
 
@@ -130,45 +134,36 @@ fn push_content_blocks(
                     Some("thinking") => {}
                     Some("tool_use") => push_tool_use(session, timestamp.clone(), item),
                     Some("tool_result") => {
-                        let content = item
-                            .get("content")
-                            .expect("Claude structured tool_result must include content");
-                        push_block(
-                            session,
-                            AgentBlockKind::ToolOutput,
-                            timestamp.clone(),
-                            None,
-                            extract_content_text(content),
-                        );
+                        if let Some(content) = item.get("content") {
+                            push_block(
+                                session,
+                                AgentBlockKind::ToolOutput,
+                                timestamp.clone(),
+                                None,
+                                extract_content_text(content),
+                            );
+                        }
                     }
                     Some("image") => {}
-                    None => {
-                        panic!("Claude content item must include type");
-                    }
-                    Some(item_type) => {
-                        panic!("Unexpected Claude content item type: {item_type}");
-                    }
+                    _ => {}
                 }
             }
         }
         Value::String(text) => push_text_content_blocks(session, kind, timestamp, text.clone()),
-        other => {
-            panic!("Unexpected Claude message.content shape: {other:?}");
-        }
+        _ => {}
     }
 }
 
 fn push_tool_use(session: &mut AgentSession, timestamp: Option<String>, item: &Value) {
-    let input = item
-        .get("input")
-        .expect("Claude structured tool_use must include input");
-    push_block(
-        session,
-        AgentBlockKind::ToolCall,
-        timestamp,
-        item.get("name").and_then(Value::as_str).map(str::to_string),
-        pretty_json_value(input),
-    );
+    if let Some(input) = item.get("input") {
+        push_block(
+            session,
+            AgentBlockKind::ToolCall,
+            timestamp,
+            item.get("name").and_then(Value::as_str).map(str::to_string),
+            pretty_json_value(input),
+        );
+    }
 }
 
 fn push_text_content_blocks(
@@ -403,6 +398,53 @@ mod tests {
             format_blocks(&session.blocks),
             "## User\nhello\n\n## Assistant\ndone"
         );
+    }
+
+    #[test]
+    fn ignores_claude_non_dialogue_events_and_keeps_custom_title() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"type":"custom-title","sessionId":"abc","customTitle":"Named session"}
+{"type":"permission-mode","sessionId":"abc","permissionMode":"default"}
+{"type":"user","sessionId":"abc","cwd":"C:\\repo","message":{"role":"user","content":"hello"}}
+{"type":"pr-link","sessionId":"abc","prNumber":19,"prUrl":"https://github.com/Ariestar/sivtr/pull/19","prRepository":"Ariestar/sivtr","timestamp":"2026-05-23T03:25:11.176Z"}
+{"type":"assistant","sessionId":"abc","cwd":"C:\\repo","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}
+"#,
+        )
+        .unwrap();
+
+        let session = ClaudeProvider.parse_session_file(&path).unwrap();
+
+        assert_eq!(session.id.as_deref(), Some("abc"));
+        assert_eq!(session.cwd.as_deref(), Some("C:\\repo"));
+        assert_eq!(session.title.as_deref(), Some("Named session"));
+        assert_eq!(session.blocks.len(), 2);
+        assert_eq!(
+            format_blocks(&session.blocks),
+            "## User\nhello\n\n## Assistant\ndone"
+        );
+    }
+
+    #[test]
+    fn ignores_unknown_claude_content_items() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"type":"user","sessionId":"abc","cwd":"C:\\repo","message":{"role":"user","content":"hello"}}
+{"type":"assistant","sessionId":"abc","cwd":"C:\\repo","message":{"role":"assistant","content":[{"type":"citation","text":"ignored"},{"type":"text","text":"done"}]}}
+"#,
+        )
+        .unwrap();
+
+        let session = ClaudeProvider.parse_session_file(&path).unwrap();
+
+        assert_eq!(session.blocks.len(), 2);
+        assert_eq!(session.blocks[0].kind, AgentBlockKind::User);
+        assert_eq!(session.blocks[1].kind, AgentBlockKind::Assistant);
+        assert_eq!(session.blocks[1].text, "done");
     }
 
     #[test]

--- a/crates/sivtr-core/src/record/index.rs
+++ b/crates/sivtr-core/src/record/index.rs
@@ -208,11 +208,24 @@ mod tests {
         turn_index: usize,
         combined: &str,
     ) -> WorkRecord {
+        use crate::record::model::{WorkChannel, WorkSessionRef, WorkSource};
+        let work_ref = WorkRef::agent_record(AgentProvider::Pi, session_id, turn_index);
         WorkRecord {
             schema_version: 1,
-            work_ref: WorkRef::agent_record(AgentProvider::Pi, session_id, turn_index),
+            id: work_ref.to_string(),
+            work_ref,
             kind: WorkRecordKind::ChatTurn,
-            session_path: None,
+            source: WorkSource {
+                channel: WorkChannel::Chat,
+                provider: Some("pi".to_string()),
+            },
+            session: WorkSessionRef {
+                id: session_id.to_string(),
+                canonical_id: Some(session_id.to_string()),
+                path: None,
+                index: turn_index - 1,
+                work_ref: WorkRef::agent_record(AgentProvider::Pi, session_id, turn_index),
+            },
             cwd: None,
             time: WorkTime::default(),
             status: WorkStatus {
@@ -240,11 +253,24 @@ mod tests {
         turn_index: usize,
         text: &str,
     ) -> WorkRecord {
+        use crate::record::model::{WorkChannel, WorkSessionRef, WorkSource};
+        let work_ref = WorkRef::terminal_record(session_id, turn_index);
         WorkRecord {
             schema_version: 1,
-            work_ref: WorkRef::terminal_record(session_id, turn_index),
+            id: work_ref.to_string(),
+            work_ref,
             kind: WorkRecordKind::TerminalCommand,
-            session_path: None,
+            source: WorkSource {
+                channel: WorkChannel::Terminal,
+                provider: None,
+            },
+            session: WorkSessionRef {
+                id: session_id.to_string(),
+                canonical_id: Some(session_id.to_string()),
+                path: None,
+                index: turn_index - 1,
+                work_ref: WorkRef::terminal_record(session_id, turn_index),
+            },
             cwd: None,
             time: WorkTime::default(),
             status: WorkStatus {

--- a/crates/sivtr-core/src/record/index.rs
+++ b/crates/sivtr-core/src/record/index.rs
@@ -1,5 +1,22 @@
-use super::model::{WorkRecord, WorkRecordKind};
-use super::refs::WorkRef;
+use regex::Regex;
+
+use super::model::{WorkPart, WorkPartIo, WorkRecord, WorkRecordKind};
+use super::refs::{WorkRef, WorkRefTarget};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkRecordSearchScope {
+    Content,
+    Title,
+    Session,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct WorkRecordMatch<'a> {
+    pub record: &'a WorkRecord,
+    pub target: WorkRefTarget,
+    pub content: &'a str,
+    pub matched_line: usize,
+}
 
 #[derive(Debug, Clone)]
 pub struct WorkRecordIndex {
@@ -21,6 +38,38 @@ impl WorkRecordIndex {
             .iter()
             .find(|record| record.work_ref == record_ref)
     }
+
+    pub fn resolve_part(&self, reference: &WorkRef) -> Option<&WorkPart> {
+        let (io, index) = reference.part()?;
+        self.resolve(reference)
+            .and_then(|record| find_part(record, io, index))
+    }
+
+    pub fn search(
+        &self,
+        regex: &Regex,
+        scope: WorkRecordSearchScope,
+        limit: usize,
+        include: impl Fn(&WorkRecord) -> bool,
+    ) -> Vec<WorkRecordMatch<'_>> {
+        self.records
+            .iter()
+            .filter(|record| include(record))
+            .filter_map(|record| match scope {
+                WorkRecordSearchScope::Content => matching_content(record, regex),
+                WorkRecordSearchScope::Title => {
+                    regex.is_match(&record.title).then_some(WorkRecordMatch {
+                        record,
+                        target: WorkRefTarget::Record,
+                        content: record.title.as_str(),
+                        matched_line: 1,
+                    })
+                }
+                WorkRecordSearchScope::Session => matching_session(record, regex),
+            })
+            .take(limit)
+            .collect()
+    }
 }
 
 impl WorkRecord {
@@ -32,12 +81,89 @@ impl WorkRecord {
     }
 }
 
+fn matching_content<'a>(record: &'a WorkRecord, regex: &Regex) -> Option<WorkRecordMatch<'a>> {
+    work_record_content_matches(record, regex)
+        .into_iter()
+        .next()
+}
+
+pub fn work_record_content_matches<'a>(
+    record: &'a WorkRecord,
+    regex: &Regex,
+) -> Vec<WorkRecordMatch<'a>> {
+    let part_matches = matching_parts(record, regex);
+    if part_matches.is_empty() {
+        matching_lines(record, regex)
+    } else {
+        part_matches
+    }
+}
+
+fn matching_parts<'a>(record: &'a WorkRecord, regex: &Regex) -> Vec<WorkRecordMatch<'a>> {
+    record
+        .parts
+        .iter()
+        .flat_map(|part| {
+            part.text
+                .lines()
+                .enumerate()
+                .filter(|(_, line)| regex.is_match(line))
+                .map(|(line_index, line)| WorkRecordMatch {
+                    record,
+                    target: WorkRefTarget::Part {
+                        io: part.io,
+                        index: part.index_in_record,
+                    },
+                    content: line,
+                    matched_line: line_index + 1,
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn matching_lines<'a>(record: &'a WorkRecord, regex: &Regex) -> Vec<WorkRecordMatch<'a>> {
+    record
+        .text
+        .combined
+        .lines()
+        .enumerate()
+        .filter(|(_, line)| regex.is_match(line))
+        .map(|(line_index, line)| WorkRecordMatch {
+            record,
+            target: WorkRefTarget::Line(line_index + 1),
+            content: line,
+            matched_line: line_index + 1,
+        })
+        .collect()
+}
+
+fn matching_session<'a>(record: &'a WorkRecord, regex: &Regex) -> Option<WorkRecordMatch<'a>> {
+    let session_id = record.work_ref.session();
+    if regex.is_match(session_id) {
+        return Some(WorkRecordMatch {
+            record,
+            target: WorkRefTarget::Record,
+            content: session_id,
+            matched_line: 1,
+        });
+    }
+    None
+}
+
+fn find_part(record: &WorkRecord, io: WorkPartIo, index: usize) -> Option<&WorkPart> {
+    record
+        .parts
+        .iter()
+        .find(|part| part.io == io && part.index_in_record == index)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::ai::AgentProvider;
     use crate::record::model::{
-        WorkOutcome, WorkPayload, WorkRecordKind, WorkStatus, WorkText, WorkTime,
+        WorkOutcome, WorkPartKind, WorkPayload, WorkRecordKind, WorkStatus, WorkText, WorkTime,
     };
 
     #[test]
@@ -50,6 +176,30 @@ mod tests {
         assert!(index
             .resolve(&WorkRef::agent_record(AgentProvider::Pi, "abcdef12", 3))
             .is_none());
+    }
+
+    #[test]
+    fn resolves_parts_by_typed_ref() {
+        let record = test_record_with_parts("terminal/current/1", "current", 1, "hello");
+        let index = WorkRecordIndex::new(vec![record]);
+        let reference = WorkRef::terminal_record("current", 1).with_part(WorkPartIo::Output, 1);
+
+        assert!(index.resolve_part(&reference).is_some());
+    }
+
+    #[test]
+    fn search_finds_part_matches() {
+        let records = vec![test_record_with_parts(
+            "terminal/current/1",
+            "current",
+            1,
+            "hello world",
+        )];
+        let index = WorkRecordIndex::new(records);
+        let regex = Regex::new("hello").unwrap();
+        let matches = index.search(&regex, WorkRecordSearchScope::Content, 10, |_| true);
+
+        assert!(!matches.is_empty());
     }
 
     fn test_record(
@@ -73,11 +223,55 @@ mod tests {
             text: WorkText {
                 input: None,
                 output: Some(combined.to_string()),
+                combined: combined.to_string(),
             },
+            parts: Vec::new(),
             payload: WorkPayload::ChatTurn {
                 user: String::new(),
                 assistant: combined.to_string(),
                 messages: Vec::new(),
+            },
+        }
+    }
+
+    fn test_record_with_parts(
+        _ref_id: &str,
+        session_id: &str,
+        turn_index: usize,
+        text: &str,
+    ) -> WorkRecord {
+        WorkRecord {
+            schema_version: 1,
+            work_ref: WorkRef::terminal_record(session_id, turn_index),
+            kind: WorkRecordKind::TerminalCommand,
+            session_path: None,
+            cwd: None,
+            time: WorkTime::default(),
+            status: WorkStatus {
+                outcome: WorkOutcome::Success,
+                exit_code: Some(0),
+            },
+            title: "title".to_string(),
+            text: WorkText {
+                input: None,
+                output: Some(text.to_string()),
+                combined: text.to_string(),
+            },
+            parts: vec![WorkPart {
+                io: WorkPartIo::Output,
+                kind: WorkPartKind::Text,
+                index_in_record: 1,
+                occurred_at: None,
+                label: None,
+                text: text.to_string(),
+                ansi: None,
+            }],
+            payload: WorkPayload::TerminalCommand {
+                prompt: String::new(),
+                command: "cmd".to_string(),
+                output: text.to_string(),
+                prompt_ansi: None,
+                output_ansi: None,
             },
         }
     }

--- a/crates/sivtr-core/src/record/mod.rs
+++ b/crates/sivtr-core/src/record/mod.rs
@@ -2,10 +2,10 @@ pub mod index;
 pub mod model;
 pub mod refs;
 
-pub use index::WorkRecordIndex;
+pub use index::{WorkRecordIndex, WorkRecordMatch, WorkRecordSearchScope};
 pub use model::{
     chat_turn_ranges, is_real_user_block, ChatMessage, RecordText, RecordTextMode, WorkOutcome,
-    WorkPayload, WorkRecord, WorkRecordCopyParts, WorkRecordKind, WorkStatus, WorkText, WorkTime,
-    RECORD_SCHEMA_VERSION,
+    WorkPart, WorkPartIo, WorkPartKind, WorkPayload, WorkRecord, WorkRecordCopyParts,
+    WorkRecordKind, WorkStatus, WorkText, WorkTime, RECORD_SCHEMA_VERSION,
 };
 pub use refs::{WorkRef, WorkRefSelector, WorkRefTarget};

--- a/crates/sivtr-core/src/record/mod.rs
+++ b/crates/sivtr-core/src/record/mod.rs
@@ -2,10 +2,13 @@ pub mod index;
 pub mod model;
 pub mod refs;
 
-pub use index::{WorkRecordIndex, WorkRecordMatch, WorkRecordSearchScope};
+pub use index::{
+    work_record_content_matches, WorkRecordIndex, WorkRecordMatch, WorkRecordSearchScope,
+};
 pub use model::{
-    chat_turn_ranges, is_real_user_block, ChatMessage, RecordText, RecordTextMode, WorkOutcome,
-    WorkPart, WorkPartIo, WorkPartKind, WorkPayload, WorkRecord, WorkRecordCopyParts,
-    WorkRecordKind, WorkStatus, WorkText, WorkTime, RECORD_SCHEMA_VERSION,
+    chat_turn_ranges, is_real_user_block, ChatMessage, RecordText, RecordTextMode, WorkChannel,
+    WorkOutcome, WorkPart, WorkPartIo, WorkPartKind, WorkPayload, WorkRecord, WorkRecordCopyParts,
+    WorkRecordKind, WorkSessionRef, WorkSource, WorkStatus, WorkText, WorkTime,
+    RECORD_SCHEMA_VERSION,
 };
 pub use refs::{WorkRef, WorkRefSelector, WorkRefTarget};

--- a/crates/sivtr-core/src/record/model.rs
+++ b/crates/sivtr-core/src/record/model.rs
@@ -1,4 +1,4 @@
-use super::refs::WorkRef;
+use super::refs::{WorkRef, WorkRefTarget};
 use crate::ai::{
     format_blocks_with_text, select_blocks, AgentBlock, AgentBlockKind, AgentProvider,
     AgentSelection, AgentSession,
@@ -131,12 +131,48 @@ pub struct WorkStatus {
     pub exit_code: Option<i32>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkPartIo {
+    Input,
+    Output,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkPartKind {
+    Prompt,
+    Command,
+    UserMessage,
+    AssistantMessage,
+    ToolCall,
+    ToolOutput,
+    Text,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WorkPart {
+    pub io: WorkPartIo,
+    pub kind: WorkPartKind,
+    pub index_in_record: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub occurred_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ansi: Option<String>,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub struct WorkText {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output: Option<String>,
+    #[serde(default)]
+    pub combined: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -179,6 +215,8 @@ pub struct WorkRecord {
     pub status: WorkStatus,
     pub title: String,
     pub text: WorkText,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parts: Vec<WorkPart>,
     pub payload: WorkPayload,
 }
 
@@ -222,7 +260,9 @@ impl WorkRecord {
             text: WorkText {
                 input: non_empty(Some(command.clone())),
                 output: non_empty(Some(output.clone())),
+                combined: join_nonempty([command.as_str(), output.as_str()]),
             },
+            parts: terminal_parts(entry, &command, &output),
             payload: WorkPayload::TerminalCommand {
                 prompt: entry.prompt.clone(),
                 command,
@@ -309,7 +349,9 @@ impl WorkRecord {
             text: WorkText {
                 input: non_empty(Some(user.clone())),
                 output: non_empty(Some(assistant.clone())),
+                combined: format_blocks_with_compacted_skills(&chat_blocks),
             },
+            parts: agent_parts(blocks),
             payload: WorkPayload::ChatTurn {
                 user,
                 assistant,
@@ -420,6 +462,28 @@ impl WorkRecord {
             ),
             command: self.copy_text_with_prompt(RecordTextMode::Command, false, None),
         }
+    }
+
+    pub fn content_for_target(&self, target: WorkRefTarget) -> Option<&str> {
+        match target {
+            WorkRefTarget::Record => Some(self.text.combined.as_str()),
+            WorkRefTarget::Line(line) => line
+                .checked_sub(1)
+                .and_then(|index| self.text.combined.lines().nth(index)),
+            WorkRefTarget::Part { .. } => {
+                self.part_for_target(target).map(|part| part.text.as_str())
+            }
+        }
+    }
+
+    pub fn part_for_target(&self, target: WorkRefTarget) -> Option<&WorkPart> {
+        let (io, index) = match target {
+            WorkRefTarget::Part { io, index } => (io, index),
+            WorkRefTarget::Record | WorkRefTarget::Line(_) => return None,
+        };
+        self.parts
+            .iter()
+            .find(|part| part.io == io && part.index_in_record == index)
     }
 }
 
@@ -582,7 +646,12 @@ fn selected_block_record(
             exit_code: None,
         },
         title,
-        text: WorkText { input, output },
+        text: WorkText {
+            input: input.clone(),
+            output: output.clone(),
+            combined: text.clone(),
+        },
+        parts: agent_parts(std::slice::from_ref(&block)),
         payload: WorkPayload::ChatTurn {
             user: match kind {
                 AgentBlockKind::User => text.clone(),
@@ -616,6 +685,7 @@ fn selected_group_record(
     let work_ref = WorkRef::agent_record(provider, session_ref.clone(), 1);
     let started_at = first_timestamp(&blocks).and_then(|timestamp| normalize_timestamp(&timestamp));
     let ended_at = last_timestamp(&blocks).and_then(|timestamp| normalize_timestamp(&timestamp));
+    let parts = agent_parts(&blocks);
     vec![WorkRecord {
         schema_version: RECORD_SCHEMA_VERSION,
         work_ref,
@@ -631,7 +701,9 @@ fn selected_group_record(
         text: WorkText {
             input: None,
             output: Some(combined.clone()),
+            combined: combined.clone(),
         },
+        parts,
         payload: WorkPayload::ChatTurn {
             user: String::new(),
             assistant: combined,
@@ -851,6 +923,88 @@ fn join_nonempty<'a>(texts: impl IntoIterator<Item = &'a str>) -> String {
 
 fn non_empty(value: Option<String>) -> Option<String> {
     value.and_then(|value| (!value.trim().is_empty()).then_some(value))
+}
+
+fn terminal_parts(entry: &SessionEntry, command: &str, output: &str) -> Vec<WorkPart> {
+    let mut parts = Vec::new();
+    let mut input_count = 0;
+    let mut output_count = 0;
+    let prompt = entry.prompt.trim_end_matches(['\r', '\n']);
+    if !prompt.trim().is_empty() {
+        input_count += 1;
+        parts.push(WorkPart {
+            io: WorkPartIo::Input,
+            kind: WorkPartKind::Prompt,
+            index_in_record: input_count,
+            occurred_at: entry.ended_at.clone(),
+            label: None,
+            text: prompt.to_string(),
+            ansi: entry.prompt_ansi.clone(),
+        });
+    }
+    if !command.is_empty() {
+        input_count += 1;
+        parts.push(WorkPart {
+            io: WorkPartIo::Input,
+            kind: WorkPartKind::Command,
+            index_in_record: input_count,
+            occurred_at: entry.ended_at.clone(),
+            label: None,
+            text: command.to_string(),
+            ansi: None,
+        });
+    }
+    if !output.is_empty() {
+        output_count += 1;
+        parts.push(WorkPart {
+            io: WorkPartIo::Output,
+            kind: WorkPartKind::Text,
+            index_in_record: output_count,
+            occurred_at: entry.ended_at.clone(),
+            label: None,
+            text: output.to_string(),
+            ansi: entry.output_ansi.clone(),
+        });
+    }
+    parts
+}
+
+fn agent_parts(blocks: &[AgentBlock]) -> Vec<WorkPart> {
+    let mut parts = Vec::new();
+    let mut input_count = 0;
+    let mut output_count = 0;
+    for block in blocks {
+        let text = block.text.trim().to_string();
+        if text.is_empty() {
+            continue;
+        }
+        let (io, kind) = match block.kind {
+            AgentBlockKind::User => (WorkPartIo::Input, WorkPartKind::UserMessage),
+            AgentBlockKind::Assistant => (WorkPartIo::Output, WorkPartKind::AssistantMessage),
+            AgentBlockKind::ToolCall => (WorkPartIo::Input, WorkPartKind::ToolCall),
+            AgentBlockKind::ToolOutput => (WorkPartIo::Output, WorkPartKind::ToolOutput),
+        };
+        let index_in_record = match io {
+            WorkPartIo::Input => {
+                input_count += 1;
+                input_count
+            }
+            WorkPartIo::Output => {
+                output_count += 1;
+                output_count
+            }
+        };
+        parts.push(WorkPart {
+            io,
+            kind,
+            index_in_record,
+            occurred_at: block.timestamp.clone(),
+            label: block.label.clone(),
+            text,
+            ansi: None,
+        });
+    }
+    parts
 }
 
 #[cfg(test)]

--- a/crates/sivtr-core/src/record/model.rs
+++ b/crates/sivtr-core/src/record/model.rs
@@ -91,6 +91,82 @@ pub enum WorkOutcome {
     Unknown,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkChannel {
+    Terminal,
+    Chat,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WorkSource {
+    pub channel: WorkChannel,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WorkSessionRef {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub canonical_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    pub index: usize,
+    pub work_ref: WorkRef,
+}
+
+impl WorkSessionRef {
+    pub fn marker_ref(&self) -> String {
+        match &self.work_ref {
+            WorkRef::Terminal { session, .. } => format!("terminal/{session}"),
+            WorkRef::Agent {
+                provider, session, ..
+            } => format!("{}/{session}", provider.command_name()),
+        }
+    }
+
+    pub fn provider(&self) -> Option<AgentProvider> {
+        self.work_ref.provider()
+    }
+
+    pub fn matches_id(&self, value: &str) -> bool {
+        self.id == value || self.canonical_id.as_deref() == Some(value)
+    }
+
+    pub fn matches_record_ref(&self, reference: &WorkRef) -> bool {
+        let reference = reference.record_ref();
+        match (&self.work_ref, &reference) {
+            (
+                WorkRef::Terminal { record_index, .. },
+                WorkRef::Terminal {
+                    session,
+                    record_index: wanted_index,
+                    ..
+                },
+            ) => record_index == wanted_index && self.matches_id(session),
+            (
+                WorkRef::Agent {
+                    provider,
+                    turn_index,
+                    ..
+                },
+                WorkRef::Agent {
+                    provider: wanted_provider,
+                    session,
+                    turn_index: wanted_index,
+                    ..
+                },
+            ) => {
+                provider == wanted_provider
+                    && turn_index == wanted_index
+                    && self.matches_id(session)
+            }
+            _ => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub struct WorkTime {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -205,10 +281,11 @@ pub struct ChatMessage {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct WorkRecord {
     pub schema_version: u32,
+    pub id: String,
     pub work_ref: WorkRef,
     pub kind: WorkRecordKind,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub session_path: Option<String>,
+    pub source: WorkSource,
+    pub session: WorkSessionRef,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cwd: Option<String>,
     pub time: WorkTime,
@@ -247,9 +324,20 @@ impl WorkRecord {
 
         Some(Self {
             schema_version: RECORD_SCHEMA_VERSION,
+            id: work_ref.to_string(),
             work_ref,
             kind: WorkRecordKind::TerminalCommand,
-            session_path: Some(session_path.display().to_string()),
+            source: WorkSource {
+                channel: WorkChannel::Terminal,
+                provider: None,
+            },
+            session: WorkSessionRef {
+                id: session_id.clone(),
+                canonical_id: Some(session_id.clone()),
+                path: Some(session_path.display().to_string()),
+                index,
+                work_ref: WorkRef::terminal_record(session_id, index + 1),
+            },
             cwd: non_empty(entry.cwd.clone()),
             time: WorkTime::from_components(None, entry.ended_at.clone(), entry.duration_ms),
             status: WorkStatus {
@@ -323,8 +411,9 @@ impl WorkRecord {
             return None;
         }
 
-        let session_ref = agent_session_ref_id(session.id.as_deref(), &session.path);
-        let work_ref = WorkRef::agent_record(provider, session_ref.clone(), index + 1);
+        let session_ref_id = agent_session_ref_id(session.id.as_deref(), &session.path);
+        let canonical_id = agent_session_canonical_id(session.id.as_deref(), &session.path);
+        let work_ref = WorkRef::agent_record(provider, session_ref_id.clone(), index + 1);
         let title = if user.trim().is_empty() {
             title_preview(&assistant)
         } else {
@@ -336,9 +425,24 @@ impl WorkRecord {
 
         Some(Self {
             schema_version: RECORD_SCHEMA_VERSION,
+            id: work_ref.to_string(),
             work_ref,
             kind: WorkRecordKind::ChatTurn,
-            session_path: Some(session.path.display().to_string()),
+            source: WorkSource {
+                channel: WorkChannel::Chat,
+                provider: Some(provider.command_name().to_string()),
+            },
+            session: WorkSessionRef {
+                id: session_ref_id,
+                canonical_id,
+                path: Some(session.path.display().to_string()),
+                index,
+                work_ref: WorkRef::agent_record(
+                    provider,
+                    agent_session_ref_id(session.id.as_deref(), &session.path),
+                    index + 1,
+                ),
+            },
             cwd: non_empty(session.cwd.clone()),
             time: WorkTime::from_components(started_at, ended_at, None),
             status: WorkStatus {
@@ -625,8 +729,9 @@ fn selected_block_record(
 ) -> WorkRecord {
     let text = compact_skill_blocks(block.text.trim());
     let title = title_preview(&text);
-    let session_ref = agent_session_ref_id(session.id.as_deref(), &session.path);
-    let work_ref = WorkRef::agent_record(provider, session_ref.clone(), index + 1);
+    let session_ref_id = agent_session_ref_id(session.id.as_deref(), &session.path);
+    let canonical_id = agent_session_canonical_id(session.id.as_deref(), &session.path);
+    let work_ref = WorkRef::agent_record(provider, session_ref_id.clone(), index + 1);
     let block_timestamp = block.timestamp.as_deref().and_then(normalize_timestamp);
     let (input, output) = match kind {
         AgentBlockKind::User => (Some(text.clone()), None),
@@ -636,9 +741,24 @@ fn selected_block_record(
 
     WorkRecord {
         schema_version: RECORD_SCHEMA_VERSION,
+        id: work_ref.to_string(),
         work_ref,
         kind: WorkRecordKind::ChatTurn,
-        session_path: Some(session.path.display().to_string()),
+        source: WorkSource {
+            channel: WorkChannel::Chat,
+            provider: Some(provider.command_name().to_string()),
+        },
+        session: WorkSessionRef {
+            id: session_ref_id,
+            canonical_id,
+            path: Some(session.path.display().to_string()),
+            index,
+            work_ref: WorkRef::agent_record(
+                provider,
+                agent_session_ref_id(session.id.as_deref(), &session.path),
+                index + 1,
+            ),
+        },
         cwd: non_empty(session.cwd.clone()),
         time: WorkTime::from_components(block_timestamp.clone(), None, None),
         status: WorkStatus {
@@ -681,16 +801,32 @@ fn selected_group_record(
         return Vec::new();
     }
 
-    let session_ref = agent_session_ref_id(session.id.as_deref(), &session.path);
-    let work_ref = WorkRef::agent_record(provider, session_ref.clone(), 1);
+    let session_ref_id = agent_session_ref_id(session.id.as_deref(), &session.path);
+    let canonical_id = agent_session_canonical_id(session.id.as_deref(), &session.path);
+    let work_ref = WorkRef::agent_record(provider, session_ref_id.clone(), 1);
     let started_at = first_timestamp(&blocks).and_then(|timestamp| normalize_timestamp(&timestamp));
     let ended_at = last_timestamp(&blocks).and_then(|timestamp| normalize_timestamp(&timestamp));
     let parts = agent_parts(&blocks);
     vec![WorkRecord {
         schema_version: RECORD_SCHEMA_VERSION,
+        id: work_ref.to_string(),
         work_ref,
         kind: WorkRecordKind::ChatTurn,
-        session_path: Some(session.path.display().to_string()),
+        source: WorkSource {
+            channel: WorkChannel::Chat,
+            provider: Some(provider.command_name().to_string()),
+        },
+        session: WorkSessionRef {
+            id: session_ref_id,
+            canonical_id,
+            path: Some(session.path.display().to_string()),
+            index: 0,
+            work_ref: WorkRef::agent_record(
+                provider,
+                agent_session_ref_id(session.id.as_deref(), &session.path),
+                1,
+            ),
+        },
         cwd: non_empty(session.cwd.clone()),
         time: WorkTime::from_components(started_at, ended_at, None),
         status: WorkStatus {
@@ -799,6 +935,17 @@ fn agent_session_ref_id(id: Option<&str>, path: &Path) -> String {
                 .filter(|id| !id.is_empty())
         })
         .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn agent_session_canonical_id(id: Option<&str>, path: &Path) -> Option<String> {
+    id.filter(|id| !id.trim().is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            path.file_stem()
+                .and_then(|name| name.to_str())
+                .map(str::to_string)
+                .filter(|id| !id.trim().is_empty())
+        })
 }
 
 fn short_id(id: &str) -> String {

--- a/crates/sivtr-core/src/record/refs.rs
+++ b/crates/sivtr-core/src/record/refs.rs
@@ -4,11 +4,13 @@ use std::fmt;
 use std::str::FromStr;
 
 use crate::ai::AgentProvider;
+use crate::record::model::WorkPartIo;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WorkRefTarget {
     Record,
     Line(usize),
+    Part { io: WorkPartIo, index: usize },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -130,6 +132,14 @@ impl WorkRef {
     }
 
     pub fn with_line(&self, line: usize) -> Self {
+        self.with_target(WorkRefTarget::Line(line))
+    }
+
+    pub fn with_part(&self, io: WorkPartIo, index: usize) -> Self {
+        self.with_target(WorkRefTarget::Part { io, index })
+    }
+
+    pub fn with_target(&self, target: WorkRefTarget) -> Self {
         match self {
             Self::Terminal {
                 session,
@@ -138,7 +148,7 @@ impl WorkRef {
             } => Self::Terminal {
                 session: session.clone(),
                 record_index: *record_index,
-                target: WorkRefTarget::Line(line),
+                target,
             },
             Self::Agent {
                 provider,
@@ -149,7 +159,7 @@ impl WorkRef {
                 provider: *provider,
                 session: session.clone(),
                 turn_index: *turn_index,
-                target: WorkRefTarget::Line(line),
+                target,
             },
         }
     }
@@ -174,6 +184,14 @@ impl WorkRef {
         match self.target() {
             WorkRefTarget::Record => None,
             WorkRefTarget::Line(line) => Some(line),
+            WorkRefTarget::Part { .. } => None,
+        }
+    }
+
+    pub fn part(&self) -> Option<(WorkPartIo, usize)> {
+        match self.target() {
+            WorkRefTarget::Part { io, index } => Some((io, index)),
+            WorkRefTarget::Record | WorkRefTarget::Line(_) => None,
         }
     }
 
@@ -232,8 +250,12 @@ impl fmt::Display for WorkRef {
 
 fn write_parts(f: &mut fmt::Formatter<'_>, parts: &[&str], target: WorkRefTarget) -> fmt::Result {
     write!(f, "{}", parts.join("/"))?;
-    if let WorkRefTarget::Line(line) = target {
-        write!(f, "/{line}")?;
+    match target {
+        WorkRefTarget::Record => {}
+        WorkRefTarget::Line(line) => write!(f, "/{line}")?,
+        WorkRefTarget::Part { io, index } => {
+            write!(f, "/{}/{index}", part_segment(io))?;
+        }
     }
     Ok(())
 }
@@ -309,57 +331,72 @@ impl FromStr for WorkRef {
     type Err = anyhow::Error;
 
     fn from_str(value: &str) -> Result<Self> {
-        let selector: WorkRefSelector = value.parse()?;
-        match selector {
-            WorkRefSelector::Terminal {
-                session,
-                records,
-                lines,
-            } => Ok(Self::Terminal {
-                session: required_session(session, value)?,
-                record_index: single_index(records.as_deref(), "record", value)?,
-                target: target_from_lines(lines.as_deref(), value)?,
-            }),
-            WorkRefSelector::Agent {
-                provider: Some(provider),
-                session,
-                records,
-                lines,
-            } => Ok(Self::Agent {
-                provider,
-                session: required_session(session, value)?,
-                turn_index: single_index(records.as_deref(), "record", value)?,
-                target: target_from_lines(lines.as_deref(), value)?,
-            }),
-            WorkRefSelector::Agent { provider: None, .. } => {
-                bail!("Invalid work ref `{value}`; provider-specific source is required")
-            }
+        let parts = value
+            .split('/')
+            .filter(|part| !part.is_empty())
+            .collect::<Vec<_>>();
+        if !(3..=5).contains(&parts.len()) {
+            bail!(
+                "Invalid work ref `{value}`; expected terminal/<session>/<record>[/line|/i/<part>|/o/<part>] or <provider>/<session>/<turn>[/line|/i/<part>|/o/<part>]"
+            );
         }
+
+        let target = match parts.len() {
+            3 => WorkRefTarget::Record,
+            4 => WorkRefTarget::Line(parse_one_based(parts[3], "line", value)?),
+            5 => WorkRefTarget::Part {
+                io: parse_part_io(parts[3], value)?,
+                index: parse_one_based(parts[4], "part", value)?,
+            },
+            _ => unreachable!("length already validated"),
+        };
+        let item_index = parse_one_based(parts[2], "record", value)?;
+
+        if parts[0].eq_ignore_ascii_case("terminal") {
+            return Ok(Self::Terminal {
+                session: parts[1].to_string(),
+                record_index: item_index,
+                target,
+            });
+        }
+
+        let provider = AgentProvider::from_command_name(parts[0]).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Invalid work ref `{value}`; unknown provider `{}`",
+                parts[0]
+            )
+        })?;
+        Ok(Self::Agent {
+            provider,
+            session: parts[1].to_string(),
+            turn_index: item_index,
+            target,
+        })
     }
 }
 
-fn required_session(session: Option<String>, reference: &str) -> Result<String> {
-    session.ok_or_else(|| anyhow::anyhow!("Invalid work ref `{reference}`; session is required"))
+fn parse_one_based(part: &str, label: &str, reference: &str) -> Result<usize> {
+    let value = part.parse::<usize>().with_context(|| {
+        format!("Invalid work ref `{reference}`; {label} index must be a positive integer")
+    })?;
+    if value == 0 {
+        bail!("Invalid work ref `{reference}`; {label} index must be 1-based");
+    }
+    Ok(value)
 }
 
-fn target_from_lines(lines: Option<&[usize]>, reference: &str) -> Result<WorkRefTarget> {
-    match lines {
-        Some(lines) => Ok(WorkRefTarget::Line(single_index(
-            Some(lines),
-            "line",
-            reference,
-        )?)),
-        None => Ok(WorkRefTarget::Record),
+fn parse_part_io(part: &str, reference: &str) -> Result<WorkPartIo> {
+    match part {
+        "i" => Ok(WorkPartIo::Input),
+        "o" => Ok(WorkPartIo::Output),
+        _ => bail!("Invalid work ref `{reference}`; expected `i` or `o` part selector"),
     }
 }
 
-fn single_index(indices: Option<&[usize]>, label: &str, reference: &str) -> Result<usize> {
-    match indices {
-        Some([index]) => Ok(*index),
-        Some(_) => {
-            bail!("Invalid work ref `{reference}`; {label} selector must resolve to one index")
-        }
-        None => bail!("Invalid work ref `{reference}`; {label} index is required"),
+fn part_segment(io: WorkPartIo) -> &'static str {
+    match io {
+        WorkPartIo::Input => "i",
+        WorkPartIo::Output => "o",
     }
 }
 
@@ -390,16 +427,6 @@ fn parse_index_selector(part: &str, label: &str, reference: &str) -> Result<Vec<
     Ok(indices)
 }
 
-fn parse_one_based(part: &str, label: &str, reference: &str) -> Result<usize> {
-    let value = part.parse::<usize>().with_context(|| {
-        format!("Invalid work ref selector `{reference}`; {label} index must be a positive integer")
-    })?;
-    if value == 0 {
-        bail!("Invalid work ref selector `{reference}`; {label} index must be 1-based");
-    }
-    Ok(value)
-}
-
 fn segment_matches(expected: &str, actual: &str) -> bool {
     actual == expected || actual.starts_with(expected)
 }
@@ -424,6 +451,25 @@ mod tests {
     }
 
     #[test]
+    fn parses_and_renders_terminal_part_refs() {
+        let reference: WorkRef = "terminal/current/3/o/2".parse().unwrap();
+        assert_eq!(
+            reference,
+            WorkRef::Terminal {
+                session: "current".to_string(),
+                record_index: 3,
+                target: WorkRefTarget::Part {
+                    io: WorkPartIo::Output,
+                    index: 2,
+                },
+            }
+        );
+        assert_eq!(reference.part(), Some((WorkPartIo::Output, 2)));
+        assert_eq!(reference.to_string(), "terminal/current/3/o/2");
+        assert_eq!(reference.record_ref().to_string(), "terminal/current/3");
+    }
+
+    #[test]
     fn parses_and_renders_agent_refs() {
         let reference: WorkRef = "pi/abcdef12/2".parse().unwrap();
         assert_eq!(
@@ -436,12 +482,22 @@ mod tests {
             }
         );
         assert_eq!(reference.with_line(7).to_string(), "pi/abcdef12/2/7");
+        assert_eq!(
+            reference.with_part(WorkPartIo::Input, 3).to_string(),
+            "pi/abcdef12/2/i/3"
+        );
     }
 
     #[test]
     fn rejects_zero_indices() {
         assert!("pi/session/0".parse::<WorkRef>().is_err());
         assert!("pi/session/1/0".parse::<WorkRef>().is_err());
+        assert!("pi/session/1/i/0".parse::<WorkRef>().is_err());
+    }
+
+    #[test]
+    fn rejects_unknown_part_selector() {
+        assert!("pi/session/1/x/1".parse::<WorkRef>().is_err());
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -126,6 +126,61 @@ impl std::fmt::Display for SearchSortArg {
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum WorkPartFilterArg {
+    Input,
+    Output,
+    #[default]
+    All,
+}
+
+impl WorkPartFilterArg {
+    pub fn matches(self, io: sivtr_core::record::WorkPartIo) -> bool {
+        match self {
+            Self::All => true,
+            Self::Input => io == sivtr_core::record::WorkPartIo::Input,
+            Self::Output => io == sivtr_core::record::WorkPartIo::Output,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Input => "input",
+            Self::Output => "output",
+            Self::All => "all",
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Input => "input",
+            Self::Output => "output",
+            Self::All => "any",
+        }
+    }
+}
+
+impl FromStr for WorkPartFilterArg {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_ascii_lowercase().as_str() {
+            "input" | "in" | "i" => Ok(Self::Input),
+            "output" | "out" | "o" => Ok(Self::Output),
+            "all" => Ok(Self::All),
+            _ => Err(format!(
+                "unknown part filter `{value}`; expected all, input, or output"
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for WorkPartFilterArg {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum SearchOutputFormatArg {
     Compact,
     Timeline,
@@ -250,6 +305,27 @@ Examples:
   sivtr copy cmd 3 --print
   sivtr copy cmd --pick
   sivtr copy cmd 2..5
+";
+
+const COPY_REF_AFTER_HELP: &str = "\
+Defaults:
+  `sivtr copy ref <ref>` copies the exact content addressed by a
+  terminal or AI workspace ref.
+
+Supported Refs:
+  terminal/current/12
+  terminal/current/12/8
+  codex/SESSION/3
+  codex/SESSION/3/i/2
+  codex/SESSION/3/o/1
+
+Filters:
+  `--regex` and `--lines` run after the ref content is resolved.
+
+Examples:
+  sivtr copy ref codex/019df7fb/3/o/1
+  sivtr copy ref terminal/current/12/8 --print
+  sivtr copy ref claude/abc123/4 --cwd /path/to/project
 ";
 
 const COPY_CODEX_AFTER_HELP: &str = "\
@@ -437,6 +513,10 @@ Pipelines:
   If stdin is piped into `sivtr search`, it must be JSON output from a previous search.
   Leave intermediate searches on the default JSON format, then choose the display format on the final search.
 
+Notes:
+  Content hits may return structured refs such as `.../i/<n>` or `.../o/<n>`
+  when the match belongs to a canonical input/output part.
+
 Examples:
   sivtr search terminal --status failure --latest 1 --json
   sivtr s terminal --status fail -m "panic|failed" -v "example|sample" --latest 20 --refs
@@ -446,6 +526,52 @@ Examples:
   sivtr search pi/019e5941/7 --format json
   sivtr search terminal/session_13104/3/12 --format json
 "##;
+
+const WORK_SESSIONS_AFTER_HELP: &str = "\
+Defaults:
+  `sivtr work sessions` lists session markers for the current workspace.
+  Output stays at marker level and does not print full session content.
+
+Scope:
+  Terminal sessions from the current git workspace are always included.
+  `--provider` limits which AI providers are scanned.
+
+Examples:
+  sivtr work sessions
+  sivtr work sessions --provider codex
+  sivtr work sessions --json
+";
+
+const WORK_RECORDS_AFTER_HELP: &str = "\
+Defaults:
+  `sivtr work records <session-ref>` lists record markers within one session.
+  Output stays at marker level and does not print full record content.
+
+Session Refs:
+  terminal/<session>
+  codex/<session>
+  claude/<session>
+
+Examples:
+  sivtr work records terminal/session_123
+  sivtr work records codex/019df7fb --json
+";
+
+const WORK_PARTS_AFTER_HELP: &str = "\
+Defaults:
+  `sivtr work parts <record-ref>` lists leaf part markers within one record.
+  Use `sivtr show <part-ref>` to print the full leaf content.
+
+Filters:
+  `--io all` lists every part.
+  `--io input` lists only input-side parts.
+  `--io output` lists only output-side parts.
+
+Examples:
+  sivtr work parts codex/019df7fb/3
+  sivtr work parts codex/019df7fb/3 --io output
+  sivtr show codex/019df7fb/3/o/1
+";
 
 const HOTKEY_AFTER_HELP: &str = "\
 Examples:
@@ -492,6 +618,9 @@ pub enum Commands {
     /// Search captured terminal and AI workspace sessions
     #[command(visible_alias = "s", after_help = SEARCH_AFTER_HELP)]
     Search(SearchArgs),
+
+    /// Traverse workspace sessions, records, and parts without printing full content
+    Work(WorkCommand),
 
     /// Show a captured terminal or AI workspace ref
     Show(ShowArgs),
@@ -585,6 +714,10 @@ pub enum CopySubcommand {
     #[command(after_help = COPY_COMMAND_AFTER_HELP)]
     Cmd(CopySimpleArgs),
 
+    /// Copy the exact content addressed by a work ref
+    #[command(after_help = COPY_REF_AFTER_HELP)]
+    Ref(CopyRefArgs),
+
     /// Copy content from the current Codex conversation session
     #[command(after_help = COPY_CODEX_AFTER_HELP)]
     Codex(AgentCopyCommand),
@@ -643,6 +776,28 @@ pub struct CopyArgs {
 pub struct CopySimpleArgs {
     #[command(flatten)]
     pub common: CopyCommonArgs,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct CopyRefArgs {
+    /// Ref to copy, for example `codex/019e4f40/3/o/1`
+    pub reference: String,
+
+    /// Workspace directory used to resolve current AI sessions
+    #[arg(long, value_name = "PATH")]
+    pub cwd: Option<PathBuf>,
+
+    /// Print the copied text after copying
+    #[arg(long)]
+    pub print: bool,
+
+    /// Keep only lines matching this regex
+    #[arg(long, value_name = "PATTERN")]
+    pub regex: Option<String>,
+
+    /// Keep only selected 1-based lines, for example `10:20` or `1,3,8:12`
+    #[arg(long, value_name = "SPEC")]
+    pub lines: Option<String>,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -771,8 +926,76 @@ pub struct SearchArgs {
 
 #[derive(Args, Debug, Clone)]
 pub struct ShowArgs {
-    /// Ref to show, for example `pi/019e4f40/3` or `terminal/current/12/8`.
+    /// Ref to show, for example `pi/019e4f40/3`, `pi/019e4f40/3/o/1`, or `terminal/current/12/8`.
     pub reference: String,
+
+    /// Workspace directory used to resolve current AI sessions
+    #[arg(long, value_name = "PATH")]
+    pub cwd: Option<PathBuf>,
+
+    /// Print machine-readable JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct WorkCommand {
+    #[command(subcommand)]
+    pub action: WorkSubcommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum WorkSubcommand {
+    /// List session markers for the current workspace
+    #[command(after_help = WORK_SESSIONS_AFTER_HELP)]
+    Sessions(WorkSessionsArgs),
+
+    /// List record markers for one session marker
+    #[command(after_help = WORK_RECORDS_AFTER_HELP)]
+    Records(WorkRecordsArgs),
+
+    /// List part markers for one record ref
+    #[command(after_help = WORK_PARTS_AFTER_HELP)]
+    Parts(WorkPartsArgs),
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct WorkSessionsArgs {
+    /// AI provider sessions to include; terminal workspace records are always included
+    #[arg(long, default_value_t = HotkeyProviderSelection::default(), value_name = "PROVIDER")]
+    pub provider: HotkeyProviderSelection,
+
+    /// Workspace directory used to resolve current AI sessions
+    #[arg(long, value_name = "PATH")]
+    pub cwd: Option<PathBuf>,
+
+    /// Print machine-readable JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct WorkRecordsArgs {
+    /// Session marker from `sivtr work sessions`, for example `codex/019df7fb`
+    pub session: String,
+
+    /// Workspace directory used to resolve current AI sessions
+    #[arg(long, value_name = "PATH")]
+    pub cwd: Option<PathBuf>,
+
+    /// Print machine-readable JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct WorkPartsArgs {
+    /// Record ref, for example `codex/019df7fb/3` or `terminal/session_123/12`
+    pub record: String,
+
+    /// Which leaf parts to list: all, input, or output
+    #[arg(long, default_value_t = WorkPartFilterArg::default(), value_name = "IO")]
+    pub io: WorkPartFilterArg,
 
     /// Workspace directory used to resolve current AI sessions
     #[arg(long, value_name = "PATH")]
@@ -1083,6 +1306,32 @@ mod tests {
     }
 
     #[test]
+    fn copy_ref_accepts_workspace_ref_and_filters() {
+        let cli = Cli::try_parse_from([
+            "sivtr",
+            "copy",
+            "ref",
+            "codex/session/3/o/1",
+            "--print",
+            "--regex",
+            "error",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::Copy(cmd)) => match cmd.mode {
+                Some(CopySubcommand::Ref(args)) => {
+                    assert_eq!(args.reference, "codex/session/3/o/1");
+                    assert!(args.print);
+                    assert_eq!(args.regex.as_deref(), Some("error"));
+                }
+                _ => panic!("expected copy ref mode"),
+            },
+            _ => panic!("expected copy command"),
+        }
+    }
+
+    #[test]
     fn codex_copy_defaults_to_last_turn() {
         let cli = Cli::try_parse_from(["sivtr", "copy", "codex"]).unwrap();
 
@@ -1264,6 +1513,69 @@ mod tests {
                 assert!(!args.refs);
             }
             _ => panic!("expected search command"),
+        }
+    }
+
+    #[test]
+    fn work_sessions_accepts_provider_and_json() {
+        let cli =
+            Cli::try_parse_from(["sivtr", "work", "sessions", "--provider", "codex", "--json"])
+                .unwrap();
+
+        match cli.command {
+            Some(Commands::Work(cmd)) => match cmd.action {
+                WorkSubcommand::Sessions(args) => {
+                    assert_eq!(
+                        args.provider,
+                        HotkeyProviderSelection::provider(AgentProvider::Codex)
+                    );
+                    assert!(args.json);
+                }
+                _ => panic!("expected work sessions command"),
+            },
+            _ => panic!("expected work command"),
+        }
+    }
+
+    #[test]
+    fn work_records_accepts_session_marker() {
+        let cli = Cli::try_parse_from(["sivtr", "work", "records", "codex/019df7fb"]).unwrap();
+
+        match cli.command {
+            Some(Commands::Work(cmd)) => match cmd.action {
+                WorkSubcommand::Records(args) => {
+                    assert_eq!(args.session, "codex/019df7fb");
+                    assert!(!args.json);
+                }
+                _ => panic!("expected work records command"),
+            },
+            _ => panic!("expected work command"),
+        }
+    }
+
+    #[test]
+    fn work_parts_accepts_output_filter() {
+        let cli = Cli::try_parse_from([
+            "sivtr",
+            "work",
+            "parts",
+            "codex/019df7fb/3",
+            "--io",
+            "output",
+            "--json",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Some(Commands::Work(cmd)) => match cmd.action {
+                WorkSubcommand::Parts(args) => {
+                    assert_eq!(args.record, "codex/019df7fb/3");
+                    assert_eq!(args.io, WorkPartFilterArg::Output);
+                    assert!(args.json);
+                }
+                _ => panic!("expected work parts command"),
+            },
+            _ => panic!("expected work command"),
         }
     }
 

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -1,14 +1,16 @@
 use anyhow::{Context, Result};
 use regex::Regex;
+use std::path::Path;
 use std::time::SystemTime;
 
 use crate::commands::command_block_selector::{parse_selector, resolve_selector, CommandSelection};
+use crate::commands::records::current_work_record_index;
 use sivtr_core::ai::{
     AgentBlockKind, AgentProvider, AgentSelection, AgentSession, AgentSessionInfo,
     AgentSessionProvider,
 };
 use sivtr_core::capture::scrollback;
-use sivtr_core::record::{is_real_user_block, RecordTextMode, WorkRecord};
+use sivtr_core::record::{is_real_user_block, RecordTextMode, WorkRecord, WorkRef};
 use sivtr_core::session::{self, SessionEntry};
 
 mod vim;
@@ -244,7 +246,7 @@ pub fn execute_agent(request: AgentCopyRequest<'_>) -> Result<()> {
                 .unwrap_or(SystemTime::UNIX_EPOCH),
         };
         let choice =
-            build_agent_session_choice(source.as_ref(), &info, session, request.selection_mode)
+            build_agent_session_choice(request.provider, &info, session, request.selection_mode)
                 .with_context(|| format!("{provider_name} session has no selectable content"))?;
         let mut terminal = init_tui()?;
         let result = run_workspace_picker_on_terminal(
@@ -277,6 +279,58 @@ pub fn execute_agent(request: AgentCopyRequest<'_>) -> Result<()> {
         format!("selected {provider_name} content is empty"),
         format!("sivtr: copied {provider_name} content to clipboard"),
     )
+}
+
+pub fn execute_ref(
+    reference: &str,
+    cwd: Option<&Path>,
+    print_full: bool,
+    regex: Option<&str>,
+    lines: Option<&str>,
+) -> Result<()> {
+    let work_ref: WorkRef = reference.parse()?;
+    let cwd = cwd
+        .map(Path::to_path_buf)
+        .unwrap_or(std::env::current_dir().context("Failed to resolve current directory")?);
+    let providers = work_ref
+        .provider()
+        .map(|provider| vec![provider])
+        .unwrap_or_else(|| {
+            AgentProvider::all()
+                .iter()
+                .map(|spec| spec.provider)
+                .collect()
+        });
+    let records = current_work_record_index(&providers, &cwd, None)?;
+    let record = records
+        .resolve(&work_ref)
+        .with_context(|| format!("No record found for ref `{reference}`"))?;
+    let mut text = ref_text_pair(record, &work_ref, reference)?;
+
+    if let Some(pattern) = regex {
+        text = filter_lines_by_regex(&text, pattern)?;
+    }
+
+    if let Some(spec) = lines {
+        text = filter_lines_by_spec(&text, spec)?;
+    }
+
+    finish_copy(
+        text.plain.trim().to_string(),
+        print_full,
+        "sivtr: copied ref content to clipboard".to_string(),
+    )
+}
+
+fn ref_text_pair(record: &WorkRecord, work_ref: &WorkRef, input_ref: &str) -> Result<TextPair> {
+    let plain = record
+        .content_for_target(work_ref.target())
+        .map(str::to_string)
+        .with_context(|| missing_ref_content_message(work_ref, input_ref))?;
+    Ok(TextPair {
+        ansi: plain.clone(),
+        plain,
+    })
 }
 
 pub fn execute_agent_picker(request: AgentPickerRequest<'_>) -> Result<()> {
@@ -463,8 +517,8 @@ fn pick_current_agent_session_content_on_terminal(
         title: session.title.clone(),
         modified: SystemTime::UNIX_EPOCH,
     };
-    let choice =
-        build_agent_session_choice(source, &info, session, selection_mode).with_context(|| {
+    let choice = build_agent_session_choice(source.provider(), &info, session, selection_mode)
+        .with_context(|| {
             format!(
                 "Current {} session has no selectable content",
                 source.provider().name()
@@ -482,7 +536,9 @@ fn build_agent_session_choices(
 
     for info in sessions {
         let session = source.parse_session_file(&info.path)?;
-        if let Some(choice) = build_agent_session_choice(source, info, session, selection_mode) {
+        if let Some(choice) =
+            build_agent_session_choice(source.provider(), info, session, selection_mode)
+        {
             choices.push(choice);
         }
     }
@@ -518,6 +574,7 @@ fn build_lazy_agent_session_choice(
         modified: info.modified,
         title,
         search_title,
+        notice: None,
         records: Vec::new(),
         load: Some(WorkspaceSessionLoad {
             provider,
@@ -536,37 +593,31 @@ fn load_workspace_session(session: &WorkspaceSession) -> Result<WorkspaceSession
         return Ok(session.clone());
     };
 
+    let info = AgentSessionInfo {
+        path: load.path.clone(),
+        id: load.id.clone(),
+        cwd: load.cwd.clone(),
+        title: load.title.clone(),
+        modified: load.modified,
+    };
     let source = load.provider.session_provider();
-    let info = AgentSessionInfo {
-        path: load.path.clone(),
-        id: load.id.clone(),
-        cwd: load.cwd.clone(),
-        title: load.title.clone(),
-        modified: load.modified,
+    let parsed = match source.parse_session_file(&load.path) {
+        Ok(parsed) => parsed,
+        Err(_) => {
+            return Ok(unavailable_workspace_session(
+                load.provider,
+                info,
+                format!("Failed to load {} session.", load.provider.name()),
+            ));
+        }
     };
-    let parsed = source.parse_session_file(&load.path)?;
-    match build_agent_session_choice(source.as_ref(), &info, parsed, load.selection_mode) {
-        Some(session) => Ok(session),
-        None => Ok(empty_loaded_agent_session(load)),
-    }
-}
 
-fn empty_loaded_agent_session(load: &WorkspaceSessionLoad) -> WorkspaceSession {
-    let info = AgentSessionInfo {
-        path: load.path.clone(),
-        id: load.id.clone(),
-        cwd: load.cwd.clone(),
-        title: load.title.clone(),
-        modified: load.modified,
-    };
-    WorkspaceSession {
-        source: WorkspaceSource::Agent(load.provider),
-        modified: load.modified,
-        title: agent_session_info_display_title(&info),
-        search_title: agent_session_info_fallback_title(&info),
-        records: Vec::new(),
-        load: None,
-    }
+    Ok(resolved_workspace_session(
+        load.provider,
+        &info,
+        parsed,
+        load.selection_mode,
+    ))
 }
 
 pub(super) fn load_workspace_session_at(
@@ -597,12 +648,12 @@ pub(super) fn load_workspace_sessions_for_indices(
 }
 
 fn build_agent_session_choice(
-    source: &dyn AgentSessionProvider,
+    provider: AgentProvider,
     info: &AgentSessionInfo,
     session: AgentSession,
     selection_mode: AgentSelection,
 ) -> Option<WorkspaceSession> {
-    let records = WorkRecord::selected_chat_records(source.provider(), &session, selection_mode);
+    let records = WorkRecord::selected_chat_records(provider, &session, selection_mode);
     if session.blocks.is_empty() || records.is_empty() {
         return None;
     }
@@ -611,13 +662,49 @@ fn build_agent_session_choice(
     let search_title = agent_session_search_title(info, &session);
 
     Some(WorkspaceSession {
-        source: WorkspaceSource::Agent(source.provider()),
+        source: WorkspaceSource::Agent(provider),
         modified: info.modified,
         title,
         search_title,
+        notice: None,
         records,
         load: None,
     })
+}
+
+fn resolved_workspace_session(
+    provider: AgentProvider,
+    info: &AgentSessionInfo,
+    session: AgentSession,
+    selection_mode: AgentSelection,
+) -> WorkspaceSession {
+    build_agent_session_choice(provider, info, session, selection_mode).unwrap_or_else(|| {
+        unavailable_workspace_session(
+            provider,
+            info.clone(),
+            format!("{} session has no selectable content.", provider.name()),
+        )
+    })
+}
+
+fn unavailable_workspace_session(
+    provider: AgentProvider,
+    info: AgentSessionInfo,
+    notice: String,
+) -> WorkspaceSession {
+    WorkspaceSession {
+        source: WorkspaceSource::Agent(provider),
+        modified: info.modified,
+        title: agent_session_info_display_title(&info),
+        search_title: info
+            .title
+            .clone()
+            .filter(|title| !title.trim().is_empty())
+            .unwrap_or_else(|| agent_session_info_fallback_title(&info)),
+        notice: Some(notice),
+        records: Vec::new(),
+        load: None,
+    }
 }
 
 fn workspace_sessions_from_agent_choices(
@@ -746,6 +833,7 @@ fn build_terminal_workspace_session(
         modified,
         search_title: title.clone(),
         title,
+        notice: None,
         records,
         load: None,
     })
@@ -910,6 +998,20 @@ fn finish_copy(text: String, print_full: bool, success_message: String) -> Resul
 
     eprintln!("{success_message}");
     Ok(())
+}
+
+fn missing_ref_content_message(work_ref: &WorkRef, input_ref: &str) -> String {
+    if let Some((io, index)) = work_ref.part() {
+        let label = match io {
+            sivtr_core::record::WorkPartIo::Input => "input",
+            sivtr_core::record::WorkPartIo::Output => "output",
+        };
+        format!("No {label} part {index} in ref `{input_ref}`")
+    } else if let Some(line) = work_ref.line() {
+        format!("No line {line} in ref `{input_ref}`")
+    } else {
+        format!("No record found for ref `{input_ref}`")
+    }
 }
 
 fn resolve_agent_session_path(
@@ -1211,13 +1313,17 @@ mod tests {
     use super::vim::{is_vim_command, vim_single_quote};
     use super::{
         agent_session_preview, filter_lines_by_regex, filter_lines_by_spec, load_workspace_session,
-        record_to_copy_parts, records_to_text_pairs, resolve_agent_session_selector,
-        AgentBlockKind, AgentProvider, AgentSelection, AgentSession, AgentSessionInfo,
-        AgentSessionProvider, TextPair,
+        record_to_copy_parts, records_to_text_pairs, ref_text_pair, resolve_agent_session_selector,
+        resolved_workspace_session, AgentBlockKind, AgentProvider, AgentSelection, AgentSession,
+        AgentSessionInfo, AgentSessionProvider, TextPair,
     };
     use anyhow::Result;
     use sivtr_core::ai::AgentBlock;
-    use sivtr_core::record::{RecordTextMode, WorkRecord};
+    use sivtr_core::record::{
+        RecordTextMode, WorkChannel, WorkOutcome, WorkPart, WorkPartIo, WorkPartKind, WorkPayload,
+        WorkRecord, WorkRecordKind, WorkRef, WorkSessionRef, WorkSource, WorkStatus, WorkText,
+        WorkTime,
+    };
     use sivtr_core::session::SessionEntry;
     use std::collections::HashMap;
     use std::path::{Path, PathBuf};
@@ -1281,6 +1387,48 @@ mod tests {
     }
 
     #[test]
+    fn resolves_ref_text_for_part_targets() {
+        let record = WorkRecord::terminal(
+            &SessionEntry::new("PS C:\\repo>", "cargo test", "ok"),
+            Path::new("current"),
+            0,
+        )
+        .unwrap();
+        let reference = WorkRef::terminal_record("current", 1)
+            .with_part(sivtr_core::record::WorkPartIo::Output, 1);
+
+        let text = ref_text_pair(&record, &reference, "terminal/current/1/o/1").unwrap();
+
+        assert_eq!(text.plain, "ok");
+    }
+
+    #[test]
+    fn resolves_ref_text_for_part_refs_emitted_by_work_parts() {
+        let record = test_record();
+        let reference_text = record
+            .session
+            .work_ref
+            .with_part(WorkPartIo::Output, 1)
+            .to_string();
+        let reference: WorkRef = reference_text.parse().unwrap();
+
+        let text = ref_text_pair(&record, &reference, &reference_text).unwrap();
+
+        assert_eq!(reference_text, "codex/session/1/o/1");
+        assert_eq!(text.plain, "ok");
+    }
+
+    #[test]
+    fn resolves_ref_text_for_line_targets() {
+        let record = test_record();
+        let reference = WorkRef::agent_record(AgentProvider::Codex, "session", 1).with_line(2);
+
+        let text = ref_text_pair(&record, &reference, "codex/session/1/2").unwrap();
+
+        assert_eq!(text.plain, "ok");
+    }
+
+    #[test]
     fn filters_by_regex() {
         let filtered = filter_lines_by_regex(
             &TextPair {
@@ -1338,6 +1486,63 @@ mod tests {
         assert!(is_vim_command("C:\\Tools\\gVim\\gvim.exe"));
         assert!(!is_vim_command("code --wait"));
         assert!(!is_vim_command("hx"));
+    }
+
+    fn test_record() -> WorkRecord {
+        WorkRecord {
+            schema_version: 1,
+            id: "codex/session/1".to_string(),
+            work_ref: WorkRef::agent_record(AgentProvider::Codex, "session", 1),
+            kind: WorkRecordKind::ChatTurn,
+            source: WorkSource {
+                channel: WorkChannel::Chat,
+                provider: Some("codex".to_string()),
+            },
+            session: WorkSessionRef {
+                id: "session".to_string(),
+                canonical_id: Some("session-0123456789abcdef".to_string()),
+                path: None,
+                index: 1,
+                work_ref: WorkRef::agent_record(AgentProvider::Codex, "session", 1),
+            },
+            cwd: None,
+            time: WorkTime::default(),
+            status: WorkStatus {
+                outcome: WorkOutcome::Unknown,
+                exit_code: None,
+            },
+            title: "title".to_string(),
+            text: WorkText {
+                input: Some("user".to_string()),
+                output: Some("ok".to_string()),
+                combined: "user\nok".to_string(),
+            },
+            parts: vec![
+                WorkPart {
+                    io: WorkPartIo::Input,
+                    kind: WorkPartKind::UserMessage,
+                    index_in_record: 1,
+                    occurred_at: None,
+                    label: Some("user".to_string()),
+                    text: "user".to_string(),
+                    ansi: None,
+                },
+                WorkPart {
+                    io: WorkPartIo::Output,
+                    kind: WorkPartKind::AssistantMessage,
+                    index_in_record: 1,
+                    occurred_at: None,
+                    label: Some("assistant".to_string()),
+                    text: "ok".to_string(),
+                    ansi: None,
+                },
+            ],
+            payload: WorkPayload::ChatTurn {
+                user: "user".to_string(),
+                assistant: "ok".to_string(),
+                messages: Vec::new(),
+            },
+        }
     }
 
     #[test]
@@ -1441,6 +1646,44 @@ mod tests {
         assert_eq!(copy_units[0].output.plain, "answer");
         assert_eq!(copy_units[0].block.plain, "question\n\nanswer");
         assert!(!copy_units[0].block.plain.contains("## Assistant"));
+    }
+
+    #[test]
+    fn resolved_workspace_session_downgrades_tool_only_sessions_to_notice() {
+        let info = AgentSessionInfo {
+            path: PathBuf::from("tool-only.jsonl"),
+            id: Some("tool-only".to_string()),
+            cwd: Some("d:\\repo".to_string()),
+            title: Some("tool only".to_string()),
+            modified: SystemTime::UNIX_EPOCH,
+        };
+        let session = AgentSession {
+            path: PathBuf::from("tool-only.jsonl"),
+            id: Some("tool-only".to_string()),
+            cwd: Some("d:\\repo".to_string()),
+            title: Some("tool only".to_string()),
+            blocks: vec![AgentBlock {
+                kind: AgentBlockKind::ToolOutput,
+                timestamp: None,
+                label: Some("Bash".to_string()),
+                text: "tool-only entry".to_string(),
+            }],
+        };
+
+        let resolved = resolved_workspace_session(
+            AgentProvider::Claude,
+            &info,
+            session,
+            AgentSelection::LastTurn,
+        );
+
+        assert_eq!(resolved.title, "tool only  [tool-onl]");
+        assert_eq!(
+            resolved.notice.as_deref(),
+            Some("Claude session has no selectable content.")
+        );
+        assert!(resolved.records.is_empty());
+        assert!(resolved.load.is_none());
     }
 
     #[test]

--- a/src/commands/copy/workspace_picker.rs
+++ b/src/commands/copy/workspace_picker.rs
@@ -2795,7 +2795,9 @@ mod tests {
             text: WorkText {
                 input: Some(plain.to_string()),
                 output: None,
+                combined: plain.to_string(),
             },
+            parts: Vec::new(),
             payload: WorkPayload::ChatTurn {
                 user: plain.to_string(),
                 assistant: String::new(),

--- a/src/commands/copy/workspace_picker.rs
+++ b/src/commands/copy/workspace_picker.rs
@@ -13,14 +13,16 @@ use crate::tui::content_view::{
 };
 use crate::tui::terminal::{init as init_tui, restore as restore_tui};
 use crate::tui::workspace::{
-    can_open_dialogue_vim, render_workspace, selected_index, workspace_help_entries,
-    workspace_hit_test, workspace_layout, TextPair, WorkspaceDialogue, WorkspaceFocus,
-    WorkspaceHelpAction, WorkspacePickedContent, WorkspaceSearchView, WorkspaceSession,
-    WorkspaceSource, WorkspaceView,
+    can_open_dialogue_vim, render_workspace, selected_index, workspace_content_text,
+    workspace_help_entries, workspace_hit_test, workspace_layout, TextPair, WorkspaceDialogue,
+    WorkspaceFocus, WorkspaceHelpAction, WorkspacePickedContent, WorkspaceSearchView,
+    WorkspaceSession, WorkspaceSource, WorkspaceView,
 };
 use crate::tui::workspace_search::{
-    workspace_search_has_query, workspace_search_scope, WorkspaceSearchIndex, WorkspaceSearchOutput,
+    workspace_search_has_query, workspace_search_scope, WorkspaceSearchIndex, WorkspaceSearchMatch,
+    WorkspaceSearchOutput,
 };
+use sivtr_core::record::{WorkRef, WorkRefTarget};
 
 use super::vim::{open_vim_view, VimBlock, VimView};
 use super::{
@@ -49,11 +51,8 @@ pub(super) fn run_workspace_picker_on_terminal(
     initial_focus: WorkspaceFocus,
 ) -> Result<WorkspacePickedContent> {
     let mut session_state = ListState::default();
-    session_state.select(Some(0));
     let mut source_state = ListState::default();
-    source_state.select(Some(0));
     let mut dialogue_state = ListState::default();
-    dialogue_state.select(Some(0));
     let mut help_state = ListState::default();
     help_state.select(Some(0));
     let mut focus = initial_focus;
@@ -61,6 +60,9 @@ pub(super) fn run_workspace_picker_on_terminal(
     let sources = workspace_sources(&all_sessions);
     let mut selected_sources = vec![true; sources.len()];
     let mut sessions = workspace_sessions_for_sources(&all_sessions, &sources, &selected_sources);
+    clamp_list_state(&mut source_state, sources.len());
+    clamp_list_state(&mut session_state, sessions.len());
+    clamp_list_state(&mut dialogue_state, 0);
     let mut selected_sessions = vec![false; sessions.len()];
     let mut selected_dialogues = Vec::new();
     let mut range_anchor = None;
@@ -121,7 +123,7 @@ pub(super) fn run_workspace_picker_on_terminal(
             );
         }
         let session_idx = selected_index(&session_state).min(sessions.len().saturating_sub(1));
-        session_state.select(Some(session_idx));
+        session_state.select((!sessions.is_empty()).then_some(session_idx));
         let dialogues =
             workspace_dialogues_for_sessions(&sessions, session_idx, &selected_sessions);
         let dialogue_count = dialogues.len();
@@ -141,7 +143,7 @@ pub(super) fn run_workspace_picker_on_terminal(
         if let Some(matched) = pending_match {
             if let Some(dialogue) = dialogues.get(dialogue_idx) {
                 content_scroll = matched
-                    .line_index
+                    .content_scroll_index()
                     .min(line_count(&dialogue.unit.plain).saturating_sub(1));
             } else {
                 content_scroll = 0;
@@ -154,17 +156,34 @@ pub(super) fn run_workspace_picker_on_terminal(
                 focus,
                 fullscreen,
             );
+            let content_target = active_workspace_content_target(
+                search_has_query,
+                &search_output,
+                search_cursor,
+                session_idx,
+                &selected_dialogues,
+                dialogue_idx,
+            );
             content_scroll = content_scroll.min(
                 workspace_content_line_count(
                     &dialogues,
                     &selected_dialogues,
                     dialogue_idx,
+                    content_target,
                     layout.content,
                     content_mode,
                 )
                 .saturating_sub(1),
             );
         }
+        let active_content_target = active_workspace_content_target(
+            search_has_query,
+            &search_output,
+            search_cursor,
+            session_idx,
+            &selected_dialogues,
+            dialogue_idx,
+        );
 
         terminal.draw(|frame| {
             render_workspace(
@@ -183,6 +202,7 @@ pub(super) fn run_workspace_picker_on_terminal(
                     focus,
                     content_scroll,
                     content_mode,
+                    content_target: active_content_target,
                     show_help,
                     help_state: &help_state,
                     search: (show_search || search_has_query).then_some(WorkspaceSearchView {
@@ -191,6 +211,11 @@ pub(super) fn run_workspace_picker_on_terminal(
                         result_count: sessions.len(),
                         current_match: (!search_output.matches.is_empty()).then_some(search_cursor),
                         match_count: search_output.matches.len(),
+                        current_target: search_output
+                            .matches
+                            .get(search_cursor)
+                            .and_then(|matched| workspace_search_target_ref(&sessions, matched))
+                            .map(|work_ref| work_ref.to_string()),
                         input_open: show_search,
                     }),
                     line_filter_input_open,
@@ -219,8 +244,13 @@ pub(super) fn run_workspace_picker_on_terminal(
                         focus,
                         fullscreen,
                     );
-                    let text =
-                        workspace_display_text(&dialogues, &selected_dialogues, dialogue_idx);
+                    let text = workspace_content_text(
+                        &dialogues,
+                        &selected_dialogues,
+                        dialogue_idx,
+                        content_mode,
+                        active_content_target,
+                    );
                     if let Some(picked) = handle_visual_select_key(
                         key.code,
                         key.modifiers,
@@ -399,6 +429,7 @@ pub(super) fn run_workspace_picker_on_terminal(
                                 &mut search_query,
                                 &mut search_dirty,
                                 &mut visual_select_mode,
+                                active_content_target,
                                 &sessions,
                                 &dialogues,
                                 session_idx,
@@ -493,6 +524,7 @@ pub(super) fn run_workspace_picker_on_terminal(
                             dialogue_idx,
                             WorkspaceCopyShortcut::Input,
                             line_filter_spec(&line_filter),
+                            None,
                         ) {
                             Ok(picked) => return Ok(picked),
                             Err(err) => {
@@ -520,6 +552,7 @@ pub(super) fn run_workspace_picker_on_terminal(
                             dialogue_idx,
                             WorkspaceCopyShortcut::Output,
                             line_filter_spec(&line_filter),
+                            None,
                         ) {
                             Ok(picked) => return Ok(picked),
                             Err(err) => {
@@ -547,6 +580,7 @@ pub(super) fn run_workspace_picker_on_terminal(
                             dialogue_idx,
                             WorkspaceCopyShortcut::Block,
                             line_filter_spec(&line_filter),
+                            None,
                         ) {
                             Ok(picked) => return Ok(picked),
                             Err(err) => {
@@ -574,6 +608,7 @@ pub(super) fn run_workspace_picker_on_terminal(
                             dialogue_idx,
                             WorkspaceCopyShortcut::Command,
                             line_filter_spec(&line_filter),
+                            None,
                         ) {
                             Ok(picked) => return Ok(picked),
                             Err(err) => {
@@ -673,67 +708,36 @@ pub(super) fn run_workspace_picker_on_terminal(
                             set_focus(&mut focus, &mut fullscreen, next_focus);
                         }
                     }
-                    KeyCode::Up | KeyCode::Char('k') => match focus {
-                        WorkspaceFocus::Source => {
-                            let next = selected_index(&source_state).saturating_sub(1);
-                            source_state.select(Some(next));
-                        }
-                        WorkspaceFocus::Sessions => {
-                            let next = selected_index(&session_state).saturating_sub(1);
-                            if next != selected_index(&session_state) {
-                                session_state.select(Some(next));
-                                if !has_selected_sessions(&selected_sessions) {
-                                    reset_workspace_dialogue_state(
-                                        0,
-                                        &mut dialogue_state,
-                                        &mut selected_dialogues,
-                                        &mut range_anchor,
-                                    );
-                                }
-                                content_scroll = 0;
-                            }
-                        }
-                        WorkspaceFocus::Dialogues => {
-                            let next = selected_index(&dialogue_state).saturating_sub(1);
-                            dialogue_state.select(Some(next));
-                            content_scroll = 0;
-                        }
-                        WorkspaceFocus::Content => {
-                            content_scroll = content_scroll.saturating_sub(1);
-                        }
-                    },
-                    KeyCode::Down | KeyCode::Char('j') => match focus {
-                        WorkspaceFocus::Source => {
-                            let current = selected_index(&source_state);
-                            let next = (current + 1).min(sources.len().saturating_sub(1));
-                            source_state.select(Some(next));
-                        }
-                        WorkspaceFocus::Sessions => {
-                            let current = selected_index(&session_state);
-                            let next = (current + 1).min(sessions.len().saturating_sub(1));
-                            if next != current {
-                                session_state.select(Some(next));
-                                if !has_selected_sessions(&selected_sessions) {
-                                    reset_workspace_dialogue_state(
-                                        0,
-                                        &mut dialogue_state,
-                                        &mut selected_dialogues,
-                                        &mut range_anchor,
-                                    );
-                                }
-                                content_scroll = 0;
-                            }
-                        }
-                        WorkspaceFocus::Dialogues => {
-                            let current = selected_index(&dialogue_state);
-                            let next = (current + 1).min(dialogue_count.saturating_sub(1));
-                            dialogue_state.select(Some(next));
-                            content_scroll = 0;
-                        }
-                        WorkspaceFocus::Content => {
-                            content_scroll = content_scroll.saturating_add(1);
-                        }
-                    },
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        move_workspace_cursor_up(
+                            focus,
+                            &sources,
+                            &sessions,
+                            dialogue_count,
+                            &selected_sessions,
+                            &mut source_state,
+                            &mut session_state,
+                            &mut dialogue_state,
+                            &mut selected_dialogues,
+                            &mut range_anchor,
+                            &mut content_scroll,
+                        );
+                    }
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        move_workspace_cursor_down(
+                            focus,
+                            &sources,
+                            &sessions,
+                            dialogue_count,
+                            &selected_sessions,
+                            &mut source_state,
+                            &mut session_state,
+                            &mut dialogue_state,
+                            &mut selected_dialogues,
+                            &mut range_anchor,
+                            &mut content_scroll,
+                        );
+                    }
                     KeyCode::PageDown | KeyCode::Char('d')
                         if focus == WorkspaceFocus::Content
                             && (key.code == KeyCode::PageDown
@@ -762,6 +766,7 @@ pub(super) fn run_workspace_picker_on_terminal(
                             &dialogues,
                             &selected_dialogues,
                             dialogue_idx,
+                            active_content_target,
                             layout.content,
                             content_mode,
                         )
@@ -781,7 +786,13 @@ pub(super) fn run_workspace_picker_on_terminal(
                             &mut visual_select_mode,
                             &mut content_scroll,
                             layout.content,
-                            &workspace_display_text(&dialogues, &selected_dialogues, dialogue_idx),
+                            &workspace_content_text(
+                                &dialogues,
+                                &selected_dialogues,
+                                dialogue_idx,
+                                content_mode,
+                                active_content_target,
+                            ),
                             content_mode,
                         );
                     }
@@ -845,7 +856,13 @@ pub(super) fn run_workspace_picker_on_terminal(
                             &selected_sessions,
                         );
                         let dialogue_idx = dialogue_idx.min(dialogues.len().saturating_sub(1));
-                        let view = workspace_dialogue_vim_view(&dialogues[dialogue_idx]);
+                        let view = dialogue_text_vim_view(workspace_content_text(
+                            &dialogues,
+                            &selected_dialogues,
+                            dialogue_idx,
+                            content_mode,
+                            active_content_target,
+                        ));
                         restore_tui(terminal)?;
                         open_vim_view(&view)?;
                         *terminal = init_tui()?;
@@ -887,6 +904,7 @@ pub(super) fn run_workspace_picker_on_terminal(
                                 &selected_dialogues,
                                 dialogue_idx,
                                 line_filter_spec(&line_filter),
+                                active_content_target,
                             ) {
                                 Ok(picked) => return Ok(picked),
                                 Err(err) => {
@@ -913,6 +931,7 @@ pub(super) fn run_workspace_picker_on_terminal(
                                 &selected_dialogues,
                                 dialogue_idx,
                                 line_filter_spec(&line_filter),
+                                active_content_target,
                             ) {
                                 Ok(picked) => return Ok(picked),
                                 Err(err) => {
@@ -932,7 +951,13 @@ pub(super) fn run_workspace_picker_on_terminal(
                     focus,
                     fullscreen,
                 );
-                let text = workspace_display_text(&dialogues, &selected_dialogues, dialogue_idx);
+                let text = workspace_content_text(
+                    &dialogues,
+                    &selected_dialogues,
+                    dialogue_idx,
+                    content_mode,
+                    active_content_target,
+                );
                 handle_visual_select_mouse(
                     visual_select_mode.as_mut().expect("checked above"),
                     mouse.kind,
@@ -1035,10 +1060,12 @@ pub(super) fn run_workspace_picker_on_terminal(
                                 WorkspaceFocus::Content => {
                                     let dialogue_idx = selected_index(&dialogue_state)
                                         .min(dialogues.len().saturating_sub(1));
-                                    let text = workspace_display_text(
+                                    let text = workspace_content_text(
                                         &dialogues,
                                         &selected_dialogues,
                                         dialogue_idx,
+                                        content_mode,
+                                        active_content_target,
                                     );
                                     if let Some(target) = content_link_at(
                                         layout.content,
@@ -1285,7 +1312,7 @@ fn workspace_picked_content_for_visual_selection(
     content_mode: ContentViewMode,
     selection: ContentSelection,
 ) -> WorkspacePickedContent {
-    let source = workspace_picked_content(dialogues, selected_dialogues, dialogue_idx).source;
+    let source = workspace_picked_content(dialogues, selected_dialogues, dialogue_idx, None).source;
     let plain = selected_content_text(content_area, text, content_mode, selection);
     WorkspacePickedContent {
         source,
@@ -1406,23 +1433,6 @@ fn load_workspace_dialogue_sessions_with_cache(
     Ok(())
 }
 
-fn workspace_display_text(
-    dialogues: &[WorkspaceDialogue],
-    selected_dialogues: &[bool],
-    dialogue_idx: usize,
-) -> String {
-    if dialogues.is_empty() {
-        return "<empty>".to_string();
-    }
-
-    workspace_picked_content(dialogues, selected_dialogues, dialogue_idx)
-        .units
-        .into_iter()
-        .map(|unit| unit.plain)
-        .collect::<Vec<_>>()
-        .join("\n\n")
-}
-
 fn open_link_target(target: &str) -> Result<()> {
     #[cfg(target_os = "windows")]
     {
@@ -1471,6 +1481,7 @@ fn apply_workspace_help_action(
     search_query: &mut String,
     search_dirty: &mut bool,
     visual_select_mode: &mut Option<VisualSelectMode>,
+    content_target: Option<WorkRefTarget>,
     sessions: &[WorkspaceSession],
     dialogues: &[WorkspaceDialogue],
     session_idx: usize,
@@ -1489,61 +1500,32 @@ fn apply_workspace_help_action(
         WorkspaceHelpAction::FocusContent if dialogue_count > 0 => {
             set_focus(focus, fullscreen, WorkspaceFocus::Content)
         }
-        WorkspaceHelpAction::MoveUp => match *focus {
-            WorkspaceFocus::Source => {
-                let next = selected_index(source_state).saturating_sub(1);
-                source_state.select(Some(next));
-            }
-            WorkspaceFocus::Sessions => {
-                let next = selected_index(session_state).saturating_sub(1);
-                if next != selected_index(session_state) {
-                    session_state.select(Some(next));
-                    if !has_selected_sessions(selected_sessions) {
-                        reset_workspace_dialogue_state(
-                            0,
-                            dialogue_state,
-                            selected_dialogues,
-                            range_anchor,
-                        );
-                    }
-                    *content_scroll = 0;
-                }
-            }
-            WorkspaceFocus::Dialogues => {
-                dialogue_state.select(Some(selected_index(dialogue_state).saturating_sub(1)));
-                *content_scroll = 0;
-            }
-            WorkspaceFocus::Content => *content_scroll = (*content_scroll).saturating_sub(1),
-        },
-        WorkspaceHelpAction::MoveDown => match *focus {
-            WorkspaceFocus::Source => {
-                let current = selected_index(source_state);
-                let next = (current + 1).min(sources.len().saturating_sub(1));
-                source_state.select(Some(next));
-            }
-            WorkspaceFocus::Sessions => {
-                let current = selected_index(session_state);
-                let next = (current + 1).min(sessions.len().saturating_sub(1));
-                if next != current {
-                    session_state.select(Some(next));
-                    if !has_selected_sessions(selected_sessions) {
-                        reset_workspace_dialogue_state(
-                            0,
-                            dialogue_state,
-                            selected_dialogues,
-                            range_anchor,
-                        );
-                    }
-                    *content_scroll = 0;
-                }
-            }
-            WorkspaceFocus::Dialogues => {
-                let current = selected_index(dialogue_state);
-                dialogue_state.select(Some((current + 1).min(dialogue_count.saturating_sub(1))));
-                *content_scroll = 0;
-            }
-            WorkspaceFocus::Content => *content_scroll = (*content_scroll).saturating_add(1),
-        },
+        WorkspaceHelpAction::MoveUp => move_workspace_cursor_up(
+            *focus,
+            sources,
+            sessions,
+            dialogue_count,
+            selected_sessions,
+            source_state,
+            session_state,
+            dialogue_state,
+            selected_dialogues,
+            range_anchor,
+            content_scroll,
+        ),
+        WorkspaceHelpAction::MoveDown => move_workspace_cursor_down(
+            *focus,
+            sources,
+            sessions,
+            dialogue_count,
+            selected_sessions,
+            source_state,
+            session_state,
+            dialogue_state,
+            selected_dialogues,
+            range_anchor,
+            content_scroll,
+        ),
         WorkspaceHelpAction::PreviousPane => {
             if let Some(next_focus) = focus.previous(dialogue_count) {
                 set_focus(focus, fullscreen, next_focus);
@@ -1630,7 +1612,13 @@ fn apply_workspace_help_action(
             *range_anchor = None;
         }
         WorkspaceHelpAction::OpenVim if can_open_dialogue_vim(*focus, dialogue_count) => {
-            let view = workspace_dialogue_vim_view(&dialogues[dialogue_idx]);
+            let view = dialogue_text_vim_view(workspace_content_text(
+                dialogues,
+                selected_dialogues,
+                dialogue_idx,
+                *content_mode,
+                content_target,
+            ));
             restore_tui(terminal)?;
             open_vim_view(&view)?;
             *terminal = init_tui()?;
@@ -1655,7 +1643,13 @@ fn apply_workspace_help_action(
                 visual_select_mode,
                 content_scroll,
                 layout.content,
-                &workspace_display_text(dialogues, selected_dialogues, dialogue_idx),
+                &workspace_content_text(
+                    dialogues,
+                    selected_dialogues,
+                    dialogue_idx,
+                    *content_mode,
+                    content_target,
+                ),
                 *content_mode,
             );
         }
@@ -1669,6 +1663,7 @@ fn apply_workspace_help_action(
                     dialogues,
                     selected_dialogues,
                     dialogue_idx,
+                    content_target,
                 )));
             }
             WorkspaceFocus::Sessions => {}
@@ -1755,9 +1750,16 @@ pub(super) fn workspace_picked_content(
     dialogues: &[WorkspaceDialogue],
     selected_dialogues: &[bool],
     dialogue_idx: usize,
+    target: Option<WorkRefTarget>,
 ) -> WorkspacePickedContent {
-    workspace_picked_content_with_line_filter(dialogues, selected_dialogues, dialogue_idx, None)
-        .expect("workspace copy without a line filter should not fail")
+    workspace_picked_content_with_line_filter(
+        dialogues,
+        selected_dialogues,
+        dialogue_idx,
+        None,
+        target,
+    )
+    .expect("workspace copy without a line filter should not fail")
 }
 
 fn workspace_picked_content_with_line_filter(
@@ -1765,6 +1767,7 @@ fn workspace_picked_content_with_line_filter(
     selected_dialogues: &[bool],
     dialogue_idx: usize,
     line_filter: Option<&str>,
+    target: Option<WorkRefTarget>,
 ) -> Result<WorkspacePickedContent> {
     workspace_picked_content_for_copy_with_line_filter(
         dialogues,
@@ -1772,6 +1775,7 @@ fn workspace_picked_content_with_line_filter(
         dialogue_idx,
         WorkspaceCopyShortcut::Displayed,
         line_filter,
+        target,
     )
 }
 
@@ -1796,6 +1800,7 @@ fn workspace_picked_content_for_copy(
         dialogue_idx,
         shortcut,
         None,
+        None,
     )
     .expect("workspace copy without a line filter should not fail")
 }
@@ -1806,6 +1811,7 @@ fn workspace_picked_content_for_copy_with_line_filter(
     dialogue_idx: usize,
     shortcut: WorkspaceCopyShortcut,
     line_filter: Option<&str>,
+    target: Option<WorkRefTarget>,
 ) -> Result<WorkspacePickedContent> {
     let selected_indices = selected_dialogues
         .iter()
@@ -1818,11 +1824,15 @@ fn workspace_picked_content_for_copy_with_line_filter(
         selected_indices
     };
     let source_idx = picked_indices[0];
+    let display_target = (picked_indices.len() == 1
+        && matches!(shortcut, WorkspaceCopyShortcut::Displayed))
+    .then_some(target)
+    .flatten();
     let units = picked_indices
         .into_iter()
         .filter_map(|idx| dialogues.get(idx))
         .map(|dialogue| match shortcut {
-            WorkspaceCopyShortcut::Displayed => dialogue.unit.clone(),
+            WorkspaceCopyShortcut::Displayed => dialogue.display_unit(display_target),
             WorkspaceCopyShortcut::Input => dialogue.copy.input.clone(),
             WorkspaceCopyShortcut::Output => dialogue.copy.output.clone(),
             WorkspaceCopyShortcut::Block => dialogue.copy.block.clone(),
@@ -1905,28 +1915,11 @@ fn workspace_content_line_count(
     dialogues: &[WorkspaceDialogue],
     selected_dialogues: &[bool],
     highlighted_idx: usize,
+    target: Option<WorkRefTarget>,
     content_area: ratatui::layout::Rect,
     mode: ContentViewMode,
 ) -> usize {
-    let selected = selected_dialogues
-        .iter()
-        .enumerate()
-        .filter_map(|(idx, selected)| selected.then_some(idx))
-        .collect::<Vec<_>>();
-
-    if selected.is_empty() {
-        return dialogues
-            .get(highlighted_idx)
-            .map(|dialogue| content_view_line_count(content_area, &dialogue.unit.plain, mode))
-            .unwrap_or(1);
-    }
-
-    let text = selected
-        .into_iter()
-        .filter_map(|dialogue_idx| dialogues.get(dialogue_idx))
-        .map(|dialogue| dialogue.unit.plain.as_str())
-        .collect::<Vec<_>>()
-        .join("\n\n");
+    let text = workspace_content_text(dialogues, selected_dialogues, highlighted_idx, mode, target);
     content_view_line_count(content_area, &text, mode)
 }
 
@@ -2026,7 +2019,9 @@ pub(super) fn workspace_dialogues_for_sessions(
             .filter_map(|idx| sessions.get(idx))
             .map(|session| WorkspaceDialogue {
                 source: session.source,
+                work_ref: None,
                 title: "<loading: press Enter to load dialogue>".to_string(),
+                record: None,
                 unit: TextPair {
                     plain: "<loading: press Enter to load dialogue>".to_string(),
                     ansi: String::new(),
@@ -2040,16 +2035,68 @@ pub(super) fn workspace_dialogues_for_sessions(
         .into_iter()
         .filter_map(|idx| sessions.get(idx))
         .flat_map(|session| {
-            session.records.iter().map(move |record| WorkspaceDialogue {
-                source: session.source,
-                title: record.title.clone(),
-                unit: record_text_to_pair(
-                    record.copy_text(sivtr_core::record::RecordTextMode::Combined, false),
-                ),
-                copy: record_to_copy_parts(record, sivtr_core::ai::AgentSelection::LastTurn),
-            })
+            let dialogues = if let Some(notice) = &session.notice {
+                vec![WorkspaceDialogue {
+                    source: session.source,
+                    work_ref: None,
+                    title: "<session notice>".to_string(),
+                    record: None,
+                    unit: TextPair {
+                        plain: notice.clone(),
+                        ansi: String::new(),
+                    },
+                    copy: crate::tui::workspace::WorkspaceCopyParts::default(),
+                }]
+            } else {
+                session
+                    .records
+                    .iter()
+                    .map(move |record| WorkspaceDialogue {
+                        source: session.source,
+                        work_ref: Some(record.session.work_ref.clone()),
+                        title: record.title.clone(),
+                        record: Some(record.clone()),
+                        unit: record_text_to_pair(
+                            record.copy_text(sivtr_core::record::RecordTextMode::Combined, false),
+                        ),
+                        copy: record_to_copy_parts(
+                            record,
+                            sivtr_core::ai::AgentSelection::LastTurn,
+                        ),
+                    })
+                    .collect::<Vec<_>>()
+            };
+            dialogues.into_iter()
         })
         .collect()
+}
+
+fn workspace_search_target_ref(
+    sessions: &[WorkspaceSession],
+    matched: &WorkspaceSearchMatch,
+) -> Option<WorkRef> {
+    sessions
+        .get(matched.session_index)?
+        .records
+        .get(matched.dialogue_index)
+        .map(|record| record.session.work_ref.with_target(matched.target))
+}
+
+fn active_workspace_content_target(
+    search_has_query: bool,
+    search_output: &WorkspaceSearchOutput,
+    search_cursor: usize,
+    session_idx: usize,
+    selected_dialogues: &[bool],
+    dialogue_idx: usize,
+) -> Option<WorkRefTarget> {
+    if !search_has_query || selected_dialogues.iter().any(|selected| *selected) {
+        return None;
+    }
+
+    let matched = search_output.matches.get(search_cursor)?;
+    (matched.session_index == session_idx && matched.dialogue_index == dialogue_idx)
+        .then_some(matched.target)
 }
 
 fn reset_workspace_after_source_change(
@@ -2060,9 +2107,9 @@ fn reset_workspace_after_source_change(
     range_anchor: &mut Option<usize>,
     content_scroll: &mut usize,
 ) {
-    session_state.select(Some(0));
+    session_state.select(None);
     selected_sessions.clear();
-    dialogue_state.select(Some(0));
+    dialogue_state.select(None);
     selected_dialogues.clear();
     *range_anchor = None;
     *content_scroll = 0;
@@ -2076,9 +2123,9 @@ fn reset_workspace_search_state(
     range_anchor: &mut Option<usize>,
     content_scroll: &mut usize,
 ) {
-    session_state.select(Some(0));
+    session_state.select(None);
     selected_sessions.clear();
-    dialogue_state.select(Some(0));
+    dialogue_state.select(None);
     selected_dialogues.clear();
     *range_anchor = None;
     *content_scroll = 0;
@@ -2094,12 +2141,21 @@ fn resize_workspace_dialogue_selection(
     *range_anchor = None;
 }
 
+fn clamp_list_state(state: &mut ListState, len: usize) {
+    let selected = if len == 0 {
+        None
+    } else {
+        Some(selected_index(state).min(len.saturating_sub(1)))
+    };
+    state.select(selected);
+}
+
 #[allow(clippy::too_many_arguments)]
 fn move_workspace_cursor_up(
     focus: WorkspaceFocus,
     sources: &[WorkspaceSource],
     sessions: &[WorkspaceSession],
-    _dialogue_count: usize,
+    dialogue_count: usize,
     selected_sessions: &[bool],
     source_state: &mut ListState,
     session_state: &mut ListState,
@@ -2116,7 +2172,7 @@ fn move_workspace_cursor_up(
         WorkspaceFocus::Sessions => {
             let next = selected_index(session_state).saturating_sub(1);
             if next != selected_index(session_state) {
-                session_state.select(Some(next));
+                session_state.select((!sessions.is_empty()).then_some(next));
                 if !has_selected_sessions(selected_sessions) {
                     reset_workspace_dialogue_state(
                         0,
@@ -2130,7 +2186,7 @@ fn move_workspace_cursor_up(
         }
         WorkspaceFocus::Dialogues => {
             let next = selected_index(dialogue_state).saturating_sub(1);
-            dialogue_state.select((!sessions.is_empty()).then_some(next));
+            dialogue_state.select((dialogue_count > 0).then_some(next));
             *content_scroll = 0;
         }
         WorkspaceFocus::Content => {
@@ -2157,13 +2213,13 @@ fn move_workspace_cursor_down(
         WorkspaceFocus::Source => {
             let current = selected_index(source_state);
             let next = (current + 1).min(sources.len().saturating_sub(1));
-            source_state.select(Some(next));
+            source_state.select((!sources.is_empty()).then_some(next));
         }
         WorkspaceFocus::Sessions => {
             let current = selected_index(session_state);
             let next = (current + 1).min(sessions.len().saturating_sub(1));
             if next != current {
-                session_state.select(Some(next));
+                session_state.select((!sessions.is_empty()).then_some(next));
                 if !has_selected_sessions(selected_sessions) {
                     reset_workspace_dialogue_state(
                         0,
@@ -2232,6 +2288,7 @@ fn reset_workspace_dialogue_state(
     *range_anchor = None;
 }
 
+#[cfg(test)]
 pub(super) fn workspace_dialogue_vim_view(dialogue: &WorkspaceDialogue) -> VimView {
     dialogue_text_vim_view(dialogue.unit.plain.clone())
 }
@@ -2258,26 +2315,29 @@ fn dialogue_text_vim_view(text: String) -> VimView {
 #[cfg(test)]
 mod tests {
     use super::{
-        handle_line_filter_key, workspace_dialogue_vim_view, workspace_dialogues_for_sessions,
-        workspace_picked_content, workspace_picked_content_for_copy,
-        workspace_picked_content_for_copy_with_line_filter,
-        workspace_picked_content_with_line_filter, WorkspaceCopyShortcut,
+        clamp_list_state, handle_line_filter_key, move_workspace_cursor_up,
+        workspace_dialogue_vim_view, workspace_dialogues_for_sessions, workspace_picked_content,
+        workspace_picked_content_for_copy, workspace_picked_content_for_copy_with_line_filter,
+        workspace_picked_content_with_line_filter, workspace_search_target_ref,
+        WorkspaceCopyShortcut,
     };
     use crate::commands::command_block_selector::CommandSelection;
     use crate::tui::workspace::{
-        TextPair, WorkspaceCopyParts, WorkspaceDialogue, WorkspaceSession, WorkspaceSource,
+        TextPair, WorkspaceCopyParts, WorkspaceDialogue, WorkspaceFocus, WorkspaceSession,
+        WorkspaceSource,
     };
     use crate::tui::workspace_search::{
         workspace_search_query, workspace_search_regex, WorkspaceSearchIndex, WorkspaceSearchMatch,
         WorkspaceSearchScope,
     };
     use crossterm::event::KeyCode;
+    use ratatui::widgets::ListState;
     use sivtr_core::ai::AgentProvider;
-    use sivtr_core::record::WorkRef;
     use sivtr_core::record::{
-        ChatMessage, WorkOutcome, WorkPayload, WorkRecord, WorkRecordKind, WorkStatus, WorkText,
-        WorkTime, RECORD_SCHEMA_VERSION,
+        ChatMessage, WorkChannel, WorkOutcome, WorkPayload, WorkRecord, WorkRecordKind,
+        WorkSessionRef, WorkSource, WorkStatus, WorkText, WorkTime, RECORD_SCHEMA_VERSION,
     };
+    use sivtr_core::record::{WorkRef, WorkRefTarget};
     use std::time::SystemTime;
 
     #[test]
@@ -2296,6 +2356,10 @@ mod tests {
         assert_eq!(dialogues.len(), 1);
         assert_eq!(dialogues[0].title, "o1");
         assert_eq!(dialogues[0].unit.plain, "old:o1");
+        assert_eq!(
+            dialogues[0].work_ref.as_ref().unwrap().to_string(),
+            "claude/test/1"
+        );
     }
 
     #[test]
@@ -2325,6 +2389,35 @@ mod tests {
                 .map(|dialogue| dialogue.unit.plain.as_str())
                 .collect::<Vec<_>>(),
             vec!["codex session:c1", "codex session:c2", "claude session:a1"]
+        );
+        assert_eq!(
+            dialogues
+                .iter()
+                .map(|dialogue| dialogue.work_ref.as_ref().unwrap().to_string())
+                .collect::<Vec<_>>(),
+            vec!["codex/test/1", "codex/test/2", "claude/test/1"]
+        );
+    }
+
+    #[test]
+    fn workspace_dialogues_surface_session_notice_without_exiting() {
+        let sessions = vec![WorkspaceSession {
+            source: WorkspaceSource::Agent(AgentProvider::Claude),
+            modified: SystemTime::UNIX_EPOCH,
+            title: "tool only".to_string(),
+            search_title: "tool only".to_string(),
+            notice: Some("Claude session has no selectable content.".to_string()),
+            records: Vec::new(),
+            load: None,
+        }];
+
+        let dialogues = workspace_dialogues_for_sessions(&sessions, 0, &[false]);
+
+        assert_eq!(dialogues.len(), 1);
+        assert_eq!(dialogues[0].title, "<session notice>");
+        assert_eq!(
+            dialogues[0].unit.plain,
+            "Claude session has no selectable content."
         );
     }
 
@@ -2464,6 +2557,7 @@ mod tests {
             modified: SystemTime::UNIX_EPOCH,
             title: "session".to_string(),
             search_title: "session".to_string(),
+            notice: None,
             records: vec![workspace_test_record(
                 WorkspaceSource::Agent(AgentProvider::Codex),
                 "dialogue",
@@ -2481,15 +2575,193 @@ mod tests {
                 WorkspaceSearchMatch {
                     session_index: 0,
                     dialogue_index: 0,
-                    line_index: 1
+                    target: WorkRefTarget::Line(2),
+                    matched_line: 2,
                 },
                 WorkspaceSearchMatch {
                     session_index: 0,
                     dialogue_index: 0,
-                    line_index: 3
+                    target: WorkRefTarget::Line(4),
+                    matched_line: 4,
                 }
             ]
         );
+    }
+
+    #[test]
+    fn workspace_search_prefers_hidden_part_targets() {
+        let mut record = workspace_test_record(
+            WorkspaceSource::Agent(AgentProvider::Codex),
+            "dialogue",
+            "visible text",
+            0,
+        );
+        record.parts = vec![sivtr_core::record::WorkPart {
+            io: sivtr_core::record::WorkPartIo::Input,
+            kind: sivtr_core::record::WorkPartKind::ToolCall,
+            index_in_record: 1,
+            occurred_at: None,
+            label: Some("tool".to_string()),
+            text: "hidden cargo test".to_string(),
+            ansi: None,
+        }];
+        let sessions = vec![WorkspaceSession {
+            source: WorkspaceSource::Agent(AgentProvider::Codex),
+            modified: SystemTime::UNIX_EPOCH,
+            title: "session".to_string(),
+            search_title: "session".to_string(),
+            notice: None,
+            records: vec![record],
+            load: None,
+        }];
+
+        let output = WorkspaceSearchIndex::new(&sessions).search(&sessions, "cargo");
+
+        assert_eq!(
+            output.matches,
+            vec![WorkspaceSearchMatch {
+                session_index: 0,
+                dialogue_index: 0,
+                target: WorkRefTarget::Part {
+                    io: sivtr_core::record::WorkPartIo::Input,
+                    index: 1,
+                },
+                matched_line: 1,
+            }]
+        );
+    }
+
+    #[test]
+    fn workspace_search_preserves_line_offsets_inside_part_targets() {
+        let mut record = workspace_test_record(
+            WorkspaceSource::Agent(AgentProvider::Codex),
+            "dialogue",
+            "visible text",
+            0,
+        );
+        record.parts = vec![sivtr_core::record::WorkPart {
+            io: sivtr_core::record::WorkPartIo::Output,
+            kind: sivtr_core::record::WorkPartKind::ToolOutput,
+            index_in_record: 1,
+            occurred_at: None,
+            label: Some("tool".to_string()),
+            text: "first line\nneedle one\nmiddle\nneedle two".to_string(),
+            ansi: None,
+        }];
+        let sessions = vec![WorkspaceSession {
+            source: WorkspaceSource::Agent(AgentProvider::Codex),
+            modified: SystemTime::UNIX_EPOCH,
+            title: "session".to_string(),
+            search_title: "session".to_string(),
+            notice: None,
+            records: vec![record],
+            load: None,
+        }];
+
+        let output = WorkspaceSearchIndex::new(&sessions).search(&sessions, "needle");
+
+        assert_eq!(
+            output.matches,
+            vec![
+                WorkspaceSearchMatch {
+                    session_index: 0,
+                    dialogue_index: 0,
+                    target: WorkRefTarget::Part {
+                        io: sivtr_core::record::WorkPartIo::Output,
+                        index: 1,
+                    },
+                    matched_line: 2,
+                },
+                WorkspaceSearchMatch {
+                    session_index: 0,
+                    dialogue_index: 0,
+                    target: WorkRefTarget::Part {
+                        io: sivtr_core::record::WorkPartIo::Output,
+                        index: 1,
+                    },
+                    matched_line: 4,
+                },
+            ]
+        );
+        assert_eq!(output.matches[1].content_scroll_index(), 3);
+    }
+
+    #[test]
+    fn workspace_search_target_ref_round_trips_part_match() {
+        let mut record = workspace_test_record(
+            WorkspaceSource::Agent(AgentProvider::Codex),
+            "dialogue",
+            "visible text",
+            0,
+        );
+        record.parts = vec![sivtr_core::record::WorkPart {
+            io: sivtr_core::record::WorkPartIo::Input,
+            kind: sivtr_core::record::WorkPartKind::ToolCall,
+            index_in_record: 1,
+            occurred_at: None,
+            label: Some("tool".to_string()),
+            text: "hidden cargo test".to_string(),
+            ansi: None,
+        }];
+        let sessions = vec![WorkspaceSession {
+            source: WorkspaceSource::Agent(AgentProvider::Codex),
+            modified: SystemTime::UNIX_EPOCH,
+            title: "session".to_string(),
+            search_title: "session".to_string(),
+            notice: None,
+            records: vec![record],
+            load: None,
+        }];
+
+        let output = WorkspaceSearchIndex::new(&sessions).search(&sessions, "cargo");
+        let work_ref =
+            workspace_search_target_ref(&output.sessions, &output.matches[0]).expect("work ref");
+
+        assert_eq!(work_ref.to_string(), "codex/test/1/i/1");
+    }
+
+    #[test]
+    fn clamp_list_state_clears_stale_selection_for_empty_lists() {
+        let mut state = ListState::default();
+        state.select(Some(0));
+
+        clamp_list_state(&mut state, 0);
+
+        assert_eq!(state.selected(), None);
+    }
+
+    #[test]
+    fn move_workspace_cursor_up_uses_dialogue_count_for_dialogue_focus() {
+        let sessions = vec![workspace_test_session(
+            "session",
+            WorkspaceSource::Agent(AgentProvider::Codex),
+            &["dialogue"],
+        )];
+        let mut source_state = ListState::default();
+        source_state.select(Some(0));
+        let mut session_state = ListState::default();
+        session_state.select(Some(0));
+        let mut dialogue_state = ListState::default();
+        dialogue_state.select(Some(0));
+        let mut selected_dialogues = Vec::new();
+        let mut range_anchor = None;
+        let mut content_scroll = 0;
+
+        move_workspace_cursor_up(
+            WorkspaceFocus::Dialogues,
+            &[WorkspaceSource::Agent(AgentProvider::Codex)],
+            &sessions,
+            0,
+            &[false],
+            &mut source_state,
+            &mut session_state,
+            &mut dialogue_state,
+            &mut selected_dialogues,
+            &mut range_anchor,
+            &mut content_scroll,
+        );
+
+        assert_eq!(dialogue_state.selected(), None);
     }
 
     #[test]
@@ -2500,7 +2772,7 @@ mod tests {
             workspace_test_dialogue("d3", "text 3"),
         ];
 
-        let picked = workspace_picked_content(&dialogues, &[false, true, true], 0);
+        let picked = workspace_picked_content(&dialogues, &[false, true, true], 0, None);
 
         assert_eq!(
             picked
@@ -2523,7 +2795,7 @@ mod tests {
             workspace_test_dialogue("d2", "text 2"),
         ];
 
-        let picked = workspace_picked_content(&dialogues, &[false, false], 1);
+        let picked = workspace_picked_content(&dialogues, &[false, false], 1, None);
 
         assert_eq!(picked.units.len(), 1);
         assert_eq!(picked.units[0].plain, "text 2");
@@ -2534,7 +2806,9 @@ mod tests {
     fn workspace_copy_shortcuts_use_structured_chat_parts_without_headings() {
         let dialogues = vec![WorkspaceDialogue {
             source: WorkspaceSource::Agent(AgentProvider::Codex),
+            work_ref: Some(WorkRef::agent_record(AgentProvider::Codex, "session", 1)),
             title: "question".to_string(),
+            record: None,
             unit: TextPair {
                 plain: "## User\nquestion\n\n## Assistant\nanswer".to_string(),
                 ansi: String::new(),
@@ -2584,7 +2858,9 @@ mod tests {
     fn workspace_line_filter_applies_to_displayed_and_structured_copies() {
         let dialogues = vec![WorkspaceDialogue {
             source: WorkspaceSource::Agent(AgentProvider::Codex),
+            work_ref: Some(WorkRef::agent_record(AgentProvider::Codex, "session", 1)),
             title: "question".to_string(),
+            record: None,
             unit: TextPair {
                 plain: "line 1\nline 2\nline 3".to_string(),
                 ansi: String::new(),
@@ -2607,7 +2883,7 @@ mod tests {
         }];
 
         let displayed =
-            workspace_picked_content_with_line_filter(&dialogues, &[false], 0, Some("2:3"))
+            workspace_picked_content_with_line_filter(&dialogues, &[false], 0, Some("2:3"), None)
                 .unwrap();
         let input = workspace_picked_content_for_copy_with_line_filter(
             &dialogues,
@@ -2615,6 +2891,7 @@ mod tests {
             0,
             WorkspaceCopyShortcut::Input,
             Some("1,3"),
+            None,
         )
         .unwrap();
 
@@ -2626,8 +2903,9 @@ mod tests {
     fn workspace_line_filter_rejects_invalid_specs() {
         let dialogues = vec![workspace_test_dialogue("d1", "alpha\nbeta\ngamma")];
 
-        let err = workspace_picked_content_with_line_filter(&dialogues, &[false], 0, Some("x"))
-            .unwrap_err();
+        let err =
+            workspace_picked_content_with_line_filter(&dialogues, &[false], 0, Some("x"), None)
+                .unwrap_err();
 
         assert!(
             err.to_string().contains("Invalid line number"),
@@ -2681,7 +2959,9 @@ mod tests {
     fn workspace_command_shortcut_uses_terminal_command_without_prompt() {
         let dialogues = vec![WorkspaceDialogue {
             source: WorkspaceSource::Terminal,
+            work_ref: Some(WorkRef::terminal_record("shell", 1)),
             title: "cargo test".to_string(),
+            record: None,
             unit: TextPair {
                 plain: "PS C:\\repo> cargo test\nok".to_string(),
                 ansi: String::new(),
@@ -2720,7 +3000,9 @@ mod tests {
     fn workspace_dialogue_vim_view_tracks_exact_dialogue_lines() {
         let dialogue = WorkspaceDialogue {
             source: WorkspaceSource::Agent(AgentProvider::Codex),
+            work_ref: Some(WorkRef::agent_record(AgentProvider::Codex, "session", 1)),
             title: "line1".to_string(),
+            record: None,
             unit: TextPair {
                 plain: "line1\nline2\nline3\nline4".to_string(),
                 ansi: "line1\nline2\nline3\nline4".to_string(),
@@ -2741,6 +3023,51 @@ mod tests {
         assert_eq!(view.blocks[0].output_text, view.raw);
     }
 
+    #[test]
+    fn workspace_picked_content_prefers_active_part_target_for_display_copy() {
+        let mut record = workspace_test_record(
+            WorkspaceSource::Agent(AgentProvider::Codex),
+            "dialogue",
+            "visible text",
+            0,
+        );
+        record.parts = vec![sivtr_core::record::WorkPart {
+            io: sivtr_core::record::WorkPartIo::Input,
+            kind: sivtr_core::record::WorkPartKind::ToolCall,
+            index_in_record: 1,
+            occurred_at: None,
+            label: Some("tool".to_string()),
+            text: "hidden cargo test".to_string(),
+            ansi: None,
+        }];
+        let dialogues = vec![WorkspaceDialogue {
+            source: WorkspaceSource::Agent(AgentProvider::Codex),
+            work_ref: Some(WorkRef::agent_record(AgentProvider::Codex, "session", 1)),
+            title: "question".to_string(),
+            record: Some(record),
+            unit: TextPair {
+                plain: "visible text".to_string(),
+                ansi: String::new(),
+            },
+            copy: WorkspaceCopyParts::from_block(TextPair {
+                plain: "visible text".to_string(),
+                ansi: String::new(),
+            }),
+        }];
+
+        let picked = workspace_picked_content(
+            &dialogues,
+            &[false],
+            0,
+            Some(WorkRefTarget::Part {
+                io: sivtr_core::record::WorkPartIo::Input,
+                index: 1,
+            }),
+        );
+
+        assert_eq!(picked.units[0].plain, "hidden cargo test");
+    }
+
     fn workspace_test_session(
         title: &str,
         source: WorkspaceSource,
@@ -2751,6 +3078,7 @@ mod tests {
             modified: SystemTime::UNIX_EPOCH,
             title: title.to_string(),
             search_title: title.to_string(),
+            notice: None,
             records: dialogue_titles
                 .iter()
                 .enumerate()
@@ -2773,18 +3101,33 @@ mod tests {
         plain: &str,
         index: usize,
     ) -> WorkRecord {
+        let (channel, provider, kind) = match source {
+            WorkspaceSource::Terminal => {
+                (WorkChannel::Terminal, None, WorkRecordKind::TerminalCommand)
+            }
+            WorkspaceSource::Agent(provider) => (
+                WorkChannel::Chat,
+                Some(provider.command_name().to_string()),
+                WorkRecordKind::ChatTurn,
+            ),
+        };
         let work_ref = match source {
             WorkspaceSource::Terminal => WorkRef::terminal_record("test", index + 1),
             WorkspaceSource::Agent(provider) => WorkRef::agent_record(provider, "test", index + 1),
         };
         WorkRecord {
             schema_version: RECORD_SCHEMA_VERSION,
-            work_ref,
-            kind: match source {
-                WorkspaceSource::Terminal => WorkRecordKind::TerminalCommand,
-                WorkspaceSource::Agent(_) => WorkRecordKind::ChatTurn,
+            id: work_ref.to_string(),
+            work_ref: work_ref.clone(),
+            source: WorkSource { channel, provider },
+            session: WorkSessionRef {
+                id: "test".to_string(),
+                canonical_id: Some("test-session-0123456789abcdef".to_string()),
+                path: None,
+                index,
+                work_ref: work_ref.clone(),
             },
-            session_path: None,
+            kind,
             cwd: None,
             time: WorkTime::default(),
             status: WorkStatus {
@@ -2813,7 +3156,9 @@ mod tests {
     fn workspace_test_dialogue(title: &str, plain: &str) -> WorkspaceDialogue {
         WorkspaceDialogue {
             source: WorkspaceSource::Agent(AgentProvider::Codex),
+            work_ref: Some(WorkRef::agent_record(AgentProvider::Codex, "dialogue", 1)),
             title: title.to_string(),
+            record: None,
             unit: TextPair {
                 plain: plain.to_string(),
                 ansi: plain.to_string(),

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -197,7 +197,7 @@ const TMUX_MARKER_START: &str = "# >>> sivtr tmux shortcut >>>";
 const TMUX_MARKER_END: &str = "# <<< sivtr tmux shortcut <<<";
 #[cfg(unix)]
 const TMUX_HOOK: &str = r##"# >>> sivtr tmux shortcut >>>
-bind-key y new-window -c "#{pane_current_path}" "sivtr copy codex --pick"
+bind-key y new-window -c "#{pane_current_path}" "sivtr hotkey-pick-agent --cwd . --provider all"
 # <<< sivtr tmux shortcut <<<
 "##;
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -19,3 +19,5 @@ pub mod search;
 pub mod show;
 pub mod time_filter;
 pub mod version;
+pub mod work;
+pub mod work_json;

--- a/src/commands/records.rs
+++ b/src/commands/records.rs
@@ -1,7 +1,8 @@
 use anyhow::{Context, Result};
 use sivtr_core::ai::AgentProvider;
-use sivtr_core::record::{WorkRecord, WorkRecordIndex};
+use sivtr_core::record::{WorkRecord, WorkRecordIndex, WorkRef};
 use sivtr_core::{session, workspace};
+use std::collections::HashMap;
 use std::path::Path;
 
 pub(crate) fn current_work_record_index(
@@ -20,6 +21,8 @@ fn current_work_records(
     let mut records = Vec::new();
     records.extend(terminal_records(cwd)?);
     records.extend(agent_records(providers, cwd, recent_sessions)?);
+    dedup_records(&mut records);
+    normalize_session_display_ids(&mut records);
     records.sort_by(|a, b| b.time.primary_at().cmp(&a.time.primary_at()));
     Ok(records)
 }
@@ -59,4 +62,272 @@ fn agent_records(
     }
 
     Ok(records)
+}
+
+fn dedup_records(records: &mut Vec<WorkRecord>) {
+    let mut positions: HashMap<String, usize> = HashMap::new();
+    let mut deduped = Vec::with_capacity(records.len());
+
+    for record in records.drain(..) {
+        let key = record_identity_key(&record);
+        if let Some(position) = positions.get(&key).copied() {
+            if record_is_better(&record, &deduped[position]) {
+                deduped[position] = record;
+            }
+            continue;
+        }
+
+        positions.insert(key, deduped.len());
+        deduped.push(record);
+    }
+
+    *records = deduped;
+}
+
+fn record_identity_key(record: &WorkRecord) -> String {
+    match (&record.session.canonical_id, &record.session.work_ref) {
+        (Some(canonical_id), WorkRef::Terminal { record_index, .. }) => {
+            format!("terminal:{canonical_id}:{record_index}")
+        }
+        (
+            Some(canonical_id),
+            WorkRef::Agent {
+                provider,
+                turn_index,
+                ..
+            },
+        ) => format!("{}:{canonical_id}:{turn_index}", provider.command_name()),
+        (None, _) => record.id.clone(),
+    }
+}
+
+fn record_is_better(candidate: &WorkRecord, existing: &WorkRecord) -> bool {
+    candidate
+        .parts
+        .len()
+        .cmp(&existing.parts.len())
+        .then_with(|| {
+            candidate
+                .text
+                .combined
+                .len()
+                .cmp(&existing.text.combined.len())
+        })
+        .then_with(|| candidate.time.primary_at().cmp(&existing.time.primary_at()))
+        .is_gt()
+}
+
+fn normalize_session_display_ids(records: &mut [WorkRecord]) {
+    let mut source_sessions: HashMap<String, Vec<String>> = HashMap::new();
+
+    for record in records.iter() {
+        let Some(canonical_id) = record.session.canonical_id.as_deref() else {
+            continue;
+        };
+        let source_key = session_source_key(&record.session.work_ref);
+        let sessions = source_sessions.entry(source_key).or_default();
+        if !sessions.iter().any(|existing| existing == canonical_id) {
+            sessions.push(canonical_id.to_string());
+        }
+    }
+
+    for record in records.iter_mut() {
+        let Some(canonical_id) = record.session.canonical_id.as_deref() else {
+            continue;
+        };
+        let source_key = session_source_key(&record.session.work_ref);
+        let Some(all_sessions) = source_sessions.get(&source_key) else {
+            continue;
+        };
+        let display_id = compact_unique_session_id(canonical_id, all_sessions);
+        if record.session.id != display_id {
+            rewrite_record_session_display_id(record, &display_id);
+        }
+    }
+}
+
+fn session_source_key(reference: &WorkRef) -> String {
+    match reference {
+        WorkRef::Terminal { .. } => "terminal".to_string(),
+        WorkRef::Agent { provider, .. } => format!("agent:{}", provider.command_name()),
+    }
+}
+
+fn compact_unique_session_id(canonical_id: &str, all_sessions: &[String]) -> String {
+    let canonical_len = canonical_id.chars().count();
+    if canonical_len <= 8 {
+        return canonical_id.to_string();
+    }
+
+    for prefix_len in 8..=canonical_len {
+        let candidate = prefix_chars(canonical_id, prefix_len);
+        let unique = all_sessions
+            .iter()
+            .all(|other| other == canonical_id || prefix_chars(other, prefix_len) != candidate);
+        if unique {
+            return candidate;
+        }
+    }
+
+    canonical_id.to_string()
+}
+
+fn prefix_chars(value: &str, len: usize) -> String {
+    value.chars().take(len).collect()
+}
+
+fn rewrite_record_session_display_id(record: &mut WorkRecord, display_id: &str) {
+    record.session.id = display_id.to_string();
+    record.session.work_ref = match &record.session.work_ref {
+        WorkRef::Terminal { record_index, .. } => {
+            WorkRef::terminal_record(display_id, *record_index)
+        }
+        WorkRef::Agent {
+            provider,
+            turn_index,
+            ..
+        } => WorkRef::agent_record(*provider, display_id, *turn_index),
+    };
+    record.id = record.session.work_ref.to_string();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sivtr_core::record::{
+        WorkChannel, WorkOutcome, WorkPayload, WorkRecordKind, WorkSessionRef, WorkSource,
+        WorkStatus, WorkText, WorkTime,
+    };
+
+    #[test]
+    fn keeps_short_session_ids_when_already_unique() {
+        let mut records = vec![test_record(
+            WorkRef::agent_record(AgentProvider::Codex, "abcdef12", 1),
+            "abcdef12",
+            Some("abcdef1234567890"),
+        )];
+
+        normalize_session_display_ids(&mut records);
+
+        assert_eq!(records[0].session.id, "abcdef12");
+        assert_eq!(records[0].id, "codex/abcdef12/1");
+    }
+
+    #[test]
+    fn extends_display_ids_to_break_canonical_prefix_collisions() {
+        let mut records = vec![
+            test_record(
+                WorkRef::agent_record(AgentProvider::Codex, "abcdef12", 1),
+                "abcdef12",
+                Some("abcdef1234567890"),
+            ),
+            test_record(
+                WorkRef::agent_record(AgentProvider::Codex, "abcdef12", 2),
+                "abcdef12",
+                Some("abcdef1299999999"),
+            ),
+        ];
+
+        normalize_session_display_ids(&mut records);
+
+        assert_eq!(records[0].session.id, "abcdef123");
+        assert_eq!(records[0].id, "codex/abcdef123/1");
+        assert_eq!(records[1].session.id, "abcdef129");
+        assert_eq!(records[1].id, "codex/abcdef129/2");
+    }
+
+    #[test]
+    fn keeps_provider_namespaces_independent_for_compaction() {
+        let mut records = vec![
+            test_record(
+                WorkRef::agent_record(AgentProvider::Codex, "abcdef12", 1),
+                "abcdef12",
+                Some("abcdef1234567890"),
+            ),
+            test_record(
+                WorkRef::agent_record(AgentProvider::Claude, "abcdef12", 1),
+                "abcdef12",
+                Some("abcdef1299999999"),
+            ),
+        ];
+
+        normalize_session_display_ids(&mut records);
+
+        assert_eq!(records[0].session.id, "abcdef12");
+        assert_eq!(records[1].session.id, "abcdef12");
+    }
+
+    #[test]
+    fn deduplicates_canonical_records_and_keeps_more_complete_copy() {
+        let mut records = vec![
+            test_record(
+                WorkRef::agent_record(AgentProvider::Codex, "abcdef12", 1),
+                "abcdef12",
+                Some("session-0123456789abcdef"),
+            ),
+            test_record(
+                WorkRef::agent_record(AgentProvider::Codex, "session-01234567", 1),
+                "session-01234567",
+                Some("session-0123456789abcdef"),
+            ),
+        ];
+        records[1].text.output = Some("assistant with more detail".to_string());
+        records[1].text.combined = "user\nassistant with more detail".to_string();
+        records[1].parts.push(sivtr_core::record::WorkPart {
+            io: sivtr_core::record::WorkPartIo::Output,
+            kind: sivtr_core::record::WorkPartKind::AssistantMessage,
+            index_in_record: 1,
+            occurred_at: None,
+            label: Some("assistant".to_string()),
+            text: "assistant with more detail".to_string(),
+            ansi: None,
+        });
+
+        dedup_records(&mut records);
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].text.output.as_deref(),
+            Some("assistant with more detail")
+        );
+        assert_eq!(records[0].session.id, "session-01234567");
+    }
+
+    fn test_record(work_ref: WorkRef, display_id: &str, canonical_id: Option<&str>) -> WorkRecord {
+        WorkRecord {
+            schema_version: 1,
+            work_ref: work_ref.clone(),
+            id: work_ref.to_string(),
+            kind: WorkRecordKind::ChatTurn,
+            source: WorkSource {
+                channel: WorkChannel::Chat,
+                provider: Some("codex".to_string()),
+            },
+            session: WorkSessionRef {
+                id: display_id.to_string(),
+                canonical_id: canonical_id.map(str::to_string),
+                path: None,
+                index: 0,
+                work_ref,
+            },
+            cwd: None,
+            time: WorkTime::default(),
+            status: WorkStatus {
+                outcome: WorkOutcome::Unknown,
+                exit_code: None,
+            },
+            title: "title".to_string(),
+            text: WorkText {
+                input: Some("user".to_string()),
+                output: Some("assistant".to_string()),
+                combined: "user\nassistant".to_string(),
+            },
+            parts: Vec::new(),
+            payload: WorkPayload::ChatTurn {
+                user: "user".to_string(),
+                assistant: "assistant".to_string(),
+                messages: Vec::new(),
+            },
+        }
+    }
 }

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -645,7 +645,8 @@ fn excluded_session_matches(record: &WorkRecord, excluded_sessions: &HashSet<Pat
     }
 
     record
-        .session_path
+        .session
+        .path
         .as_deref()
         .map(Path::new)
         .map(comparable_path)
@@ -972,11 +973,24 @@ mod tests {
     }
 
     fn test_terminal_record(_ref_id: &str, combined: &str) -> WorkRecord {
+        use sivtr_core::record::{WorkChannel, WorkSessionRef, WorkSource};
+        let work_ref = WorkRef::terminal_record("session_1", 3);
         WorkRecord {
             schema_version: 1,
-            work_ref: WorkRef::terminal_record("session_1", 3),
+            id: work_ref.to_string(),
+            work_ref,
             kind: WorkRecordKind::TerminalCommand,
-            session_path: None,
+            source: WorkSource {
+                channel: WorkChannel::Terminal,
+                provider: None,
+            },
+            session: WorkSessionRef {
+                id: "session_1".to_string(),
+                canonical_id: Some("session_1".to_string()),
+                path: None,
+                index: 2,
+                work_ref: WorkRef::terminal_record("session_1", 3),
+            },
             cwd: None,
             time: WorkTime::from_components(
                 Some("2026-05-24T00:00:00Z".to_string()),

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -991,7 +991,9 @@ mod tests {
             text: WorkText {
                 input: Some("cargo test".to_string()),
                 output: Some(combined.to_string()),
+                combined: combined.to_string(),
             },
+            parts: Vec::new(),
             payload: WorkPayload::TerminalCommand {
                 prompt: String::new(),
                 command: String::new(),

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use serde::Serialize;
-use sivtr_core::record::{RecordTextMode, WorkRef, WorkRefSelector};
+use sivtr_core::record::{RecordTextMode, WorkRef, WorkRefSelector, WorkRefTarget};
 
 use crate::cli::ShowArgs;
 use crate::commands::records::current_work_record_index;
@@ -35,6 +35,11 @@ pub fn execute(args: &ShowArgs) -> Result<()> {
         .cwd
         .clone()
         .unwrap_or(std::env::current_dir().context("Failed to resolve current directory")?);
+
+    if let Ok(work_ref) = args.reference.parse::<WorkRef>() {
+        return show_by_ref(args, &cwd, &work_ref);
+    }
+
     let selector: WorkRefSelector = args.reference.parse()?;
     let providers = selector.providers();
     let records = current_work_record_index(&providers, &cwd, None)?;
@@ -55,8 +60,12 @@ pub fn execute(args: &ShowArgs) -> Result<()> {
         for work_ref in line_refs {
             let content = content_for_ref(record, &work_ref)
                 .with_context(|| format!("No content found for ref `{work_ref}`"))?;
+            let display_ref = match work_ref.target() {
+                WorkRefTarget::Record => record.work_ref.with_target(work_ref.target()),
+                _ => work_ref,
+            };
             items.push(ShowItem {
-                ref_: work_ref,
+                ref_: display_ref,
                 content,
                 kind: record.kind_label().to_string(),
                 timestamp: record.time.primary_at().map(str::to_string),
@@ -89,15 +98,61 @@ pub fn execute(args: &ShowArgs) -> Result<()> {
     Ok(())
 }
 
+fn show_by_ref(args: &ShowArgs, cwd: &std::path::Path, work_ref: &WorkRef) -> Result<()> {
+    let providers = work_ref
+        .provider()
+        .map(|provider| vec![provider])
+        .unwrap_or_else(|| {
+            sivtr_core::ai::AgentProvider::all()
+                .iter()
+                .map(|spec| spec.provider)
+                .collect()
+        });
+    let records = current_work_record_index(&providers, cwd, None)?;
+    let record = records
+        .resolve(work_ref)
+        .with_context(|| format!("No record found for ref `{}`", args.reference))?;
+    let content = record
+        .content_for_target(work_ref.target())
+        .map(str::to_string)
+        .with_context(|| format!("No content found for ref `{}`", args.reference))?;
+
+    if args.json {
+        let output = ShowJsonItem {
+            ref_: work_ref.to_string(),
+            kind: record.kind_label().to_string(),
+            timestamp: record.time.primary_at().map(str::to_string),
+            title: ShowJsonTitle {
+                session: record.work_ref.session().to_string(),
+                dialogue: Some(record.title.clone()),
+            },
+            content,
+        };
+        println!("{}", serde_json::to_string_pretty(&output)?);
+        return Ok(());
+    }
+
+    print!("{content}");
+    if !content.ends_with('\n') {
+        println!();
+    }
+    Ok(())
+}
+
 fn content_for_ref(record: &sivtr_core::record::WorkRecord, work_ref: &WorkRef) -> Option<String> {
-    match work_ref.line() {
-        Some(line) => record
-            .copy_text(RecordTextMode::Combined, false)
-            .plain
-            .lines()
-            .nth(line - 1)
+    match work_ref.target() {
+        WorkRefTarget::Part { .. } => record
+            .content_for_target(work_ref.target())
             .map(str::to_string),
-        None => Some(record.copy_text(RecordTextMode::Combined, false).plain),
+        _ => match work_ref.line() {
+            Some(line) => record
+                .copy_text(RecordTextMode::Combined, false)
+                .plain
+                .lines()
+                .nth(line - 1)
+                .map(str::to_string),
+            None => Some(record.copy_text(RecordTextMode::Combined, false).plain),
+        },
     }
 }
 

--- a/src/commands/work.rs
+++ b/src/commands/work.rs
@@ -1,0 +1,614 @@
+use anyhow::{bail, Context, Result};
+use serde::Serialize;
+use sivtr_core::ai::AgentProvider;
+use sivtr_core::record::{WorkPartIo, WorkPartKind, WorkRecord, WorkRef};
+use std::collections::HashMap;
+use std::fmt;
+use std::path::Path;
+
+use crate::cli::{
+    WorkCommand, WorkPartFilterArg, WorkPartsArgs, WorkRecordsArgs, WorkSessionsArgs,
+};
+use crate::commands::records::current_work_record_index;
+use crate::commands::work_json::{
+    session_meta, target_meta, WorkJsonSessionMeta, WorkJsonTargetMeta,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WorkSessionSource {
+    Terminal,
+    Agent(AgentProvider),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WorkSessionMarker {
+    source: WorkSessionSource,
+    session: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct WorkSessionListItem {
+    #[serde(rename = "ref")]
+    ref_: String,
+    source: String,
+    session: String,
+    session_meta: WorkJsonSessionMeta,
+    timestamp: Option<String>,
+    record_count: usize,
+    title: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct WorkRecordListItem {
+    #[serde(rename = "ref")]
+    ref_: String,
+    kind: String,
+    session: WorkJsonSessionMeta,
+    target: WorkJsonTargetMeta,
+    timestamp: Option<String>,
+    input_parts: usize,
+    output_parts: usize,
+    title: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct WorkPartListItem {
+    #[serde(rename = "ref")]
+    ref_: String,
+    session: WorkJsonSessionMeta,
+    target: WorkJsonTargetMeta,
+    io: WorkPartIo,
+    kind: WorkPartKind,
+    index: usize,
+    timestamp: Option<String>,
+    label: Option<String>,
+    summary: String,
+}
+
+#[derive(Serialize)]
+struct WorkSessionsJsonOutput {
+    cwd: String,
+    sessions: Vec<WorkSessionListItem>,
+}
+
+#[derive(Serialize)]
+struct WorkRecordsJsonOutput {
+    cwd: String,
+    session: String,
+    records: Vec<WorkRecordListItem>,
+}
+
+#[derive(Serialize)]
+struct WorkPartsJsonOutput {
+    cwd: String,
+    record: String,
+    io: &'static str,
+    parts: Vec<WorkPartListItem>,
+}
+
+pub fn execute(command: &WorkCommand) -> Result<()> {
+    match &command.action {
+        crate::cli::WorkSubcommand::Sessions(args) => execute_sessions(args),
+        crate::cli::WorkSubcommand::Records(args) => execute_records(args),
+        crate::cli::WorkSubcommand::Parts(args) => execute_parts(args),
+    }
+}
+
+fn execute_sessions(args: &WorkSessionsArgs) -> Result<()> {
+    let cwd = resolve_cwd(args.cwd.as_deref())?;
+    let providers = args.provider.providers();
+    let records = current_work_record_index(&providers, &cwd, None)?;
+    let items = build_session_items(records.records());
+
+    if args.json {
+        let output = WorkSessionsJsonOutput {
+            cwd: cwd.display().to_string(),
+            sessions: items,
+        };
+        println!("{}", serde_json::to_string_pretty(&output)?);
+        return Ok(());
+    }
+
+    if items.is_empty() {
+        println!("No workspace sessions found");
+        return Ok(());
+    }
+
+    for item in &items {
+        println!("{}", format_session_item(item));
+    }
+    Ok(())
+}
+
+fn execute_records(args: &WorkRecordsArgs) -> Result<()> {
+    let cwd = resolve_cwd(args.cwd.as_deref())?;
+    let marker = args.session.parse::<WorkSessionMarker>()?;
+    let providers = marker.providers();
+    let records = current_work_record_index(&providers, &cwd, None)?;
+    let items = records
+        .records()
+        .iter()
+        .filter(|record| marker.matches_record(record))
+        .map(record_item)
+        .collect::<Vec<_>>();
+
+    if args.json {
+        let output = WorkRecordsJsonOutput {
+            cwd: cwd.display().to_string(),
+            session: marker.to_string(),
+            records: items,
+        };
+        println!("{}", serde_json::to_string_pretty(&output)?);
+        return Ok(());
+    }
+
+    if items.is_empty() {
+        println!("No records found for `{marker}`");
+        return Ok(());
+    }
+
+    for item in &items {
+        println!("{}", format_record_item(item));
+    }
+    Ok(())
+}
+
+fn execute_parts(args: &WorkPartsArgs) -> Result<()> {
+    let cwd = resolve_cwd(args.cwd.as_deref())?;
+    let input_ref: WorkRef = args.record.parse()?;
+    let record_ref = input_ref.record_ref();
+    let providers = record_ref
+        .provider()
+        .map(|provider| vec![provider])
+        .unwrap_or_default();
+    let records = current_work_record_index(&providers, &cwd, None)?;
+    let record = records
+        .resolve(&record_ref)
+        .with_context(|| format!("No record found for ref `{}`", args.record))?;
+    let items = build_part_items(record, args.io);
+
+    if args.json {
+        let output = WorkPartsJsonOutput {
+            cwd: cwd.display().to_string(),
+            record: record_ref.to_string(),
+            io: args.io.as_str(),
+            parts: items,
+        };
+        println!("{}", serde_json::to_string_pretty(&output)?);
+        return Ok(());
+    }
+
+    if items.is_empty() {
+        println!("No {} parts found for `{}`", args.io.label(), record_ref);
+        return Ok(());
+    }
+
+    for item in &items {
+        println!("{}", format_part_item(item));
+    }
+    Ok(())
+}
+
+fn resolve_cwd(cwd: Option<&Path>) -> Result<std::path::PathBuf> {
+    Ok(cwd
+        .map(Path::to_path_buf)
+        .unwrap_or(std::env::current_dir().context("Failed to resolve current directory")?))
+}
+
+fn build_session_items(records: &[WorkRecord]) -> Vec<WorkSessionListItem> {
+    let mut items: Vec<WorkSessionListItem> = Vec::new();
+    let mut positions: HashMap<String, usize> = HashMap::new();
+
+    for record in records {
+        let marker = WorkSessionMarker::from_record(record);
+        let group_key = session_group_key(record, &marker);
+        if let Some(position) = positions.get(&group_key).copied() {
+            items[position].record_count += 1;
+            continue;
+        }
+        let display_ref = marker.to_string();
+        positions.insert(group_key, items.len());
+        items.push(WorkSessionListItem {
+            ref_: display_ref,
+            source: marker.source_name().to_string(),
+            session: marker.session,
+            session_meta: session_meta(record),
+            timestamp: record.time.primary_at().map(str::to_string),
+            record_count: 1,
+            title: record.title.clone(),
+        });
+    }
+
+    items
+}
+
+fn record_item(record: &WorkRecord) -> WorkRecordListItem {
+    let (input_parts, output_parts) = part_counts(record);
+    WorkRecordListItem {
+        ref_: record.session.work_ref.to_string(),
+        kind: record.kind_label().to_string(),
+        session: session_meta(record),
+        target: target_meta(record, record.session.work_ref.target()),
+        timestamp: record.time.primary_at().map(str::to_string),
+        input_parts,
+        output_parts,
+        title: record.title.clone(),
+    }
+}
+
+fn session_group_key(record: &WorkRecord, marker: &WorkSessionMarker) -> String {
+    let session_id = record
+        .session
+        .canonical_id
+        .as_deref()
+        .unwrap_or(marker.session.as_str());
+    format!("{}/{}", marker.source_name(), session_id)
+}
+
+fn build_part_items(record: &WorkRecord, io: WorkPartFilterArg) -> Vec<WorkPartListItem> {
+    record
+        .parts
+        .iter()
+        .filter(|part| io.matches(part.io))
+        .map(|part| WorkPartListItem {
+            ref_: record
+                .session
+                .work_ref
+                .with_part(part.io, part.index_in_record)
+                .to_string(),
+            session: session_meta(record),
+            target: target_meta(
+                record,
+                record
+                    .session
+                    .work_ref
+                    .with_part(part.io, part.index_in_record)
+                    .target(),
+            ),
+            io: part.io,
+            kind: part.kind,
+            index: part.index_in_record,
+            timestamp: part.occurred_at.clone(),
+            label: part.label.clone(),
+            summary: summary_text(&part.text),
+        })
+        .collect()
+}
+
+fn part_counts(record: &WorkRecord) -> (usize, usize) {
+    record
+        .parts
+        .iter()
+        .fold((0, 0), |(input, output), part| match part.io {
+            WorkPartIo::Input => (input + 1, output),
+            WorkPartIo::Output => (input, output + 1),
+        })
+}
+
+fn format_session_item(item: &WorkSessionListItem) -> String {
+    format_marker_line(
+        &item.ref_,
+        &[
+            format!("records {}", item.record_count),
+            timestamp_tag(item.timestamp.as_deref()),
+        ],
+        &item.title,
+    )
+}
+
+fn format_record_item(item: &WorkRecordListItem) -> String {
+    format_marker_line(
+        &item.ref_,
+        &[
+            format!("parts i={} o={}", item.input_parts, item.output_parts),
+            timestamp_tag(item.timestamp.as_deref()),
+        ],
+        &item.title,
+    )
+}
+
+fn format_part_item(item: &WorkPartListItem) -> String {
+    let mut tags = vec![
+        format!("{} {}", io_name(item.io), kind_name(item.kind)),
+        format!("n={}", item.index),
+        timestamp_tag(item.timestamp.as_deref()),
+    ];
+    if let Some(label) = item
+        .label
+        .as_deref()
+        .filter(|label| !label.trim().is_empty())
+    {
+        tags.push(format!("label {}", summary_text(label)));
+    }
+    format_marker_line(&item.ref_, &tags, &item.summary)
+}
+
+fn format_marker_line(marker: &str, tags: &[String], summary: &str) -> String {
+    let mut line = marker.to_string();
+    for tag in tags.iter().filter(|tag| !tag.is_empty()) {
+        line.push_str("  [");
+        line.push_str(tag);
+        line.push(']');
+    }
+    if !summary.trim().is_empty() {
+        line.push_str("  ");
+        line.push_str(summary);
+    }
+    line
+}
+
+fn timestamp_tag(timestamp: Option<&str>) -> String {
+    timestamp.unwrap_or("unknown-time").to_string()
+}
+
+fn summary_text(text: &str) -> String {
+    let compact = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    let trimmed = compact.trim();
+    if trimmed.is_empty() {
+        return "<empty>".to_string();
+    }
+    let summary = trimmed.chars().take(96).collect::<String>();
+    if trimmed.chars().count() > 96 {
+        format!("{summary}...")
+    } else {
+        summary
+    }
+}
+
+fn io_name(io: WorkPartIo) -> &'static str {
+    match io {
+        WorkPartIo::Input => "input",
+        WorkPartIo::Output => "output",
+    }
+}
+
+fn kind_name(kind: WorkPartKind) -> &'static str {
+    match kind {
+        WorkPartKind::Prompt => "prompt",
+        WorkPartKind::Command => "command",
+        WorkPartKind::UserMessage => "user_message",
+        WorkPartKind::AssistantMessage => "assistant_message",
+        WorkPartKind::ToolCall => "tool_call",
+        WorkPartKind::ToolOutput => "tool_output",
+        WorkPartKind::Text => "text",
+        WorkPartKind::Error => "error",
+    }
+}
+
+impl WorkSessionMarker {
+    fn from_record(record: &WorkRecord) -> Self {
+        match &record.session.work_ref {
+            WorkRef::Terminal { session, .. } => Self {
+                source: WorkSessionSource::Terminal,
+                session: session.clone(),
+            },
+            WorkRef::Agent {
+                provider, session, ..
+            } => Self {
+                source: WorkSessionSource::Agent(*provider),
+                session: session.clone(),
+            },
+        }
+    }
+
+    fn providers(&self) -> Vec<AgentProvider> {
+        match self.source {
+            WorkSessionSource::Terminal => Vec::new(),
+            WorkSessionSource::Agent(provider) => vec![provider],
+        }
+    }
+
+    fn matches_record(&self, record: &WorkRecord) -> bool {
+        self.source == Self::from_record(record).source && record.session.matches_id(&self.session)
+    }
+
+    fn source_name(&self) -> &'static str {
+        match self.source {
+            WorkSessionSource::Terminal => "terminal",
+            WorkSessionSource::Agent(provider) => provider.command_name(),
+        }
+    }
+}
+
+impl fmt::Display for WorkSessionMarker {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}/{}", self.source_name(), self.session)
+    }
+}
+
+impl std::str::FromStr for WorkSessionMarker {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        let parts = value
+            .split('/')
+            .filter(|part| !part.is_empty())
+            .collect::<Vec<_>>();
+        if parts.len() != 2 {
+            bail!(
+                "Invalid session ref `{value}`; expected terminal/<session> or <provider>/<session>"
+            );
+        }
+
+        let source = if parts[0].eq_ignore_ascii_case("terminal") {
+            WorkSessionSource::Terminal
+        } else {
+            WorkSessionSource::Agent(AgentProvider::from_command_name(parts[0]).ok_or_else(
+                || {
+                    anyhow::anyhow!(
+                        "Invalid session ref `{value}`; unknown source `{}`",
+                        parts[0]
+                    )
+                },
+            )?)
+        };
+
+        Ok(Self {
+            source,
+            session: parts[1].to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sivtr_core::record::{
+        WorkChannel, WorkOutcome, WorkPart, WorkPayload, WorkRecordKind, WorkSessionRef,
+        WorkSource, WorkStatus, WorkText, WorkTime,
+    };
+
+    #[test]
+    fn parses_session_refs() {
+        let terminal: WorkSessionMarker = "terminal/session_123".parse().unwrap();
+        assert_eq!(terminal.to_string(), "terminal/session_123");
+
+        let agent: WorkSessionMarker = "codex/abcdef12".parse().unwrap();
+        assert_eq!(agent.to_string(), "codex/abcdef12");
+
+        assert!("codex/abcdef12/3".parse::<WorkSessionMarker>().is_err());
+        assert!("unknown/abcdef12".parse::<WorkSessionMarker>().is_err());
+    }
+
+    #[test]
+    fn groups_sessions_in_latest_record_order() {
+        let records = vec![
+            test_record(
+                "codex/alpha/2",
+                "latest title",
+                Some("2026-05-24T12:00:00Z"),
+            ),
+            test_record(
+                "terminal/shell/1",
+                "shell title",
+                Some("2026-05-24T11:00:00Z"),
+            ),
+            test_record("codex/alpha/1", "older title", Some("2026-05-24T10:00:00Z")),
+        ];
+
+        let items = build_session_items(&records);
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].ref_, "codex/alpha");
+        assert_eq!(items[0].record_count, 2);
+        assert_eq!(items[0].title, "latest title");
+        assert_eq!(items[1].ref_, "terminal/shell");
+    }
+
+    #[test]
+    fn builds_part_items_with_structured_refs() {
+        let record = test_record("codex/alpha/2", "title", Some("2026-05-24T12:00:00Z"));
+
+        let parts = build_part_items(&record, WorkPartFilterArg::Output);
+
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0].ref_, "codex/alpha/2/o/1");
+        assert_eq!(
+            parts[0].session.canonical_id.as_deref(),
+            Some("alpha-session-0123456789abcdef")
+        );
+        assert_eq!(parts[0].target.type_, "part");
+        assert_eq!(
+            parts[0].ref_,
+            parts[0].target.part.as_ref().expect("part metadata").ref_
+        );
+        assert_eq!(parts[0].summary, "assistant reply");
+    }
+
+    #[test]
+    fn groups_sessions_with_canonical_session_metadata() {
+        let record = test_record("codex/alpha/2", "title", Some("2026-05-24T12:00:00Z"));
+
+        let items = build_session_items(&[record]);
+
+        assert_eq!(items[0].session_meta.display_id, "alpha");
+        assert_eq!(
+            items[0].session_meta.canonical_id.as_deref(),
+            Some("alpha-session-0123456789abcdef")
+        );
+    }
+
+    #[test]
+    fn session_markers_match_canonical_ids() {
+        let marker: WorkSessionMarker = "codex/alpha-session-0123456789abcdef".parse().unwrap();
+        let record = test_record("codex/alpha/2", "title", Some("2026-05-24T12:00:00Z"));
+
+        assert!(marker.matches_record(&record));
+    }
+
+    #[test]
+    fn keeps_distinct_canonical_sessions_separate_when_display_ids_collide() {
+        let mut first = test_record("codex/alpha/2", "first", Some("2026-05-24T12:00:00Z"));
+        first.session.canonical_id = Some("session-aaaa1111".to_string());
+        let mut second = test_record("codex/alpha/1", "second", Some("2026-05-24T11:00:00Z"));
+        second.session.canonical_id = Some("session-bbbb2222".to_string());
+
+        let items = build_session_items(&[first, second]);
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].record_count, 1);
+        assert_eq!(items[1].record_count, 1);
+    }
+
+    fn test_record(ref_id: &str, title: &str, timestamp: Option<&str>) -> WorkRecord {
+        let work_ref: WorkRef = ref_id.parse().unwrap();
+        WorkRecord {
+            schema_version: 1,
+            id: ref_id.to_string(),
+            kind: WorkRecordKind::ChatTurn,
+            work_ref: work_ref.clone(),
+            source: WorkSource {
+                channel: WorkChannel::Chat,
+                provider: Some("codex".to_string()),
+            },
+            session: WorkSessionRef {
+                id: "alpha".to_string(),
+                canonical_id: Some("alpha-session-0123456789abcdef".to_string()),
+                path: None,
+                index: 1,
+                work_ref,
+            },
+            cwd: None,
+            time: WorkTime {
+                started_at: timestamp.map(str::to_string),
+                ended_at: timestamp.map(str::to_string),
+                duration_ms: None,
+            },
+            status: WorkStatus {
+                outcome: WorkOutcome::Unknown,
+                exit_code: None,
+            },
+            title: title.to_string(),
+            text: WorkText {
+                input: Some("user prompt".to_string()),
+                output: Some("assistant reply".to_string()),
+                combined: "user prompt\nassistant reply".to_string(),
+            },
+            parts: vec![
+                WorkPart {
+                    io: WorkPartIo::Input,
+                    kind: WorkPartKind::UserMessage,
+                    index_in_record: 1,
+                    occurred_at: timestamp.map(str::to_string),
+                    label: Some("user".to_string()),
+                    text: "user prompt".to_string(),
+                    ansi: None,
+                },
+                WorkPart {
+                    io: WorkPartIo::Output,
+                    kind: WorkPartKind::AssistantMessage,
+                    index_in_record: 1,
+                    occurred_at: timestamp.map(str::to_string),
+                    label: Some("assistant".to_string()),
+                    text: "assistant reply".to_string(),
+                    ansi: None,
+                },
+            ],
+            payload: WorkPayload::ChatTurn {
+                user: "user prompt".to_string(),
+                assistant: "assistant reply".to_string(),
+                messages: Vec::new(),
+            },
+        }
+    }
+}

--- a/src/commands/work_json.rs
+++ b/src/commands/work_json.rs
@@ -1,0 +1,185 @@
+use serde::Serialize;
+use sivtr_core::record::{WorkChannel, WorkPartIo, WorkPartKind, WorkRecord, WorkRefTarget};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WorkJsonSessionMeta {
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub channel: WorkChannel,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    pub display_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub canonical_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WorkJsonTargetMeta {
+    #[serde(rename = "type")]
+    pub type_: &'static str,
+    pub record_ref: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub part: Option<WorkJsonPartMeta>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WorkJsonPartMeta {
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub io: WorkPartIo,
+    pub kind: WorkPartKind,
+    pub index: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+pub fn session_meta(record: &WorkRecord) -> WorkJsonSessionMeta {
+    WorkJsonSessionMeta {
+        ref_: record.session.marker_ref(),
+        channel: record.source.channel,
+        provider: record
+            .session
+            .provider()
+            .map(|provider| provider.command_name().to_string()),
+        display_id: record.session.id.clone(),
+        canonical_id: record.session.canonical_id.clone(),
+        path: record.session.path.clone(),
+    }
+}
+
+pub fn target_meta(record: &WorkRecord, target: WorkRefTarget) -> WorkJsonTargetMeta {
+    match target {
+        WorkRefTarget::Record => WorkJsonTargetMeta {
+            type_: "record",
+            record_ref: record.session.work_ref.to_string(),
+            line: None,
+            part: None,
+        },
+        WorkRefTarget::Line(line) => WorkJsonTargetMeta {
+            type_: "line",
+            record_ref: record.session.work_ref.to_string(),
+            line: Some(line),
+            part: None,
+        },
+        WorkRefTarget::Part { io, index } => WorkJsonTargetMeta {
+            type_: "part",
+            record_ref: record.session.work_ref.to_string(),
+            line: None,
+            part: record.part_for_target(target).map(|part| WorkJsonPartMeta {
+                ref_: record.session.work_ref.with_part(io, index).to_string(),
+                io,
+                kind: part.kind,
+                index,
+                timestamp: part.occurred_at.clone(),
+                label: part.label.clone(),
+            }),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sivtr_core::ai::AgentProvider;
+    use sivtr_core::record::{
+        WorkOutcome, WorkPart, WorkPartIo, WorkPartKind, WorkPayload, WorkRecord, WorkRecordKind,
+        WorkRef, WorkSessionRef, WorkSource, WorkStatus, WorkText, WorkTime,
+    };
+
+    #[test]
+    fn builds_session_metadata_with_canonical_id() {
+        let record = test_record();
+        let metadata = session_meta(&record);
+
+        assert_eq!(metadata.ref_, "codex/shortid");
+        assert_eq!(metadata.channel, WorkChannel::Chat);
+        assert_eq!(metadata.provider.as_deref(), Some("codex"));
+        assert_eq!(metadata.display_id, "shortid");
+        assert_eq!(
+            metadata.canonical_id.as_deref(),
+            Some("session-0123456789abcdef")
+        );
+    }
+
+    #[test]
+    fn builds_part_target_metadata() {
+        let record = test_record();
+        let metadata = target_meta(
+            &record,
+            WorkRefTarget::Part {
+                io: WorkPartIo::Output,
+                index: 1,
+            },
+        );
+
+        assert_eq!(metadata.type_, "part");
+        assert_eq!(metadata.record_ref, "codex/shortid/1");
+        let part = metadata.part.expect("part metadata");
+        assert_eq!(part.ref_, "codex/shortid/1/o/1");
+        assert_eq!(part.kind, WorkPartKind::AssistantMessage);
+        assert_eq!(part.label.as_deref(), Some("assistant"));
+    }
+
+    fn test_record() -> WorkRecord {
+        WorkRecord {
+            schema_version: 1,
+            id: "codex/shortid/1".to_string(),
+            work_ref: WorkRef::agent_record(AgentProvider::Codex, "shortid", 1),
+            kind: WorkRecordKind::ChatTurn,
+            source: WorkSource {
+                channel: WorkChannel::Chat,
+                provider: Some("codex".to_string()),
+            },
+            session: WorkSessionRef {
+                id: "shortid".to_string(),
+                canonical_id: Some("session-0123456789abcdef".to_string()),
+                path: Some("/tmp/session.jsonl".to_string()),
+                index: 0,
+                work_ref: WorkRef::agent_record(AgentProvider::Codex, "shortid", 1),
+            },
+            cwd: None,
+            time: WorkTime::default(),
+            status: WorkStatus {
+                outcome: WorkOutcome::Unknown,
+                exit_code: None,
+            },
+            title: "title".to_string(),
+            text: WorkText {
+                input: Some("user".to_string()),
+                output: Some("assistant".to_string()),
+                combined: "user\nassistant".to_string(),
+            },
+            parts: vec![
+                WorkPart {
+                    io: WorkPartIo::Input,
+                    kind: WorkPartKind::UserMessage,
+                    index_in_record: 1,
+                    occurred_at: None,
+                    label: Some("user".to_string()),
+                    text: "user".to_string(),
+                    ansi: None,
+                },
+                WorkPart {
+                    io: WorkPartIo::Output,
+                    kind: WorkPartKind::AssistantMessage,
+                    index_in_record: 1,
+                    occurred_at: Some("2026-05-24T12:00:00Z".to_string()),
+                    label: Some("assistant".to_string()),
+                    text: "assistant".to_string(),
+                    ansi: None,
+                },
+            ],
+            payload: WorkPayload::ChatTurn {
+                user: "user".to_string(),
+                assistant: "assistant".to_string(),
+                messages: Vec::new(),
+            },
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,8 @@ use anyhow::Result;
 use clap::Parser;
 
 use cli::{
-    AgentCopyArgs, AgentCopyCommand, AgentCopyMode, Cli, Commands, CopyArgs, CopySimpleArgs,
-    CopySubcommand, DiffArgs, HotkeyPickAgentArgs, HotkeyServeArgs,
+    AgentCopyArgs, AgentCopyCommand, AgentCopyMode, Cli, Commands, CopyArgs, CopyRefArgs,
+    CopySimpleArgs, CopySubcommand, DiffArgs, HotkeyPickAgentArgs, HotkeyServeArgs,
 };
 use command_blocks::CommandBlockTextMode;
 use commands::copy::{AgentCopyRequest, AgentPickerRequest, CopyMode, CopyRequest};
@@ -43,6 +43,9 @@ fn run() -> Result<()> {
         Some(Commands::Search(args)) => {
             commands::search::execute(&args)?;
         }
+        Some(Commands::Work(cmd)) => {
+            commands::work::execute(&cmd)?;
+        }
         Some(Commands::Show(args)) => {
             commands::show::execute(&args)?;
         }
@@ -69,6 +72,7 @@ fn run() -> Result<()> {
             Some(CopySubcommand::Cmd(sub_args)) => {
                 run_copy_simple(&sub_args, CopyMode::CommandOnly, false)?
             }
+            Some(CopySubcommand::Ref(sub_args)) => run_copy_ref(&sub_args)?,
             Some(CopySubcommand::Claude(sub_args)) => {
                 run_agent_copy(AgentProvider::Claude, sub_args)?
             }
@@ -162,6 +166,16 @@ fn run_copy_simple(args: &CopySimpleArgs, mode: CopyMode, include_prompt: bool) 
         regex: args.common.regex.as_deref(),
         lines: args.common.lines.as_deref(),
     })
+}
+
+fn run_copy_ref(args: &CopyRefArgs) -> Result<()> {
+    commands::copy::execute_ref(
+        &args.reference,
+        args.cwd.as_deref(),
+        args.print,
+        args.regex.as_deref(),
+        args.lines.as_deref(),
+    )
 }
 
 fn run_agent_copy(provider: AgentProvider, cmd: AgentCopyCommand) -> Result<()> {

--- a/src/tui/content_markdown.rs
+++ b/src/tui/content_markdown.rs
@@ -711,6 +711,26 @@ fn agent_heading_style(text: &str) -> Option<Style> {
                 .fg(Color::Cyan)
                 .add_modifier(Modifier::BOLD),
         )
+    } else if text.starts_with("Tool Call") || text.starts_with("Command") {
+        Some(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )
+    } else if text.starts_with("Tool Output") || text.starts_with("Output") {
+        Some(
+            Style::default()
+                .fg(Color::Blue)
+                .add_modifier(Modifier::BOLD),
+        )
+    } else if text.starts_with("Error") {
+        Some(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD))
+    } else if text.starts_with("Prompt") {
+        Some(
+            Style::default()
+                .fg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
     } else {
         None
     }
@@ -776,6 +796,26 @@ mod tests {
         assert_eq!(user.spans[1].content.as_ref(), "User");
         assert_eq!(user.spans[1].style.fg, Some(Color::Cyan));
         assert_eq!(assistant.spans[1].style.fg, Some(Color::Green));
+    }
+
+    #[test]
+    fn renders_work_part_headings_with_distinct_styles() {
+        let lines = render_markdown_window(
+            &[
+                "## Command",
+                "## Tool Call (Bash)",
+                "## Tool Output (Bash)",
+                "## Error",
+            ],
+            0,
+            4,
+            80,
+        );
+
+        assert_eq!(lines[0].line.spans[1].style.fg, Some(Color::Yellow));
+        assert_eq!(lines[1].line.spans[1].style.fg, Some(Color::Yellow));
+        assert_eq!(lines[2].line.spans[1].style.fg, Some(Color::Blue));
+        assert_eq!(lines[3].line.spans[1].style.fg, Some(Color::Red));
     }
 
     #[test]

--- a/src/tui/content_view.rs
+++ b/src/tui/content_view.rs
@@ -1131,12 +1131,16 @@ fn raw_lines(text: &str) -> Vec<&str> {
 mod tests {
     use super::{
         content_lines, content_link_at, content_position_at, content_position_in_text_row,
-        line_count, line_number_width, selected_content_text, visible_content_lines,
-        ContentPosition, ContentSelection, ContentSelectionKind, ContentViewMode,
+        line_count, line_number_width, render_content_view, selected_content_text,
+        visible_content_lines, ContentPosition, ContentSelection, ContentSelectionKind,
+        ContentView, ContentViewMode,
     };
+    use crate::tui::pane::Panel;
+    use ratatui::backend::TestBackend;
     use ratatui::layout::Rect;
     use ratatui::prelude::{Color, Modifier};
     use ratatui::text::Text;
+    use ratatui::Terminal;
     use regex::Regex;
     use unicode_width::UnicodeWidthStr;
 
@@ -1160,6 +1164,12 @@ mod tests {
             .spans
             .iter()
             .map(|span| span.content.as_ref())
+            .collect::<String>()
+    }
+
+    fn backend_row(backend: &TestBackend, y: u16) -> String {
+        (0..backend.buffer().area.width)
+            .filter_map(|x| backend.buffer().cell((x, y)).map(|cell| cell.symbol()))
             .collect::<String>()
     }
 
@@ -1443,5 +1453,32 @@ mod tests {
         assert_eq!(rendered_line_text(&rendered, 0), "alpha");
         assert_eq!(rendered.lines[0].spans[1].content.as_ref(), "lph");
         assert_eq!(rendered.lines[0].spans[1].style.bg, Some(Color::DarkGray));
+    }
+
+    #[test]
+    fn render_content_view_shows_line_numbers_in_the_visible_gutter() {
+        let backend = TestBackend::new(24, 6);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        terminal
+            .draw(|frame| {
+                render_content_view(
+                    frame,
+                    Rect::new(0, 0, 24, 6),
+                    Panel::new("3", "Content (read)", true),
+                    ContentView {
+                        text: "alpha\nbeta",
+                        scroll: 0,
+                        search_regex: None,
+                        mode: ContentViewMode::Reading,
+                        selection: None,
+                    },
+                );
+            })
+            .unwrap();
+
+        let backend = terminal.backend();
+        assert!(backend_row(backend, 1).contains("1|alpha"));
+        assert!(backend_row(backend, 2).contains("2|beta"));
     }
 }

--- a/src/tui/workspace.rs
+++ b/src/tui/workspace.rs
@@ -17,7 +17,7 @@ use crate::tui::pane::{
 };
 use crate::tui::workspace_search::{workspace_search_regex_for_query, WorkspaceSearchScope};
 use sivtr_core::ai::{AgentProvider, AgentSelection};
-use sivtr_core::record::WorkRecord;
+use sivtr_core::record::{WorkRecord, WorkRef, WorkRefTarget};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum WorkspaceSource {
@@ -96,6 +96,7 @@ pub(crate) struct WorkspaceSession {
     pub(crate) modified: SystemTime,
     pub(crate) title: String,
     pub(crate) search_title: String,
+    pub(crate) notice: Option<String>,
     pub(crate) records: Vec<WorkRecord>,
     pub(crate) load: Option<WorkspaceSessionLoad>,
 }
@@ -103,9 +104,169 @@ pub(crate) struct WorkspaceSession {
 #[derive(Clone, Debug)]
 pub(crate) struct WorkspaceDialogue {
     pub(crate) source: WorkspaceSource,
+    pub(crate) work_ref: Option<WorkRef>,
     pub(crate) title: String,
+    pub(crate) record: Option<WorkRecord>,
     pub(crate) unit: TextPair,
     pub(crate) copy: WorkspaceCopyParts,
+}
+
+impl WorkspaceDialogue {
+    pub(crate) fn display_unit(&self, target: Option<WorkRefTarget>) -> TextPair {
+        target
+            .and_then(|target| self.targeted_unit(target))
+            .unwrap_or_else(|| self.unit.clone())
+    }
+
+    pub(crate) fn content_text(
+        &self,
+        mode: ContentViewMode,
+        target: Option<WorkRefTarget>,
+    ) -> String {
+        if let Some(target @ WorkRefTarget::Part { .. }) = target {
+            return match mode {
+                ContentViewMode::Raw => self
+                    .targeted_plain_text(target)
+                    .unwrap_or(&self.unit.plain)
+                    .to_string(),
+                ContentViewMode::Reading => self
+                    .targeted_structured_text(target)
+                    .or_else(|| self.targeted_plain_text(target).map(str::to_string))
+                    .unwrap_or_else(|| self.unit.plain.clone()),
+            };
+        }
+        if matches!(target, Some(WorkRefTarget::Line(_))) {
+            return self.unit.plain.clone();
+        }
+
+        match mode {
+            ContentViewMode::Raw => self.unit.plain.clone(),
+            ContentViewMode::Reading => self
+                .record
+                .as_ref()
+                .map(structured_record_text)
+                .filter(|text| !text.trim().is_empty())
+                .unwrap_or_else(|| self.unit.plain.clone()),
+        }
+    }
+
+    pub(crate) fn content_ref(&self, target: Option<WorkRefTarget>) -> Option<WorkRef> {
+        let work_ref = self.work_ref.as_ref()?;
+        let target = match target {
+            Some(target @ WorkRefTarget::Part { .. }) => target,
+            _ => return Some(work_ref.clone()),
+        };
+        Some(work_ref.with_target(target))
+    }
+
+    fn targeted_unit(&self, target: WorkRefTarget) -> Option<TextPair> {
+        let WorkRefTarget::Part { .. } = target else {
+            return None;
+        };
+        let part = self.record.as_ref()?.part_for_target(target)?;
+        Some(TextPair {
+            plain: part.text.clone(),
+            ansi: part.ansi.clone().unwrap_or_else(|| part.text.clone()),
+        })
+    }
+
+    fn targeted_plain_text(&self, target: WorkRefTarget) -> Option<&str> {
+        let WorkRefTarget::Part { .. } = target else {
+            return None;
+        };
+        self.record.as_ref()?.content_for_target(target)
+    }
+
+    fn targeted_structured_text(&self, target: WorkRefTarget) -> Option<String> {
+        let WorkRefTarget::Part { .. } = target else {
+            return None;
+        };
+        let part = self.record.as_ref()?.part_for_target(target)?;
+        Some(structured_part_text(self.record.as_ref()?, part))
+    }
+}
+
+fn structured_record_text(record: &WorkRecord) -> String {
+    if record.parts.is_empty() {
+        return record.text.combined.clone();
+    }
+
+    record
+        .parts
+        .iter()
+        .map(|part| structured_part_text(record, part))
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn structured_part_text(record: &WorkRecord, part: &sivtr_core::record::WorkPart) -> String {
+    let heading = structured_part_heading(part);
+    let marker = structured_part_marker_line(record, part);
+    match part.kind {
+        sivtr_core::record::WorkPartKind::UserMessage
+        | sivtr_core::record::WorkPartKind::AssistantMessage => {
+            format!("{heading}\n{marker}\n{}", part.text)
+        }
+        sivtr_core::record::WorkPartKind::Prompt
+        | sivtr_core::record::WorkPartKind::Command
+        | sivtr_core::record::WorkPartKind::ToolCall
+        | sivtr_core::record::WorkPartKind::ToolOutput
+        | sivtr_core::record::WorkPartKind::Text
+        | sivtr_core::record::WorkPartKind::Error => {
+            let language = structured_part_code_language(part)
+                .map(|language| format!("~~~{language}\n"))
+                .unwrap_or_else(|| "~~~\n".to_string());
+            format!("{heading}\n{marker}\n{language}{}\n~~~", part.text)
+        }
+    }
+}
+
+fn structured_part_marker_line(record: &WorkRecord, part: &sivtr_core::record::WorkPart) -> String {
+    let mut markers = vec![format!(
+        "`{}`",
+        record
+            .session
+            .work_ref
+            .with_part(part.io, part.index_in_record)
+    )];
+    if let Some(timestamp) = part.occurred_at.as_deref().or(record.time.primary_at()) {
+        markers.push(format!("`{timestamp}`"));
+    }
+    markers.join("  ")
+}
+
+fn structured_part_heading(part: &sivtr_core::record::WorkPart) -> String {
+    let title = match part.kind {
+        sivtr_core::record::WorkPartKind::Prompt => "Prompt",
+        sivtr_core::record::WorkPartKind::Command => "Command",
+        sivtr_core::record::WorkPartKind::UserMessage => "User",
+        sivtr_core::record::WorkPartKind::AssistantMessage => "Assistant",
+        sivtr_core::record::WorkPartKind::ToolCall => "Tool Call",
+        sivtr_core::record::WorkPartKind::ToolOutput => "Tool Output",
+        sivtr_core::record::WorkPartKind::Text => "Output",
+        sivtr_core::record::WorkPartKind::Error => "Error",
+    };
+    match part
+        .label
+        .as_deref()
+        .filter(|label| !label.trim().is_empty())
+    {
+        Some(label) => format!("## {title} ({label})"),
+        None => format!("## {title}"),
+    }
+}
+
+fn structured_part_code_language(part: &sivtr_core::record::WorkPart) -> Option<&'static str> {
+    match part.kind {
+        sivtr_core::record::WorkPartKind::Command => Some("shell"),
+        sivtr_core::record::WorkPartKind::ToolCall => Some("bash"),
+        sivtr_core::record::WorkPartKind::Prompt
+        | sivtr_core::record::WorkPartKind::ToolOutput
+        | sivtr_core::record::WorkPartKind::Text
+        | sivtr_core::record::WorkPartKind::Error
+        | sivtr_core::record::WorkPartKind::UserMessage
+        | sivtr_core::record::WorkPartKind::AssistantMessage => None,
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -216,6 +377,7 @@ pub(crate) struct WorkspaceView<'a> {
     pub(crate) focus: WorkspaceFocus,
     pub(crate) content_scroll: usize,
     pub(crate) content_mode: ContentViewMode,
+    pub(crate) content_target: Option<WorkRefTarget>,
     pub(crate) show_help: bool,
     pub(crate) help_state: &'a ListState,
     pub(crate) search: Option<WorkspaceSearchView<'a>>,
@@ -232,6 +394,7 @@ pub(crate) struct WorkspaceSearchView<'a> {
     pub(crate) result_count: usize,
     pub(crate) current_match: Option<usize>,
     pub(crate) match_count: usize,
+    pub(crate) current_target: Option<String>,
     pub(crate) input_open: bool,
 }
 
@@ -245,6 +408,7 @@ struct WorkspaceFooterView<'a> {
     fullscreen: Option<WorkspaceFocus>,
     content_mode: ContentViewMode,
     content_selection: Option<ContentSelection>,
+    current_ref: Option<&'a WorkRef>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -527,6 +691,12 @@ pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
 
     let dialogue_idx =
         selected_index(view.dialogue_state).min(view.dialogues.len().saturating_sub(1));
+    let current_ref = current_content_ref(
+        view.dialogues,
+        view.selected_dialogues,
+        dialogue_idx,
+        view.content_target,
+    );
     let search_regex = view
         .search
         .as_ref()
@@ -564,13 +734,23 @@ pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
         view.focus == WorkspaceFocus::Dialogues,
     );
 
-    let content_text = content_preview_text(view.dialogues, view.selected_dialogues, dialogue_idx);
+    let content_text = workspace_content_text(
+        view.dialogues,
+        view.selected_dialogues,
+        dialogue_idx,
+        view.content_mode,
+        view.content_target,
+    );
     render_content_panel(
         frame,
         layout.content,
         Panel::new(
             WorkspaceFocus::Content.key(),
-            content_title(view.content_mode, view.selected_dialogues),
+            content_title(
+                view.content_mode,
+                view.selected_dialogues,
+                current_ref.as_ref(),
+            ),
             view.focus == WorkspaceFocus::Content,
         ),
         content_text.clone(),
@@ -594,6 +774,7 @@ pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
             fullscreen: view.fullscreen,
             content_mode: view.content_mode,
             content_selection: view.content_selection,
+            current_ref: current_ref.as_ref(),
         },
     );
 
@@ -635,20 +816,22 @@ fn render_footer(frame: &mut Frame, area: Rect, footer: WorkspaceFooterView<'_>)
         fullscreen,
         content_mode,
         content_selection,
+        current_ref,
     } = footer;
     let controls = if search.is_some() {
         let suffix = search.and_then(search_position_label).unwrap_or_default();
+        let target = search_target_footer_suffix(search);
         if search.map(|search| search.input_open).unwrap_or(false) {
             return frame.render_widget(
                 Paragraph::new(format!(
-                    "type search  > session  # dialogue  Enter accept  Esc clear  {suffix}"
+                    "type search  > session  # dialogue  Enter accept  Esc clear  {suffix}{target}"
                 )),
                 area,
             );
         }
         return frame.render_widget(
             Paragraph::new(format!(
-                "n next  N previous  Esc clear search  / edit  {suffix}"
+                "n next  N previous  Esc clear search  / edit  {suffix}{target}"
             )),
             area,
         );
@@ -689,13 +872,54 @@ fn render_footer(frame: &mut Frame, area: Rect, footer: WorkspaceFooterView<'_>)
     } else {
         String::new()
     };
-    let footer = Paragraph::new(format!("{controls}{suffix}{line_filter_status}{mode}"));
+    let ref_status = matches!(focus, WorkspaceFocus::Dialogues | WorkspaceFocus::Content)
+        .then_some(current_ref)
+        .flatten()
+        .map(|work_ref| format!("  [ref {work_ref}]"))
+        .unwrap_or_default();
+    let footer = Paragraph::new(format!(
+        "{controls}{suffix}{line_filter_status}{mode}{ref_status}"
+    ));
     frame.render_widget(footer, area);
 }
 
 fn search_position_label(search: &WorkspaceSearchView<'_>) -> Option<String> {
     let current = search.current_match?;
     Some(format!("[{}/{}]", current + 1, search.match_count))
+}
+
+fn search_target_footer_suffix(search: Option<&WorkspaceSearchView<'_>>) -> String {
+    search
+        .and_then(|search| search.current_target.as_deref())
+        .map(|target| format!("  [match {target}]"))
+        .unwrap_or_default()
+}
+
+fn current_content_dialogue<'a>(
+    dialogues: &'a [WorkspaceDialogue],
+    selected_dialogues: &[bool],
+    highlighted_idx: usize,
+) -> Option<&'a WorkspaceDialogue> {
+    let selected = selected_dialogues
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, selected)| selected.then_some(idx))
+        .collect::<Vec<_>>();
+    match selected.as_slice() {
+        [] => dialogues.get(highlighted_idx),
+        [idx] => dialogues.get(*idx),
+        _ => None,
+    }
+}
+
+fn current_content_ref(
+    dialogues: &[WorkspaceDialogue],
+    selected_dialogues: &[bool],
+    highlighted_idx: usize,
+    target: Option<WorkRefTarget>,
+) -> Option<WorkRef> {
+    current_content_dialogue(dialogues, selected_dialogues, highlighted_idx)
+        .and_then(|dialogue| dialogue.content_ref(target))
 }
 
 fn centered_rect(area: Rect, percent_x: u16, percent_y: u16) -> Rect {
@@ -720,23 +944,34 @@ fn centered_rect(area: Rect, percent_x: u16, percent_y: u16) -> Rect {
 
 fn render_search_box(frame: &mut Frame, area: Rect, search: WorkspaceSearchView<'_>) {
     frame.render_widget(Clear, area);
+    let title = search_box_title(&search);
+    let paragraph =
+        Paragraph::new(search_box_body(&search)).block(panel_block(&Panel::new("", title, true)));
+    frame.render_widget(paragraph, area);
+}
+
+fn search_box_title(search: &WorkspaceSearchView<'_>) -> String {
     let result_label = if search.query.trim().is_empty() {
         "ready".to_string()
-    } else if let Some(position) = search_position_label(&search) {
+    } else if let Some(position) = search_position_label(search) {
         position
     } else if search.result_count == 1 {
         "1 result".to_string()
     } else {
         format!("{} results", search.result_count)
     };
-    let title = if search.scope == WorkspaceSearchScope::Content {
+    if search.scope == WorkspaceSearchScope::Content {
         format!("Search  ({result_label})")
     } else {
         format!("Search {}  ({})", search.scope.label(), result_label)
-    };
-    let paragraph =
-        Paragraph::new(search.query.to_string()).block(panel_block(&Panel::new("", title, true)));
-    frame.render_widget(paragraph, area);
+    }
+}
+
+fn search_box_body(search: &WorkspaceSearchView<'_>) -> String {
+    match search.current_target.as_deref() {
+        Some(target) => format!("{}\n\nTarget: {target}", search.query),
+        None => search.query.to_string(),
+    }
 }
 
 fn render_line_filter_box(
@@ -1064,19 +1299,28 @@ fn selected_parent_title(
     }
 }
 
-fn content_title(mode: ContentViewMode, selected_dialogues: &[bool]) -> String {
-    selected_parent_title(
+fn content_title(
+    mode: ContentViewMode,
+    selected_dialogues: &[bool],
+    current_ref: Option<&WorkRef>,
+) -> String {
+    let title = selected_parent_title(
         &format!("Content ({})", mode.label()),
         selected_dialogues,
         "dialogue",
         "dialogues",
-    )
+    );
+    current_ref
+        .map(|work_ref| format!("{title} [{work_ref}]"))
+        .unwrap_or(title)
 }
 
-fn content_preview_text(
+pub(crate) fn workspace_content_text(
     dialogues: &[WorkspaceDialogue],
     selected_dialogues: &[bool],
     highlighted_idx: usize,
+    mode: ContentViewMode,
+    target: Option<WorkRefTarget>,
 ) -> String {
     if dialogues.is_empty() {
         return "<empty>".to_string();
@@ -1089,29 +1333,34 @@ fn content_preview_text(
         .collect::<Vec<_>>();
 
     if selected.is_empty() {
-        let text = dialogues
+        return dialogues
             .get(highlighted_idx)
-            .map(|dialogue| dialogue.unit.plain.as_str())
-            .unwrap_or("<empty>");
-        return text.to_string();
+            .map(|dialogue| dialogue.content_text(mode, target))
+            .unwrap_or_else(|| "<empty>".to_string());
     }
 
-    let text = selected
+    selected
         .into_iter()
         .filter_map(|dialogue_idx| dialogues.get(dialogue_idx))
-        .map(|dialogue| dialogue.unit.plain.as_str())
+        .map(|dialogue| dialogue.content_text(mode, None))
         .collect::<Vec<_>>()
-        .join("\n\n");
-    text
+        .join("\n\n")
 }
 
 #[cfg(test)]
 mod tests {
     use super::WorkspaceFocus;
     use super::{
-        can_open_dialogue_vim, content_preview_text, content_title, line_filter_prompt_text,
+        can_open_dialogue_vim, content_title, current_content_dialogue, line_filter_prompt_text,
+        search_box_body, search_box_title, workspace_content_text,
     };
     use crate::tui::content_view::ContentViewMode;
+    use crate::tui::workspace::{
+        TextPair, WorkspaceCopyParts, WorkspaceDialogue, WorkspaceSearchView, WorkspaceSource,
+    };
+    use crate::tui::workspace_search::WorkspaceSearchScope;
+    use sivtr_core::ai::AgentProvider;
+    use sivtr_core::record::{WorkRecord, WorkRef, WorkRefTarget};
 
     #[test]
     fn can_open_dialogue_vim_accepts_sessions_when_dialogues_exist() {
@@ -1123,31 +1372,292 @@ mod tests {
 
     #[test]
     fn content_preview_text_preserves_raw_text_without_line_number_prefixes() {
-        let dialogue = crate::tui::workspace::WorkspaceDialogue {
-            source: crate::tui::workspace::WorkspaceSource::Terminal,
+        let dialogue = WorkspaceDialogue {
+            source: WorkspaceSource::Terminal,
+            work_ref: None,
             title: "cmd".to_string(),
-            unit: crate::tui::workspace::TextPair {
+            record: None,
+            unit: TextPair {
                 plain: "alpha\n\nomega".to_string(),
                 ansi: String::new(),
             },
-            copy: crate::tui::workspace::WorkspaceCopyParts::default(),
+            copy: WorkspaceCopyParts::default(),
         };
 
         assert_eq!(
-            content_preview_text(&[dialogue], &[false], 0),
+            workspace_content_text(&[dialogue], &[false], 0, ContentViewMode::Raw, None),
             "alpha\n\nomega"
+        );
+    }
+
+    #[test]
+    fn content_preview_text_uses_targeted_part_text_in_raw_mode() {
+        let record = WorkRecord {
+            schema_version: 1,
+            id: "codex/session/1".to_string(),
+            work_ref: WorkRef::agent_record(AgentProvider::Codex, "session", 1),
+            kind: sivtr_core::record::WorkRecordKind::ChatTurn,
+            source: sivtr_core::record::WorkSource {
+                channel: sivtr_core::record::WorkChannel::Chat,
+                provider: Some("codex".to_string()),
+            },
+            session: sivtr_core::record::WorkSessionRef {
+                id: "session".to_string(),
+                canonical_id: None,
+                path: None,
+                index: 0,
+                work_ref: WorkRef::agent_record(AgentProvider::Codex, "session", 1),
+            },
+            cwd: None,
+            time: sivtr_core::record::WorkTime::default(),
+            status: sivtr_core::record::WorkStatus {
+                outcome: sivtr_core::record::WorkOutcome::Unknown,
+                exit_code: None,
+            },
+            title: "cmd".to_string(),
+            text: sivtr_core::record::WorkText {
+                input: Some("visible".to_string()),
+                output: Some("answer".to_string()),
+                combined: "visible\nanswer".to_string(),
+            },
+            parts: vec![sivtr_core::record::WorkPart {
+                io: sivtr_core::record::WorkPartIo::Input,
+                kind: sivtr_core::record::WorkPartKind::ToolCall,
+                index_in_record: 1,
+                occurred_at: None,
+                label: Some("tool".to_string()),
+                text: "hidden tool call".to_string(),
+                ansi: None,
+            }],
+            payload: sivtr_core::record::WorkPayload::ChatTurn {
+                user: "visible".to_string(),
+                assistant: "answer".to_string(),
+                messages: Vec::new(),
+            },
+        };
+        let dialogue = WorkspaceDialogue {
+            source: WorkspaceSource::Agent(AgentProvider::Codex),
+            work_ref: Some(WorkRef::agent_record(AgentProvider::Codex, "session", 1)),
+            title: "cmd".to_string(),
+            record: Some(record),
+            unit: TextPair {
+                plain: "visible\nanswer".to_string(),
+                ansi: String::new(),
+            },
+            copy: WorkspaceCopyParts::default(),
+        };
+
+        assert_eq!(
+            workspace_content_text(
+                &[dialogue],
+                &[false],
+                0,
+                ContentViewMode::Raw,
+                Some(WorkRefTarget::Part {
+                    io: sivtr_core::record::WorkPartIo::Input,
+                    index: 1,
+                }),
+            ),
+            "hidden tool call"
+        );
+    }
+
+    #[test]
+    fn content_preview_text_uses_structured_targeted_part_text_in_reading_mode() {
+        let record = WorkRecord {
+            schema_version: 1,
+            id: "codex/session/1".to_string(),
+            work_ref: WorkRef::agent_record(AgentProvider::Codex, "session", 1),
+            kind: sivtr_core::record::WorkRecordKind::ChatTurn,
+            source: sivtr_core::record::WorkSource {
+                channel: sivtr_core::record::WorkChannel::Chat,
+                provider: Some("codex".to_string()),
+            },
+            session: sivtr_core::record::WorkSessionRef {
+                id: "session".to_string(),
+                canonical_id: None,
+                path: None,
+                index: 0,
+                work_ref: WorkRef::agent_record(AgentProvider::Codex, "session", 1),
+            },
+            cwd: None,
+            time: sivtr_core::record::WorkTime::default(),
+            status: sivtr_core::record::WorkStatus {
+                outcome: sivtr_core::record::WorkOutcome::Unknown,
+                exit_code: None,
+            },
+            title: "cmd".to_string(),
+            text: sivtr_core::record::WorkText {
+                input: Some("visible".to_string()),
+                output: Some("answer".to_string()),
+                combined: "visible\nanswer".to_string(),
+            },
+            parts: vec![sivtr_core::record::WorkPart {
+                io: sivtr_core::record::WorkPartIo::Input,
+                kind: sivtr_core::record::WorkPartKind::ToolCall,
+                index_in_record: 1,
+                occurred_at: None,
+                label: Some("tool".to_string()),
+                text: "hidden tool call".to_string(),
+                ansi: None,
+            }],
+            payload: sivtr_core::record::WorkPayload::ChatTurn {
+                user: "visible".to_string(),
+                assistant: "answer".to_string(),
+                messages: Vec::new(),
+            },
+        };
+        let dialogue = WorkspaceDialogue {
+            source: WorkspaceSource::Agent(AgentProvider::Codex),
+            work_ref: Some(WorkRef::agent_record(AgentProvider::Codex, "session", 1)),
+            title: "cmd".to_string(),
+            record: Some(record),
+            unit: TextPair {
+                plain: "visible\nanswer".to_string(),
+                ansi: String::new(),
+            },
+            copy: WorkspaceCopyParts::default(),
+        };
+
+        let text = workspace_content_text(
+            &[dialogue],
+            &[false],
+            0,
+            ContentViewMode::Reading,
+            Some(WorkRefTarget::Part {
+                io: sivtr_core::record::WorkPartIo::Input,
+                index: 1,
+            }),
+        );
+
+        assert!(text.contains("## Tool Call (tool)"));
+        assert!(text.contains("`codex/session/1/i/1`"));
+        assert!(text.contains("~~~bash\nhidden tool call\n~~~"));
+    }
+
+    #[test]
+    fn reading_mode_structures_parts_with_headings_and_code_fences() {
+        let record = WorkRecord {
+            schema_version: 1,
+            id: "codex/session/1".to_string(),
+            work_ref: WorkRef::agent_record(AgentProvider::Codex, "session", 1),
+            kind: sivtr_core::record::WorkRecordKind::ChatTurn,
+            source: sivtr_core::record::WorkSource {
+                channel: sivtr_core::record::WorkChannel::Chat,
+                provider: Some("codex".to_string()),
+            },
+            session: sivtr_core::record::WorkSessionRef {
+                id: "session".to_string(),
+                canonical_id: None,
+                path: None,
+                index: 0,
+                work_ref: WorkRef::agent_record(AgentProvider::Codex, "session", 1),
+            },
+            cwd: None,
+            time: sivtr_core::record::WorkTime {
+                started_at: Some("2026-05-24T12:00:00Z".to_string()),
+                ended_at: None,
+                duration_ms: None,
+            },
+            status: sivtr_core::record::WorkStatus {
+                outcome: sivtr_core::record::WorkOutcome::Unknown,
+                exit_code: None,
+            },
+            title: "cmd".to_string(),
+            text: sivtr_core::record::WorkText {
+                input: Some("question".to_string()),
+                output: Some("answer".to_string()),
+                combined: "question\nanswer".to_string(),
+            },
+            parts: vec![
+                sivtr_core::record::WorkPart {
+                    io: sivtr_core::record::WorkPartIo::Input,
+                    kind: sivtr_core::record::WorkPartKind::UserMessage,
+                    index_in_record: 1,
+                    occurred_at: None,
+                    label: None,
+                    text: "question".to_string(),
+                    ansi: None,
+                },
+                sivtr_core::record::WorkPart {
+                    io: sivtr_core::record::WorkPartIo::Input,
+                    kind: sivtr_core::record::WorkPartKind::ToolCall,
+                    index_in_record: 2,
+                    occurred_at: None,
+                    label: Some("Bash".to_string()),
+                    text: "cargo test".to_string(),
+                    ansi: None,
+                },
+                sivtr_core::record::WorkPart {
+                    io: sivtr_core::record::WorkPartIo::Output,
+                    kind: sivtr_core::record::WorkPartKind::ToolOutput,
+                    index_in_record: 1,
+                    occurred_at: None,
+                    label: Some("Bash".to_string()),
+                    text: "ok".to_string(),
+                    ansi: None,
+                },
+                sivtr_core::record::WorkPart {
+                    io: sivtr_core::record::WorkPartIo::Output,
+                    kind: sivtr_core::record::WorkPartKind::AssistantMessage,
+                    index_in_record: 2,
+                    occurred_at: None,
+                    label: None,
+                    text: "answer".to_string(),
+                    ansi: None,
+                },
+            ],
+            payload: sivtr_core::record::WorkPayload::ChatTurn {
+                user: "question".to_string(),
+                assistant: "answer".to_string(),
+                messages: Vec::new(),
+            },
+        };
+        let dialogue = WorkspaceDialogue {
+            source: WorkspaceSource::Agent(AgentProvider::Codex),
+            work_ref: Some(WorkRef::agent_record(AgentProvider::Codex, "session", 1)),
+            title: "cmd".to_string(),
+            record: Some(record),
+            unit: TextPair {
+                plain: "question\nanswer".to_string(),
+                ansi: String::new(),
+            },
+            copy: WorkspaceCopyParts::default(),
+        };
+
+        let text = workspace_content_text(&[dialogue], &[false], 0, ContentViewMode::Reading, None);
+
+        assert!(text.contains("## User\n`codex/session/1/i/1`  `2026-05-24T12:00:00Z`\nquestion"));
+        assert!(text.contains(
+            "## Tool Call (Bash)\n`codex/session/1/i/2`  `2026-05-24T12:00:00Z`\n~~~bash\ncargo test\n~~~"
+        ));
+        assert!(text.contains(
+            "## Tool Output (Bash)\n`codex/session/1/o/1`  `2026-05-24T12:00:00Z`\n~~~\nok\n~~~"
+        ));
+        assert!(
+            text.contains("## Assistant\n`codex/session/1/o/2`  `2026-05-24T12:00:00Z`\nanswer")
         );
     }
 
     #[test]
     fn content_title_includes_view_mode() {
         assert_eq!(
-            content_title(ContentViewMode::Reading, &[false, false]),
+            content_title(ContentViewMode::Reading, &[false, false], None),
             "Content (read)"
         );
         assert_eq!(
-            content_title(ContentViewMode::Raw, &[true, false]),
+            content_title(ContentViewMode::Raw, &[true, false], None),
             "Content (raw): 1 dialogue selected"
+        );
+    }
+
+    #[test]
+    fn content_title_includes_current_dialogue_ref() {
+        let work_ref = WorkRef::agent_record(AgentProvider::Codex, "session", 2);
+
+        assert_eq!(
+            content_title(ContentViewMode::Reading, &[false], Some(&work_ref)),
+            "Content (read) [codex/session/2]"
         );
     }
 
@@ -1163,5 +1673,78 @@ mod tests {
         let prompt = line_filter_prompt_text(Some("23"), Some("Invalid line number"), false);
         assert!(prompt.contains("Invalid line number"));
         assert!(prompt.contains("Current: 23"));
+    }
+
+    #[test]
+    fn current_content_dialogue_uses_single_selected_dialogue() {
+        let dialogues = vec![
+            WorkspaceDialogue {
+                source: WorkspaceSource::Agent(AgentProvider::Codex),
+                work_ref: Some(WorkRef::agent_record(AgentProvider::Codex, "session", 1)),
+                title: "first".to_string(),
+                record: None,
+                unit: TextPair::default(),
+                copy: WorkspaceCopyParts::default(),
+            },
+            WorkspaceDialogue {
+                source: WorkspaceSource::Agent(AgentProvider::Codex),
+                work_ref: Some(WorkRef::agent_record(AgentProvider::Codex, "session", 2)),
+                title: "second".to_string(),
+                record: None,
+                unit: TextPair::default(),
+                copy: WorkspaceCopyParts::default(),
+            },
+        ];
+
+        let current = current_content_dialogue(&dialogues, &[false, true], 0).unwrap();
+
+        assert_eq!(
+            current.work_ref.as_ref().unwrap().to_string(),
+            "codex/session/2"
+        );
+    }
+
+    #[test]
+    fn current_content_ref_round_trips_active_part_target() {
+        let dialogues = vec![WorkspaceDialogue {
+            source: WorkspaceSource::Agent(AgentProvider::Codex),
+            work_ref: Some(WorkRef::agent_record(AgentProvider::Codex, "session", 2)),
+            title: "second".to_string(),
+            record: None,
+            unit: TextPair::default(),
+            copy: WorkspaceCopyParts::default(),
+        }];
+
+        let current = super::current_content_ref(
+            &dialogues,
+            &[false],
+            0,
+            Some(WorkRefTarget::Part {
+                io: sivtr_core::record::WorkPartIo::Output,
+                index: 1,
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(current.to_string(), "codex/session/2/o/1");
+    }
+
+    #[test]
+    fn search_box_body_includes_current_target_ref() {
+        let search = WorkspaceSearchView {
+            query: "needle",
+            scope: WorkspaceSearchScope::Content,
+            result_count: 1,
+            current_match: Some(0),
+            match_count: 1,
+            current_target: Some("codex/session/1/4".to_string()),
+            input_open: true,
+        };
+
+        assert_eq!(search_box_title(&search), "Search  ([1/1])");
+        assert_eq!(
+            search_box_body(&search),
+            "needle\n\nTarget: codex/session/1/4"
+        );
     }
 }

--- a/src/tui/workspace_search.rs
+++ b/src/tui/workspace_search.rs
@@ -1,4 +1,5 @@
 use regex::{Regex, RegexBuilder};
+use sivtr_core::record::{work_record_content_matches, WorkRefTarget};
 
 use crate::tui::workspace::WorkspaceSession;
 
@@ -62,7 +63,6 @@ struct WorkspaceSearchDialogueEntry {
     session_index: usize,
     dialogue_index: usize,
     dialogue_title: String,
-    content: String,
 }
 
 pub(crate) struct WorkspaceSearchIndex {
@@ -80,7 +80,14 @@ pub(crate) struct WorkspaceSearchOutput {
 pub(crate) struct WorkspaceSearchMatch {
     pub(crate) session_index: usize,
     pub(crate) dialogue_index: usize,
-    pub(crate) line_index: usize,
+    pub(crate) target: WorkRefTarget,
+    pub(crate) matched_line: usize,
+}
+
+impl WorkspaceSearchMatch {
+    pub(crate) fn content_scroll_index(&self) -> usize {
+        self.matched_line.saturating_sub(1)
+    }
 }
 
 impl WorkspaceSearchIndex {
@@ -108,9 +115,6 @@ impl WorkspaceSearchIndex {
                     session_index,
                     dialogue_index,
                     dialogue_title: record.title.clone(),
-                    content: record
-                        .copy_text(sivtr_core::record::RecordTextMode::Combined, false)
-                        .plain,
                 });
             }
         }
@@ -154,7 +158,8 @@ impl WorkspaceSearchIndex {
                         matches.push(WorkspaceSearchMatch {
                             session_index: filtered_session_index,
                             dialogue_index: 0,
-                            line_index: 0,
+                            target: WorkRefTarget::Record,
+                            matched_line: 1,
                         });
                     }
                 }
@@ -208,7 +213,8 @@ impl WorkspaceSearchIndex {
                     .map(move |(dialogue_index, _)| WorkspaceSearchMatch {
                         session_index,
                         dialogue_index,
-                        line_index: 0,
+                        target: WorkRefTarget::Record,
+                        matched_line: 1,
                     })
             })
             .collect();
@@ -221,11 +227,16 @@ impl WorkspaceSearchIndex {
         regex: &Regex,
     ) -> WorkspaceSearchOutput {
         let mut grouped: Vec<(usize, Vec<usize>)> = Vec::new();
-        for entry in self
-            .dialogues
-            .iter()
-            .filter(|entry| regex.is_match(&entry.content))
-        {
+        for entry in &self.dialogues {
+            let Some(record) = all_sessions
+                .get(entry.session_index)
+                .and_then(|session| session.records.get(entry.dialogue_index))
+            else {
+                continue;
+            };
+            if work_record_content_matches(record, regex).is_empty() {
+                continue;
+            }
             if let Some((_, dialogue_indices)) = grouped
                 .iter_mut()
                 .find(|(session_index, _)| *session_index == entry.session_index)
@@ -255,16 +266,13 @@ impl WorkspaceSearchIndex {
                     .iter()
                     .enumerate()
                     .flat_map(move |(dialogue_index, record)| {
-                        record
-                            .copy_text(sivtr_core::record::RecordTextMode::Combined, false)
-                            .plain
-                            .lines()
-                            .enumerate()
-                            .filter(|(_, line)| regex.is_match(line))
-                            .map(move |(line_index, _)| WorkspaceSearchMatch {
+                        work_record_content_matches(record, regex)
+                            .into_iter()
+                            .map(move |matched| WorkspaceSearchMatch {
                                 session_index,
                                 dialogue_index,
-                                line_index,
+                                target: matched.target,
+                                matched_line: matched.matched_line,
                             })
                             .collect::<Vec<_>>()
                     })


### PR DESCRIPTION
## Title: [Feat]: preserve and traverse canonical work parts (v2 — rebased)

### 1. Context and Motivation
- No matching upstream issue currently tracks this slice; this PR continues the record-centric data model and search expansion.
- Upstream has added WorkRefSelector (range parsing, fuzzy matching for search/show), sivtr doctor, init --show/uninstall, and other improvements since this PR was first opened. The original branch (feat/work-record-parts-phase1) accumulated 23 commits with 2 failed merge attempts and significant conflicts against the latest upstream/main (05a8ca9).

### 2. What Changed (v2 Rebase)

This PR was rebased onto upstream/main (05a8ca9) on a clean branch feat/work-record-parts-v2 with 2 focused commits that preserve all original improvements.

**Commit 1: Merge WorkRefSelector with part-aware WorkRef targets**
- WorkRefTarget gains Part{ io, index } alongside Record and Line(n)
- WorkRefSelector preserved with full range/comma parsing (2-4,7/*) for search/show
- WorkRef::from_str handles 5-segment part refs: pi/session/1/o/2
- WorkRef gains with_part(), part(), with_target() helpers

**Commit 2: Port all PR #20 changes onto upstream/main**
- Model layer: WorkChannel, WorkSource, WorkSessionRef, WorkPart types
- CLI: WorkPartFilterArg, CopyRefArgs, work subcommands
- Commands: work.rs, work_json.rs (new), show.rs part-aware, search.rs part-aware, copy.rs ref-based
- TUI: part-targeted content preview, structured part rendering
- Core: claude.rs customTitle extraction, graceful event handling

### 3. Developer Feedback Addressed
WorkRef now supports 3 target types (Record, Line, Part), 5-segment parsing, content_for_target(), and show tries exact WorkRef first then falls back to WorkRefSelector.

### 4. Quality
- 106 tests pass, clippy clean, fmt clean
- No merge conflicts — clean branch from upstream/main
- 20 files, +3500/-430 lines net delta

### 5. Branch Migration
Head branch changed from feat/work-record-parts-phase1 to feat/work-record-parts-v2. The new branch is a clean rebase with the same net changes but properly integrated with upstream/main.
