### PR TITLE
fix(claude): skip malformed unrelated sessions

### DIFF
--- a/crates/sivtr-core/src/ai.rs
+++ b/crates/sivtr-core/src/ai.rs
@@ -236,7 +236,16 @@ pub fn list_recent_jsonl_sessions(
     let mut sessions = Vec::new();
 
     for path in jsonl_files(root)? {
-        let meta = parse_meta(&path)?;
+        let meta = match parse_meta(&path) {
+            Ok(meta) => meta,
+            Err(error) => {
+                eprintln!(
+                    "sivtr: warning: failed to parse agent session metadata {}: {error:#}",
+                    path.display()
+                );
+                continue;
+            }
+        };
         if let Some(wanted) = wanted.as_deref() {
             let matches_cwd = meta
                 .cwd

--- a/crates/sivtr-core/src/claude.rs
+++ b/crates/sivtr-core/src/claude.rs
@@ -351,7 +351,17 @@ mod tests {
     use crate::ai::{
         format_blocks, select_blocks, AgentBlockKind, AgentSelection, AgentSessionProvider,
     };
-    use std::env;
+    use std::{
+        env,
+        sync::{Mutex, OnceLock},
+    };
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
 
     #[test]
     fn parses_claude_messages_and_tools() {
@@ -615,6 +625,7 @@ mod tests {
 
     #[test]
     fn skips_malformed_unrelated_sessions_during_listing() {
+        let _guard = env_lock();
         let dir = tempfile::tempdir().unwrap();
         let original_claude_home = env::var_os("CLAUDE_HOME");
         env::set_var("CLAUDE_HOME", dir.path());

--- a/crates/sivtr-core/src/claude.rs
+++ b/crates/sivtr-core/src/claude.rs
@@ -351,6 +351,7 @@ mod tests {
     use crate::ai::{
         format_blocks, select_blocks, AgentBlockKind, AgentSelection, AgentSessionProvider,
     };
+    use std::env;
 
     #[test]
     fn parses_claude_messages_and_tools() {
@@ -610,5 +611,62 @@ mod tests {
             format_blocks(&blocks),
             "## User\nsecond\n\n## Assistant\nnew"
         );
+    }
+
+    #[test]
+    fn skips_malformed_unrelated_sessions_during_listing() {
+        let dir = tempfile::tempdir().unwrap();
+        let original_claude_home = env::var_os("CLAUDE_HOME");
+        env::set_var("CLAUDE_HOME", dir.path());
+
+        let projects = dir.path().join("projects").join("workspace");
+        std::fs::create_dir_all(&projects).unwrap();
+
+        let valid_path = projects.join("valid.jsonl");
+        std::fs::write(
+            &valid_path,
+            r#"{"type":"user","sessionId":"good","cwd":"C:\\repo","message":{"role":"user","content":"hello"}}
+{"type":"assistant","sessionId":"good","cwd":"C:\\repo","customTitle":"valid session","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}
+"#,
+        )
+        .unwrap();
+
+        let malformed_path = projects.join("malformed.jsonl");
+        std::fs::write(
+            &malformed_path,
+            r#"{"type":"user","sessionId":"bad","cwd":"C:\\repo","message":{"role":"user","content":"oops"}}
+{"type":"assistant","sessionId":"bad","cwd":"C:\\repo","message":{"role":"assistant","content":[{"type":"text","text":"broken"}]}
+"#,
+        )
+        .unwrap();
+
+        let sessions = ClaudeProvider.list_recent_sessions(None).unwrap();
+
+        match original_claude_home {
+            Some(value) => env::set_var("CLAUDE_HOME", value),
+            None => env::remove_var("CLAUDE_HOME"),
+        }
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].id.as_deref(), Some("good"));
+        assert_eq!(sessions[0].title.as_deref(), Some("valid session"));
+    }
+
+    #[test]
+    fn explicit_malformed_claude_session_still_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"type":"user","sessionId":"bad","cwd":"C:\\repo","message":{"role":"user","content":"oops"}}
+{"type":"assistant","sessionId":"bad","cwd":"C:\\repo","message":{"role":"assistant","content":[{"type":"text","text":"broken"}]}}{"type":"user","sessionId":"bad","cwd":"C:\\repo","message":{"role":"user","content":"glued"}}
+"#,
+        )
+        .unwrap();
+
+        let error = ClaudeProvider.parse_session_file(&path).unwrap_err();
+        let message = format!("{error:#}");
+
+        assert!(message.contains("Failed to parse Claude session line 2 as JSON"));
     }
 }

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -1346,9 +1346,9 @@ mod tests {
     use super::{
         agent_session_preview, build_agent_session_choices, filter_lines_by_regex,
         filter_lines_by_spec, load_workspace_session, record_to_copy_parts, records_to_text_pairs,
-        ref_text_pair, resolve_agent_session_selector, resolved_workspace_session,
-        AgentBlockKind, AgentProvider, AgentSelection, AgentSession, AgentSessionInfo,
-        AgentSessionProvider, TextPair,
+        ref_text_pair, resolve_agent_session_selector, resolved_workspace_session, AgentBlockKind,
+        AgentProvider, AgentSelection, AgentSession, AgentSessionInfo, AgentSessionProvider,
+        TextPair,
     };
     use anyhow::Result;
     use sivtr_core::ai::AgentBlock;

--- a/src/commands/copy.rs
+++ b/src/commands/copy.rs
@@ -533,7 +533,17 @@ fn build_agent_session_choices(
     let mut choices = Vec::new();
 
     for info in sessions {
-        let session = source.parse_session_file(&info.path)?;
+        let session = match source.parse_session_file(&info.path) {
+            Ok(session) => session,
+            Err(error) => {
+                eprintln!(
+                    "sivtr: warning: failed to parse {} session {}: {error:#}",
+                    source.provider().name(),
+                    info.path.display()
+                );
+                continue;
+            }
+        };
         if let Some(choice) =
             build_agent_session_choice(source.provider(), info, session, selection_mode)
         {
@@ -1091,7 +1101,17 @@ fn selectable_agent_sessions(
     let mut selectable = Vec::new();
 
     for info in sessions {
-        let session = source.parse_session_file(&info.path)?;
+        let session = match source.parse_session_file(&info.path) {
+            Ok(session) => session,
+            Err(error) => {
+                eprintln!(
+                    "sivtr: warning: failed to parse {} session {}: {error:#}",
+                    source.provider().name(),
+                    info.path.display()
+                );
+                continue;
+            }
+        };
         if session.blocks.is_empty()
             || WorkRecord::selected_chat_records(source.provider(), &session, selection_mode)
                 .is_empty()
@@ -1133,7 +1153,18 @@ fn resolve_current_agent_session_with_blocks(
     }
 
     for session in source.list_recent_sessions(Some(cwd))? {
-        if agent_session_has_blocks(source, &session.path)? {
+        let has_blocks = match agent_session_has_blocks(source, &session.path) {
+            Ok(has_blocks) => has_blocks,
+            Err(error) => {
+                eprintln!(
+                    "sivtr: warning: failed to parse {} session {}: {error:#}",
+                    source.provider().name(),
+                    session.path.display()
+                );
+                continue;
+            }
+        };
+        if has_blocks {
             return Ok(Some(session.path));
         }
     }
@@ -1313,10 +1344,11 @@ fn record_text_mode(mode: CopyMode) -> RecordTextMode {
 mod tests {
     use super::vim::{is_vim_command, vim_single_quote};
     use super::{
-        agent_session_preview, filter_lines_by_regex, filter_lines_by_spec, load_workspace_session,
-        record_to_copy_parts, records_to_text_pairs, ref_text_pair, resolve_agent_session_selector,
-        resolved_workspace_session, AgentBlockKind, AgentProvider, AgentSelection, AgentSession,
-        AgentSessionInfo, AgentSessionProvider, TextPair,
+        agent_session_preview, build_agent_session_choices, filter_lines_by_regex,
+        filter_lines_by_spec, load_workspace_session, record_to_copy_parts, records_to_text_pairs,
+        ref_text_pair, resolve_agent_session_selector, resolved_workspace_session,
+        AgentBlockKind, AgentProvider, AgentSelection, AgentSession, AgentSessionInfo,
+        AgentSessionProvider, TextPair,
     };
     use anyhow::Result;
     use sivtr_core::ai::AgentBlock;
@@ -1810,6 +1842,57 @@ mod tests {
         );
     }
 
+    #[test]
+    fn build_agent_session_choices_skips_malformed_sessions() {
+        let source = SparseSelectableSource {
+            infos: vec![
+                AgentSessionInfo {
+                    path: PathBuf::from("broken.jsonl"),
+                    id: Some("broken".to_string()),
+                    cwd: Some("d:\\repo".to_string()),
+                    title: None,
+                    modified: SystemTime::UNIX_EPOCH + Duration::from_secs(2),
+                },
+                AgentSessionInfo {
+                    path: PathBuf::from("good.jsonl"),
+                    id: Some("good".to_string()),
+                    cwd: Some("d:\\repo".to_string()),
+                    title: None,
+                    modified: SystemTime::UNIX_EPOCH + Duration::from_secs(1),
+                },
+            ],
+            sessions: HashMap::from([(
+                PathBuf::from("good.jsonl"),
+                AgentSession {
+                    path: PathBuf::from("good.jsonl"),
+                    id: Some("good".to_string()),
+                    cwd: Some("d:\\repo".to_string()),
+                    title: None,
+                    blocks: vec![
+                        AgentBlock {
+                            kind: AgentBlockKind::User,
+                            timestamp: None,
+                            label: None,
+                            text: "question".to_string(),
+                        },
+                        AgentBlock {
+                            kind: AgentBlockKind::Assistant,
+                            timestamp: None,
+                            label: None,
+                            text: "answer".to_string(),
+                        },
+                    ],
+                },
+            )]),
+        };
+
+        let choices =
+            build_agent_session_choices(&source, &source.infos, AgentSelection::LastTurn).unwrap();
+
+        assert_eq!(choices.len(), 1);
+        assert_eq!(choices[0].title, "question  [good]");
+    }
+
     struct FakeAgentSource {
         require_cwd: bool,
         infos: Vec<AgentSessionInfo>,
@@ -1870,6 +1953,9 @@ mod tests {
         }
 
         fn parse_session_file(&self, path: &Path) -> Result<AgentSession> {
+            if path == Path::new("broken.jsonl") {
+                anyhow::bail!("synthetic parse error")
+            }
             self.sessions
                 .get(path)
                 .cloned()

--- a/src/commands/records.rs
+++ b/src/commands/records.rs
@@ -56,7 +56,17 @@ fn agent_records(
         }
 
         for info in sessions {
-            let session = source.parse_session_file(&info.path)?;
+            let session = match source.parse_session_file(&info.path) {
+                Ok(session) => session,
+                Err(error) => {
+                    eprintln!(
+                        "sivtr: warning: failed to parse {} session {}: {error:#}",
+                        source.provider().name(),
+                        info.path.display()
+                    );
+                    continue;
+                }
+            };
             records.extend(WorkRecord::chat_turns(source.provider(), &session));
         }
     }
@@ -192,10 +202,14 @@ fn rewrite_record_session_display_id(record: &mut WorkRecord, display_id: &str) 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anyhow::Result;
     use sivtr_core::record::{
         WorkChannel, WorkPart, WorkPartIo, WorkPartKind, WorkRecordKind, WorkSessionRef,
         WorkSource, WorkTime,
     };
+    use sivtr_core::ai::{AgentSession, AgentSessionInfo, AgentSessionProvider};
+    use std::path::{Path, PathBuf};
+    use std::time::{Duration, SystemTime};
 
     #[test]
     fn keeps_short_session_ids_when_already_unique() {
@@ -287,6 +301,86 @@ mod tests {
             .iter()
             .any(|part| part.text == "assistant with more detail"));
         assert_eq!(records[0].session.id, "session-01234567");
+    }
+
+    #[test]
+    fn agent_records_skips_malformed_session_files() {
+        let cwd = PathBuf::from("/repo");
+        let source = BrokenAgentSource {
+            infos: vec![
+                AgentSessionInfo {
+                    path: PathBuf::from("broken.jsonl"),
+                    id: Some("broken".to_string()),
+                    cwd: Some("/repo".to_string()),
+                    title: Some("broken".to_string()),
+                    modified: SystemTime::UNIX_EPOCH + Duration::from_secs(2),
+                },
+                AgentSessionInfo {
+                    path: PathBuf::from("good.jsonl"),
+                    id: Some("good".to_string()),
+                    cwd: Some("/repo".to_string()),
+                    title: Some("good".to_string()),
+                    modified: SystemTime::UNIX_EPOCH + Duration::from_secs(1),
+                },
+            ],
+        };
+
+        let provider = source.provider();
+        let mut records = Vec::new();
+        let mut sessions = source.list_recent_sessions(Some(&cwd)).unwrap();
+        sessions.truncate(10);
+
+        for info in sessions {
+            let session = match source.parse_session_file(&info.path) {
+                Ok(session) => session,
+                Err(_) => continue,
+            };
+            records.extend(WorkRecord::chat_turns(provider, &session));
+        }
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].session.id, "good");
+    }
+
+    struct BrokenAgentSource {
+        infos: Vec<AgentSessionInfo>,
+    }
+
+    impl AgentSessionProvider for BrokenAgentSource {
+        fn provider(&self) -> AgentProvider {
+            AgentProvider::Claude
+        }
+
+        fn list_recent_sessions(&self, _cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+            Ok(self.infos.clone())
+        }
+
+        fn parse_session_file(&self, path: &Path) -> Result<AgentSession> {
+            if path == Path::new("broken.jsonl") {
+                anyhow::bail!("synthetic parse error")
+            }
+
+            Ok(AgentSession {
+                path: path.to_path_buf(),
+                id: Some("good".to_string()),
+                cwd: Some("/repo".to_string()),
+                title: Some("good".to_string()),
+                blocks: vec![
+                    sivtr_core::ai::AgentBlock {
+                        kind: sivtr_core::ai::AgentBlockKind::User,
+                        timestamp: None,
+                        label: None,
+                        text: "question".to_string(),
+                    },
+                    sivtr_core::ai::AgentBlock {
+                        kind: sivtr_core::ai::AgentBlockKind::Assistant,
+                        timestamp: None,
+                        label: None,
+                        text: "assistant".to_string(),
+                    },
+                ],
+            })
+        }
     }
 
     fn test_record(work_ref: WorkRef, display_id: &str, canonical_id: Option<&str>) -> WorkRecord {

--- a/src/commands/records.rs
+++ b/src/commands/records.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use sivtr_core::ai::AgentProvider;
+use sivtr_core::ai::{AgentProvider, AgentSessionProvider};
 use sivtr_core::record::{WorkRecord, WorkRecordIndex, WorkRef};
 use sivtr_core::{session, workspace};
 use std::collections::HashMap;
@@ -50,25 +50,40 @@ fn agent_records(
 
     for provider in providers {
         let source = provider.session_provider();
-        let mut sessions = source.list_recent_sessions(Some(cwd))?;
-        if let Some(limit) = recent_sessions {
-            sessions.truncate(limit);
-        }
+        records.extend(agent_records_from_source(
+            source.as_ref(),
+            cwd,
+            recent_sessions,
+        )?);
+    }
 
-        for info in sessions {
-            let session = match source.parse_session_file(&info.path) {
-                Ok(session) => session,
-                Err(error) => {
-                    eprintln!(
-                        "sivtr: warning: failed to parse {} session {}: {error:#}",
-                        source.provider().name(),
-                        info.path.display()
-                    );
-                    continue;
-                }
-            };
-            records.extend(WorkRecord::chat_turns(source.provider(), &session));
-        }
+    Ok(records)
+}
+
+fn agent_records_from_source(
+    source: &dyn AgentSessionProvider,
+    cwd: &Path,
+    recent_sessions: Option<usize>,
+) -> Result<Vec<WorkRecord>> {
+    let mut records = Vec::new();
+    let mut sessions = source.list_recent_sessions(Some(cwd))?;
+    if let Some(limit) = recent_sessions {
+        sessions.truncate(limit);
+    }
+
+    for info in sessions {
+        let session = match source.parse_session_file(&info.path) {
+            Ok(session) => session,
+            Err(error) => {
+                eprintln!(
+                    "sivtr: warning: failed to parse {} session {}: {error:#}",
+                    source.provider().name(),
+                    info.path.display()
+                );
+                continue;
+            }
+        };
+        records.extend(WorkRecord::chat_turns(source.provider(), &session));
     }
 
     Ok(records)
@@ -203,11 +218,11 @@ fn rewrite_record_session_display_id(record: &mut WorkRecord, display_id: &str) 
 mod tests {
     use super::*;
     use anyhow::Result;
+    use sivtr_core::ai::{AgentSession, AgentSessionInfo, AgentSessionProvider};
     use sivtr_core::record::{
         WorkChannel, WorkPart, WorkPartIo, WorkPartKind, WorkRecordKind, WorkSessionRef,
         WorkSource, WorkTime,
     };
-    use sivtr_core::ai::{AgentSession, AgentSessionInfo, AgentSessionProvider};
     use std::path::{Path, PathBuf};
     use std::time::{Duration, SystemTime};
 
@@ -325,18 +340,7 @@ mod tests {
             ],
         };
 
-        let provider = source.provider();
-        let mut records = Vec::new();
-        let mut sessions = source.list_recent_sessions(Some(&cwd)).unwrap();
-        sessions.truncate(10);
-
-        for info in sessions {
-            let session = match source.parse_session_file(&info.path) {
-                Ok(session) => session,
-                Err(_) => continue,
-            };
-            records.extend(WorkRecord::chat_turns(provider, &session));
-        }
+        let records = agent_records_from_source(&source, &cwd, Some(10)).unwrap();
 
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].session.id, "good");


### PR DESCRIPTION
### 1. Context & Motivation (Context)
- **Issue:** n/a
- **Problem:** Claude provider traversal currently fails closed on malformed JSONL session files. A single unrelated broken Claude transcript can make `work sessions --provider claude`, `search claude/...`, and session-selection flows fail even when the target session is valid. The root cause is fail-fast metadata/session parsing inside shared JSONL session traversal, plus multi-session command paths that parse every candidate session without isolation.
- **Trade-offs:** This change makes provider-level traversal best-effort instead of fail-fast. The trade-off is that corrupted unrelated sessions are skipped with a warning instead of aborting the whole command. I kept explicit `parse_session_file()` behavior strict so directly targeting a malformed session still surfaces the real data error rather than silently hiding corruption.

### 2. Implementation Details (Implementation)
- `crates/sivtr-core/src/ai.rs`: `list_recent_jsonl_sessions()` now skips malformed session metadata with a warning instead of aborting the entire provider listing.
- `src/commands/records.rs`: multi-session agent record aggregation now skips malformed session files per-session, so `search agent` and other record-index paths continue to build records from valid sessions.
- `src/commands/copy.rs`: session-selection and selectable-session traversal now skip malformed sessions with warnings, while explicit single-session parse paths remain strict.
- `crates/sivtr-core/src/claude.rs`: regression tests cover both sides of the contract: unrelated malformed Claude sessions are skipped during listing, but explicitly parsing a malformed Claude session still returns an error.
- **Note:** This intentionally does not broaden into generic transcript repair or JSON recovery. It only hardens traversal so unrelated bad data does not poison valid sessions.

### 3. Testing Strategies (Validation)
- [x] Added regression tests for malformed unrelated Claude sessions in `crates/sivtr-core/src/claude.rs`
- [x] Added command-path regression tests for malformed session skipping in `src/commands/copy.rs` and `src/commands/records.rs`
- [x] Ran `cargo test --workspace`
- [x] Ran `cargo clippy --workspace --all-targets -- -D warnings`
- [x] Verified real local reproduction against a broken Claude transcript at `/home/jacob/.claude/projects/-home-jacob/ac205d27-3da6-4098-baa7-9178a2a9b321.jsonl`: provider listing and valid-session `show/search` continue to work while the malformed session is downgraded to a warning
