### PR TITLE
fix(editor): harden command parsing and Vim temp cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4427,6 +4427,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "shell-words",
  "strip-ansi-escapes",
  "tempfile",
  "thiserror 2.0.19",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,15 +103,14 @@ pulldown-cmark = { version = "0.13", default-features = false }
 unicode-width = "0.2"
 rmcp = { version = "3.1", default-features = false, features = ["server", "macros", "transport-io"] }
 schemars = "1"
+tempfile = "3"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["fileapi", "handleapi", "processenv", "processthreadsapi", "winbase", "winnt", "winuser", "windef", "minwindef"] }
-
 [dev-dependencies]
-tempfile = "3"
 criterion = { version = "0.8", features = ["html_reports"] }
 dhat = "0.3"
 

--- a/crates/sivtr-core/Cargo.toml
+++ b/crates/sivtr-core/Cargo.toml
@@ -26,9 +26,10 @@ rmp-serde = "1"
 thiserror = "2"
 tempfile = "3"
 toml = "1"
+shell-words = "1"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["processenv", "winbase", "wincon", "handleapi", "processthreadsapi", "winuser"] }
+winapi = { version = "0.3", features = ["processenv", "winbase", "wincon", "handleapi", "processthreadsapi", "shellapi", "winuser"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/sivtr-core/src/export/editor.rs
+++ b/crates/sivtr-core/src/export/editor.rs
@@ -118,12 +118,12 @@ fn split_editor_command(command: &str) -> Result<Vec<String>> {
     }
 
     let mut parts = Vec::with_capacity(count as usize);
-    for argument in unsafe { slice::from_raw_parts(argv, count as usize) } {
+    for &argument in unsafe { slice::from_raw_parts(argv, count as usize) } {
         let mut len = 0;
         while unsafe { *argument.add(len) } != 0 {
             len += 1;
         }
-        let value = unsafe { slice::from_raw_parts(*argument, len) };
+        let value = unsafe { slice::from_raw_parts(argument, len) };
         parts.push(OsString::from_wide(value).to_string_lossy().into_owned());
     }
     unsafe {

--- a/crates/sivtr-core/src/export/editor.rs
+++ b/crates/sivtr-core/src/export/editor.rs
@@ -55,13 +55,11 @@ pub fn open_in_editor(content: &str) -> Result<String> {
 
     let path = tmp.path().to_path_buf();
 
-    // Parse editor command (handles cases like "code --wait")
-    let parts: Vec<&str> = editor.split_whitespace().collect();
-    let (program, extra_args) = parts.split_first().context("Empty editor command")?;
+    let (program, extra_args) = parse_editor_command(&editor)?;
 
     // Spawn editor
-    let status = Command::new(program)
-        .args(extra_args)
+    let status = Command::new(&program)
+        .args(&extra_args)
         .arg(&path)
         .status()
         .with_context(|| format!("Failed to launch editor '{editor}'"))?;
@@ -74,6 +72,65 @@ pub fn open_in_editor(content: &str) -> Result<String> {
     let result = std::fs::read_to_string(&path).context("Failed to read back from temp file")?;
 
     Ok(result)
+}
+
+/// Parse a configured editor command while preserving quoted paths and arguments.
+pub fn parse_editor_command(command: &str) -> Result<(String, Vec<String>)> {
+    let command = command.trim();
+    let mut parts = split_editor_command(command)?;
+    if parts.is_empty() {
+        anyhow::bail!("Empty editor command");
+    }
+
+    let program = parts.remove(0);
+    if program.is_empty() {
+        anyhow::bail!("Empty editor command program");
+    }
+    Ok((program, parts))
+}
+
+#[cfg(not(windows))]
+fn split_editor_command(command: &str) -> Result<Vec<String>> {
+    shell_words::split(command)
+        .with_context(|| format!("Invalid editor command quoting: `{command}`"))
+}
+
+#[cfg(windows)]
+fn split_editor_command(command: &str) -> Result<Vec<String>> {
+    use std::{ffi::OsString, os::windows::ffi::OsStringExt, slice};
+    use winapi::um::{shellapi::CommandLineToArgvW, winbase::LocalFree};
+
+    if command.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let wide = command
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let mut count = 0;
+    let argv = unsafe { CommandLineToArgvW(wide.as_ptr(), &mut count) };
+    if argv.is_null() {
+        anyhow::bail!(
+            "Invalid editor command `{command}`: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+
+    let mut parts = Vec::with_capacity(count as usize);
+    for argument in unsafe { slice::from_raw_parts(argv, count as usize) } {
+        let mut len = 0;
+        while unsafe { *argument.add(len) } != 0 {
+            len += 1;
+        }
+        let value = unsafe { slice::from_raw_parts(*argument, len) };
+        parts.push(OsString::from_wide(value).to_string_lossy().into_owned());
+    }
+    unsafe {
+        LocalFree(argv.cast());
+    }
+
+    Ok(parts)
 }
 
 /// Check if a command exists on PATH.
@@ -93,5 +150,24 @@ fn which_exists(name: &str) -> bool {
             .output()
             .map(|o| o.status.success())
             .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_editor_command;
+
+    #[test]
+    fn parses_quoted_windows_editor_path_and_arguments() {
+        let (program, args) =
+            parse_editor_command(r#"  "C:\Program Files\Neovim\bin\nvim.exe" --clean  "#).unwrap();
+
+        assert_eq!(program, r#"C:\Program Files\Neovim\bin\nvim.exe"#);
+        assert_eq!(args, vec!["--clean"]);
+    }
+
+    #[test]
+    fn rejects_an_explicitly_empty_editor_program() {
+        assert!(parse_editor_command(r#""" --clean"#).is_err());
     }
 }

--- a/src/commands/browse/vim.rs
+++ b/src/commands/browse/vim.rs
@@ -96,7 +96,12 @@ fn remove_dir_all_with_retry(
     retry_delay: Duration,
     mut remove: impl FnMut(&Path) -> std::io::Result<()>,
 ) -> std::io::Result<()> {
-    debug_assert!(attempts > 0);
+    if attempts == 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "cleanup attempts must be greater than zero",
+        ));
+    }
     let mut last_error = None;
 
     for attempt in 0..attempts {
@@ -362,6 +367,23 @@ mod tests {
 
         assert_eq!(calls, 3);
         assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn zero_cleanup_attempts_are_rejected_without_reporting_success() {
+        let mut calls = 0;
+        let error = remove_dir_all_with_retry(Path::new("unused"), 0, Duration::ZERO, |_| {
+            calls += 1;
+            Ok(())
+        })
+        .unwrap_err();
+
+        assert_eq!(calls, 0);
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert_eq!(
+            error.to_string(),
+            "cleanup attempts must be greater than zero"
+        );
     }
 
     #[test]

--- a/src/commands/browse/vim.rs
+++ b/src/commands/browse/vim.rs
@@ -149,6 +149,7 @@ fn resolve_configured_vim_editor(command: &str) -> Result<Option<String>> {
     Ok(is_vim_program(&program).then(|| command.to_string()))
 }
 
+#[cfg(test)]
 pub(super) fn is_vim_command(command: &str) -> bool {
     let Ok((program, _)) = sivtr_core::export::editor::parse_editor_command(command) else {
         return false;

--- a/src/commands/browse/vim.rs
+++ b/src/commands/browse/vim.rs
@@ -1,7 +1,12 @@
 use anyhow::{Context, Result};
 use serde::Serialize;
 use std::io::Write;
+use std::path::Path;
 use std::process::Command;
+use std::time::Duration;
+
+const TEMP_CLEANUP_ATTEMPTS: usize = 3;
+const TEMP_CLEANUP_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 #[derive(Clone, Debug)]
 pub(super) struct VimView {
@@ -59,11 +64,54 @@ pub(super) fn open_vim_view(view: &VimView) -> Result<()> {
         }
         Ok(())
     })();
-    let cleanup = temp_dir
-        .close()
-        .context("Failed to securely remove temporary Vim view files");
+    let cleanup = cleanup_temp_dir(temp_dir);
 
     finish_vim_view(operation, cleanup)
+}
+
+fn cleanup_temp_dir(temp_dir: tempfile::TempDir) -> Result<()> {
+    let path = temp_dir.path().to_path_buf();
+    let cleanup = remove_dir_all_with_retry(
+        &path,
+        TEMP_CLEANUP_ATTEMPTS,
+        TEMP_CLEANUP_RETRY_DELAY,
+        |path| std::fs::remove_dir_all(path),
+    );
+    // Keep TempDir's destructor as a final best-effort attempt if all reported retries fail.
+    drop(temp_dir);
+    if cleanup.is_err() && matches!(path.try_exists(), Ok(false)) {
+        return Ok(());
+    }
+    cleanup.with_context(|| {
+        format!(
+            "Failed to securely remove temporary Vim view files from {}",
+            path.display()
+        )
+    })
+}
+
+fn remove_dir_all_with_retry(
+    path: &Path,
+    attempts: usize,
+    retry_delay: Duration,
+    mut remove: impl FnMut(&Path) -> std::io::Result<()>,
+) -> std::io::Result<()> {
+    debug_assert!(attempts > 0);
+    let mut last_error = None;
+
+    for attempt in 0..attempts {
+        match remove(path) {
+            Ok(()) => return Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => last_error = Some(error),
+        }
+
+        if attempt + 1 < attempts {
+            std::thread::sleep(retry_delay);
+        }
+    }
+
+    Err(last_error.expect("cleanup attempts must be greater than zero"))
 }
 
 fn finish_vim_view(operation: Result<()>, cleanup: Result<()>) -> Result<()> {
@@ -79,8 +127,8 @@ fn finish_vim_view(operation: Result<()>, cleanup: Result<()>) -> Result<()> {
 
 fn resolve_vim_editor() -> Result<String> {
     let config = sivtr_core::config::SivtrConfig::load().unwrap_or_default();
-    if is_vim_command(&config.editor.command) {
-        return Ok(config.editor.command);
+    if let Some(editor) = resolve_configured_vim_editor(&config.editor.command)? {
+        return Ok(editor);
     }
 
     for candidate in ["nvim", "vim", "vi"] {
@@ -92,14 +140,27 @@ fn resolve_vim_editor() -> Result<String> {
     anyhow::bail!("No Vim-compatible editor found. Set `editor.command` to nvim/vim/vi.")
 }
 
-pub fn is_vim_command(command: &str) -> bool {
+fn resolve_configured_vim_editor(command: &str) -> Result<Option<String>> {
+    if command.is_empty() {
+        return Ok(None);
+    }
+
+    let (program, _) = sivtr_core::export::editor::parse_editor_command(command)?;
+    Ok(is_vim_program(&program).then(|| command.to_string()))
+}
+
+pub(super) fn is_vim_command(command: &str) -> bool {
     let Ok((program, _)) = sivtr_core::export::editor::parse_editor_command(command) else {
         return false;
     };
-    let name = std::path::Path::new(&program)
+    is_vim_program(&program)
+}
+
+fn is_vim_program(program: &str) -> bool {
+    let name = std::path::Path::new(program)
         .file_stem()
         .and_then(|name| name.to_str())
-        .unwrap_or(&program)
+        .unwrap_or(program)
         .to_lowercase();
     name == "vi" || name.contains("vim")
 }
@@ -236,13 +297,70 @@ autocmd VimEnter * echo "sivtr: [[/]] jump blocks, myy/myi/myo/myc copy, mvv/mvi
 
 #[cfg(test)]
 mod tests {
-    use super::{finish_vim_view, is_vim_command};
+    use super::{
+        finish_vim_view, is_vim_command, remove_dir_all_with_retry, resolve_configured_vim_editor,
+    };
+    use std::path::Path;
+    use std::time::Duration;
 
     #[test]
     fn detects_quoted_windows_vim_path() {
         assert!(is_vim_command(
             r#""C:\Program Files\Neovim\bin\nvim.exe" --clean"#
         ));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn rejects_invalid_configured_vim_command_instead_of_falling_back() {
+        let error = resolve_configured_vim_editor("nvim --cmd 'set nowrap")
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("Invalid editor command quoting"));
+    }
+
+    #[test]
+    fn valid_non_vim_command_can_still_fall_back() {
+        assert_eq!(resolve_configured_vim_editor("code --wait").unwrap(), None);
+    }
+
+    #[test]
+    fn retries_temporary_directory_cleanup_before_succeeding() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().to_path_buf();
+        let mut calls = 0;
+
+        remove_dir_all_with_retry(&path, 3, Duration::ZERO, |path| {
+            calls += 1;
+            if calls < 3 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "temporary lock",
+                ));
+            }
+            std::fs::remove_dir_all(path)
+        })
+        .unwrap();
+
+        assert_eq!(calls, 3);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn temporary_directory_cleanup_retries_are_bounded() {
+        let mut calls = 0;
+        let error = remove_dir_all_with_retry(Path::new("unused"), 3, Duration::ZERO, |_| {
+            calls += 1;
+            Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "still locked",
+            ))
+        })
+        .unwrap_err();
+
+        assert_eq!(calls, 3);
+        assert_eq!(error.kind(), std::io::ErrorKind::PermissionDenied);
     }
 
     #[test]

--- a/src/commands/browse/vim.rs
+++ b/src/commands/browse/vim.rs
@@ -2,7 +2,6 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 use std::io::Write;
 use std::process::Command;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Clone, Debug)]
 pub(super) struct VimView {
@@ -26,47 +25,56 @@ pub(super) struct VimBlock {
 
 pub(super) fn open_vim_view(view: &VimView) -> Result<()> {
     let editor = resolve_vim_editor()?;
-    let dir = std::env::temp_dir();
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_millis())
-        .unwrap_or_default();
-    let content_path = dir.join(format!("sivtr-view-{}-{nonce}.txt", std::process::id()));
-    let vimrc_path = dir.join(format!("sivtr-view-{}-{nonce}.vim", std::process::id()));
-    let blocks_path = dir.join(format!(
-        "sivtr-view-{}-{nonce}.blocks.json",
-        std::process::id()
-    ));
+    // A securely randomized directory prevents predictable-name collisions and is deleted on
+    // every return path, including write, spawn, and non-zero-exit failures.
+    let temp_dir = tempfile::Builder::new()
+        .prefix("sivtr-view-")
+        .tempdir()
+        .context("Failed to create temporary Vim view directory")?;
+    let content_path = temp_dir.path().join("content.txt");
+    let vimrc_path = temp_dir.path().join("view.vim");
+    let blocks_path = temp_dir.path().join("blocks.json");
 
-    std::fs::write(&content_path, &view.raw).context("Failed to write Vim view file")?;
-    let blocks_json =
-        serde_json::to_string(&view.blocks).context("Failed to encode Vim block data")?;
-    std::fs::write(&blocks_path, blocks_json).context("Failed to write Vim block data")?;
-    write_vimrc(&vimrc_path, &blocks_path)?;
+    let operation = (|| -> Result<()> {
+        std::fs::write(&content_path, &view.raw).context("Failed to write Vim view file")?;
+        let blocks_json =
+            serde_json::to_string(&view.blocks).context("Failed to encode Vim block data")?;
+        std::fs::write(&blocks_path, blocks_json).context("Failed to write Vim block data")?;
+        write_vimrc(&vimrc_path, &blocks_path)?;
 
-    let parts: Vec<&str> = editor.split_whitespace().collect();
-    let (program, extra_args) = parts
-        .split_first()
-        .ok_or_else(|| anyhow::anyhow!("Empty Vim editor command"))?;
+        let (program, extra_args) = sivtr_core::export::editor::parse_editor_command(&editor)?;
 
-    let status = Command::new(program)
-        .args(extra_args)
-        .arg("-u")
-        .arg(&vimrc_path)
-        .arg("-n")
-        .arg("-R")
-        .arg(&content_path)
-        .status()
-        .with_context(|| format!("Failed to launch Vim editor `{editor}`"))?;
+        let status = Command::new(&program)
+            .args(&extra_args)
+            .arg("-u")
+            .arg(&vimrc_path)
+            .arg("-n")
+            .arg("-R")
+            .arg(&content_path)
+            .status()
+            .with_context(|| format!("Failed to launch Vim editor `{editor}`"))?;
 
-    let _ = std::fs::remove_file(&content_path);
-    let _ = std::fs::remove_file(&vimrc_path);
-    let _ = std::fs::remove_file(&blocks_path);
+        if !status.success() {
+            anyhow::bail!("Vim editor `{editor}` exited with {status}");
+        }
+        Ok(())
+    })();
+    let cleanup = temp_dir
+        .close()
+        .context("Failed to securely remove temporary Vim view files");
 
-    if !status.success() {
-        anyhow::bail!("Vim editor `{editor}` exited with {status}");
+    finish_vim_view(operation, cleanup)
+}
+
+fn finish_vim_view(operation: Result<()>, cleanup: Result<()>) -> Result<()> {
+    match (operation, cleanup) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Err(error), Err(cleanup_error)) => Err(anyhow::anyhow!(
+            "{error:#}; additionally failed to remove temporary Vim view files: {cleanup_error:#}"
+        )),
     }
-    Ok(())
 }
 
 fn resolve_vim_editor() -> Result<String> {
@@ -85,13 +93,13 @@ fn resolve_vim_editor() -> Result<String> {
 }
 
 pub fn is_vim_command(command: &str) -> bool {
-    let Some(program) = command.split_whitespace().next() else {
+    let Ok((program, _)) = sivtr_core::export::editor::parse_editor_command(command) else {
         return false;
     };
-    let name = std::path::Path::new(program)
+    let name = std::path::Path::new(&program)
         .file_stem()
         .and_then(|name| name.to_str())
-        .unwrap_or(program)
+        .unwrap_or(&program)
         .to_lowercase();
     name == "vi" || name.contains("vim")
 }
@@ -224,4 +232,29 @@ autocmd VimEnter * echo "sivtr: [[/]] jump blocks, myy/myi/myo/myc copy, mvv/mvi
     file.write_all(script.as_bytes())
         .context("Failed to write temporary Vim config")?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{finish_vim_view, is_vim_command};
+
+    #[test]
+    fn detects_quoted_windows_vim_path() {
+        assert!(is_vim_command(
+            r#""C:\Program Files\Neovim\bin\nvim.exe" --clean"#
+        ));
+    }
+
+    #[test]
+    fn reports_both_editor_and_sensitive_temp_cleanup_failures() {
+        let error = finish_vim_view(
+            Err(anyhow::anyhow!("editor failed")),
+            Err(anyhow::anyhow!("cleanup failed")),
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("editor failed"));
+        assert!(error.contains("cleanup failed"));
+    }
 }


### PR DESCRIPTION
## What changed

- Parse configured editor commands with platform-native quoting rules: `shell-words` on Unix and `CommandLineToArgvW` on Windows.
- Execute the parsed program and arguments directly with `Command::new`; no shell is introduced.
- Move the Vim view's generated content and vimrc into a randomized `TempDir` instead of predictable filenames.
- Route write, launch, non-zero exit, and success paths through bounded cleanup, while preserving both the primary error and a cleanup error when both occur.
- Add regression tests for quoted Windows paths, malformed commands, Vim detection, bounded cleanup retries, and combined error reporting.

## Why

The previous `split_whitespace` parser broke valid editor paths and arguments containing spaces or quotes. The Vim view also used predictable temporary paths and did not consistently preserve cleanup failures, which could leave sensitive copied session content behind after an error.

This keeps editor launching shell-free while making command parsing correct for each supported platform and making temporary-content cleanup explicit and testable.

## Scope and impact

- Focused on editor command parsing and the Vim copy view.
- Invalid configured commands now return a configuration error instead of silently falling back.
- No TUI lifecycle or rendering changes are included; the Windows TUI work is intentionally submitted as a separate, independent PR: #33.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --locked` (413 tests passed)
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `git diff --check upstream/main...HEAD`
