### PR TITLE
fix(tui): harden Windows lifecycle and ConPTY rendering

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,6 +52,10 @@ jobs:
           cargo run --quiet -- --version
           cargo run --quiet -- doctor
 
+      - name: Windows ConPTY TUI smoke
+        if: runner.os == 'Windows'
+        run: cargo test --locked tui::conpty_tests::windows_conpty_tui_smoke -- --ignored --exact
+
   audit:
     name: Dependency audit
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,8 @@ tempfile = "3"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["fileapi", "handleapi", "processenv", "processthreadsapi", "winbase", "winnt", "winuser", "windef", "minwindef"] }
+winapi = { version = "0.3", features = ["consoleapi", "fileapi", "handleapi", "namedpipeapi", "processenv", "processthreadsapi", "synchapi", "winbase", "wincon", "winerror", "winnt", "winuser", "windef", "minwindef"] }
+
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
 dhat = "0.3"

--- a/src/commands/browse/help.rs
+++ b/src/commands/browse/help.rs
@@ -203,7 +203,13 @@ pub(super) fn apply_workspace_help_action(
                 *content_mode,
                 content_at,
             ));
-            suspend(terminal, || open_vim_view(&view))??;
+            // A failed editor launch must not kill the picker: report it and keep running.
+            suspend(terminal, || {
+                if let Err(error) = open_vim_view(&view) {
+                    eprintln!("sivtr: editor error: {error}");
+                }
+                Ok(())
+            })??;
         }
         WorkspaceHelpAction::ScrollDown if *focus == WorkspaceFocus::Content => {
             content_scrolls.set(

--- a/src/commands/browse/help.rs
+++ b/src/commands/browse/help.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use ratatui::widgets::ListState;
 
 use crate::tui::content::view::ContentViewMode;
-use crate::tui::terminal::{init as init_tui, restore as restore_tui};
+use crate::tui::terminal::with_suspended;
 use crate::tui::workspace::{
     can_open_dialogue_vim, selected_index, workspace_content_io_texts, workspace_content_text,
     workspace_layout, ContentIoFocus, ContentIoFrame, ContentScrolls, WorkspaceDialogue,
@@ -203,9 +203,7 @@ pub(super) fn apply_workspace_help_action(
                 *content_mode,
                 content_at,
             ));
-            restore_tui(terminal)?;
-            open_vim_view(&view)?;
-            *terminal = init_tui()?;
+            with_suspended(terminal, || open_vim_view(&view))??;
         }
         WorkspaceHelpAction::ScrollDown if *focus == WorkspaceFocus::Content => {
             content_scrolls.set(

--- a/src/commands/browse/help.rs
+++ b/src/commands/browse/help.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use ratatui::widgets::ListState;
 
 use crate::tui::content::view::ContentViewMode;
-use crate::tui::terminal::with_suspended;
+use crate::tui::terminal::suspend;
 use crate::tui::workspace::{
     can_open_dialogue_vim, selected_index, workspace_content_io_texts, workspace_content_text,
     workspace_layout, ContentIoFocus, ContentIoFrame, ContentScrolls, WorkspaceDialogue,
@@ -203,7 +203,7 @@ pub(super) fn apply_workspace_help_action(
                 *content_mode,
                 content_at,
             ));
-            with_suspended(terminal, || open_vim_view(&view))??;
+            suspend(terminal, || open_vim_view(&view))??;
         }
         WorkspaceHelpAction::ScrollDown if *focus == WorkspaceFocus::Content => {
             content_scrolls.set(

--- a/src/commands/browse/mod.rs
+++ b/src/commands/browse/mod.rs
@@ -26,7 +26,7 @@ pub(crate) use text::{filter_lines_by_spec, record_text_to_pair, select_lines};
 use anyhow::{Context, Result};
 use sivtr_core::ai::AgentProvider;
 
-use crate::tui::terminal::{init as init_tui, restore as restore_tui};
+use crate::tui::terminal::{finish as finish_tui, init as init_tui};
 use crate::tui::workspace::{WorkspaceFocus, WorkspacePickedContent, WorkspaceSource};
 
 /// Run the workspace browser.
@@ -60,8 +60,7 @@ pub fn run(
         cwd,
         initial_focus,
     );
-    restore_tui(&mut terminal)?;
-    result
+    finish_tui(&mut terminal, result)
 }
 
 /// Open the picker on an already-built session list for one source.
@@ -81,8 +80,7 @@ pub fn run_with_sessions(
         cwd,
         initial_focus,
     );
-    restore_tui(&mut terminal)?;
-    result
+    finish_tui(&mut terminal, result)
 }
 
 /// Shared cancel sentinel for picker Esc/q.

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -9,6 +9,7 @@ use crate::tui::content::view::{content_link_at, ContentViewMode};
 use crate::tui::search::{
     workspace_search_has_query, workspace_search_scope, WorkspaceSearchIndex, WorkspaceSearchOutput,
 };
+use crate::tui::terminal::read_interaction;
 use crate::tui::workspace::{
     help_action_for_key, panel_inner_rows, render_workspace, search_match_half, selected_index,
     workspace_help_entries, workspace_hit_test, workspace_layout, ContentIoFocus, ContentIoFrame,
@@ -367,10 +368,16 @@ pub(crate) fn run(
             }
             continue;
         }
-        match event::read()? {
+        match read_interaction()? {
             Event::Key(key) => {
                 if key.kind != KeyEventKind::Press {
                     continue;
+                }
+
+                // Raw mode swallows Ctrl+C; without this the picker is unkillable by terminal
+                // control sequences and requires an external kill.
+                if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+                    anyhow::bail!(PICK_CANCELLED_MESSAGE);
                 }
 
                 if let Some(mode) = visual_select_mode.as_mut() {

--- a/src/tui/conpty_tests.rs
+++ b/src/tui/conpty_tests.rs
@@ -1,0 +1,980 @@
+//! Real Windows pseudo-console coverage for the terminal lifecycle.
+//!
+//! This module deliberately stays outside `terminal.rs`: the smoke test needs a sizeable amount
+//! of Win32 setup code, but none of it is part of the production implementation. The parent test
+//! creates a ConPTY and launches this same test executable inside it. A small child test then
+//! exercises the real crossterm/Ratatui path.
+
+use std::{
+    ffi::{c_void, OsStr, OsString},
+    fs::File,
+    io::{self, Read, Write},
+    mem::{self, size_of},
+    os::windows::{
+        ffi::OsStrExt,
+        io::{FromRawHandle, RawHandle},
+    },
+    ptr,
+    sync::mpsc::{self, Receiver, RecvTimeoutError},
+    thread::{self, JoinHandle},
+    time::{Duration, Instant},
+};
+
+use anyhow::{anyhow, bail, Context, Result};
+use crossterm::event::{Event, KeyCode, KeyEventKind};
+use ratatui::layout::Rect;
+use ratatui::widgets::{Block, Borders, Paragraph};
+use winapi::{
+    shared::{
+        minwindef::{DWORD, FALSE},
+        ntdef::HRESULT,
+        winerror::WAIT_TIMEOUT,
+    },
+    um::{
+        consoleapi::{
+            ClosePseudoConsole, CreatePseudoConsole, GetConsoleMode, GetConsoleOutputCP,
+            ResizePseudoConsole,
+        },
+        fileapi::{CreateFileW, OPEN_EXISTING},
+        handleapi::{CloseHandle, INVALID_HANDLE_VALUE},
+        namedpipeapi::CreatePipe,
+        processenv::{GetStdHandle, SetStdHandle},
+        processthreadsapi::{
+            CreateProcessW, DeleteProcThreadAttributeList, GetExitCodeProcess,
+            InitializeProcThreadAttributeList, TerminateProcess, UpdateProcThreadAttribute,
+            LPPROC_THREAD_ATTRIBUTE_LIST, PROCESS_INFORMATION,
+        },
+        synchapi::WaitForSingleObject,
+        winbase::{
+            CREATE_UNICODE_ENVIRONMENT, EXTENDED_STARTUPINFO_PRESENT, STARTUPINFOEXW,
+            STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, WAIT_FAILED, WAIT_OBJECT_0,
+        },
+        wincon::ReadConsoleOutputCharacterW,
+        wincontypes::{COORD, HPCON},
+        winnt::{
+            FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE,
+            HANDLE,
+        },
+    },
+};
+
+use super::terminal::{self, read_interaction};
+
+const CHILD_ENV: &str = "SIVTR_CONPTY_SMOKE_CHILD";
+const CHILD_TEST: &str = "tui::conpty_tests::conpty_child_entry";
+const STARTED_MARKER: &[u8] = b"SIVTR_CONPTY_CHILD_STARTED";
+const READY_MARKER: &[u8] = b"SIVTR_CONPTY_READY";
+const RESIZED_MARKER: &[u8] = b"SIVTR_CONPTY_RESIZED";
+const SUSPENDED_SUCCESS_MARKER: &[u8] = b"SIVTR_CONPTY_SUSPENDED_SUCCESS";
+const SUSPENDED_ERROR_MARKER: &[u8] = b"SIVTR_CONPTY_SUSPENDED_ERROR";
+const WIDE_CLEARED_MARKER: &[u8] = b"SIVTR_CONPTY_WIDE_CLEARED";
+const RESTORED_MARKER: &[u8] = b"SIVTR_CONPTY_RESTORED";
+const INITIAL_SIZE: COORD = COORD { X: 80, Y: 25 };
+const RESIZED_SIZE: COORD = COORD { X: 100, Y: 30 };
+const WIDE_TEXT_COORD: COORD = COORD { X: 2, Y: 2 };
+const RESUME_TEXT_COORD: COORD = COORD { X: 2, Y: 4 };
+const START_TIMEOUT: Duration = Duration::from_secs(15);
+const RESIZE_TIMEOUT: Duration = Duration::from_secs(10);
+const EXIT_TIMEOUT: Duration = Duration::from_secs(10);
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+// ProcThreadAttributeValue(ProcThreadAttributePseudoConsole = 22, FALSE, TRUE, FALSE).
+const PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE: usize = 0x0002_0016;
+
+/// Run explicitly with:
+///
+/// `cargo test --locked tui::conpty_tests::windows_conpty_tui_smoke -- --ignored --exact --nocapture`
+#[test]
+#[ignore = "requires a Windows 10+ ConPTY host and launches a real pseudo-terminal"]
+fn windows_conpty_tui_smoke() {
+    if let Err(error) = run_parent_smoke() {
+        panic!("Windows ConPTY TUI smoke failed: {error:#}");
+    }
+}
+
+/// This is a normal (non-ignored) test so the parent can select it without also selecting every
+/// ignored test. It is intentionally a no-op unless the parent supplies a private environment
+/// marker in the child's environment block.
+#[test]
+fn conpty_child_entry() {
+    if std::env::var_os(CHILD_ENV).is_none() {
+        return;
+    }
+    if let Err(error) = run_child_smoke() {
+        panic!("ConPTY child failed: {error:#}");
+    }
+}
+
+fn run_parent_smoke() -> Result<()> {
+    let (pty_input, parent_input) = create_pipe().context("create ConPTY input pipe")?;
+    let (parent_output, pty_output) = create_pipe().context("create ConPTY output pipe")?;
+    let mut pseudoconsole = PseudoConsole::create(INITIAL_SIZE, &pty_input, &pty_output)?;
+
+    // Once CreatePseudoConsole succeeds, ConPTY owns duplicates of these two endpoints. Closing
+    // our copies is essential: retaining the output endpoint would prevent the reader seeing EOF.
+    drop(pty_input);
+    drop(pty_output);
+
+    let mut input = unsafe { File::from_raw_handle(parent_input.into_raw_handle()) };
+    let output = unsafe { File::from_raw_handle(parent_output.into_raw_handle()) };
+    let (reader, receiver) = OutputReader::spawn(output)?;
+    let mut captured = Vec::new();
+
+    let executable = std::env::current_exe().context("resolve the current test executable")?;
+    let arguments = [
+        executable.as_os_str(),
+        OsStr::new("--exact"),
+        OsStr::new(CHILD_TEST),
+        OsStr::new("--nocapture"),
+        OsStr::new("--test-threads=1"),
+    ];
+    let environment = child_environment_block()?;
+    let mut process = pseudoconsole.spawn(executable.as_os_str(), &arguments, &environment)?;
+
+    receive_until(&receiver, &mut captured, READY_MARKER, START_TIMEOUT).with_context(|| {
+        format!(
+            "child did not become ready; output: {}",
+            output_excerpt(&captured)
+        )
+    })?;
+
+    pseudoconsole.resize(RESIZED_SIZE)?;
+    receive_until(&receiver, &mut captured, RESIZED_MARKER, RESIZE_TIMEOUT).with_context(|| {
+        format!(
+            "child did not handle the pseudo-console resize; output: {}",
+            output_excerpt(&captured)
+        )
+    })?;
+
+    input.write_all(b"q").context("send q to ConPTY input")?;
+    input.flush().context("flush ConPTY input")?;
+    let exit_code = process.wait(EXIT_TIMEOUT).with_context(|| {
+        format!(
+            "child did not exit after q; output: {}",
+            output_excerpt(&captured)
+        )
+    })?;
+
+    drop(input);
+    drop(pseudoconsole);
+    receive_to_eof(&receiver, &mut captured, DRAIN_TIMEOUT)?;
+    reader.join()?;
+
+    if exit_code != 0 {
+        bail!(
+            "child exited with code {exit_code}; output: {}",
+            output_excerpt(&captured)
+        );
+    }
+
+    assert_output(&captured, "涓枃", "UTF-8 CJK frame content")?;
+    assert_output(&captured, "馃榾", "UTF-8 emoji frame content")?;
+    assert_bytes(&captured, RESIZED_MARKER, "resize handling marker")?;
+    assert_bytes(
+        &captured,
+        SUSPENDED_SUCCESS_MARKER,
+        "successful suspend marker",
+    )?;
+    assert_bytes(
+        &captured,
+        SUSPENDED_ERROR_MARKER,
+        "failing operation suspend marker",
+    )?;
+    assert_bytes(
+        &captured,
+        WIDE_CLEARED_MARKER,
+        "wide-character tail cleanup marker",
+    )?;
+    assert_bytes(&captured, RESTORED_MARKER, "terminal restoration marker")?;
+    // ConPTY consumes alternate-screen and mouse-mode commands and emits their resulting buffer
+    // changes, so their original bytes are not a stable observable contract. Cursor restoration
+    // and synchronized-update commands remain visible in the output stream.
+    assert_bytes(&captured, b"\x1b[?25h", "cursor-show cleanup sequence")?;
+    assert_balanced_sequences(
+        &captured,
+        b"\x1b[?2026h",
+        b"\x1b[?2026l",
+        "synchronized terminal updates",
+    )?;
+
+    Ok(())
+}
+
+fn run_child_smoke() -> Result<()> {
+    let bindings = ChildConsoleBindings::install()?;
+    child_marker(STARTED_MARKER)?;
+    let before = ConsoleSnapshot::capture(bindings.pipe_input_handle())?;
+    let mut tui = terminal::init().context("initialize TUI inside ConPTY")?;
+
+    let operation = (|| -> Result<()> {
+        terminal::draw(&mut tui, |frame| {
+            frame.render_widget(
+                Paragraph::new("Windows ConPTY smoke 涓枃 馃榾")
+                    .block(Block::default().borders(Borders::ALL).title("sivtr")),
+                frame.area(),
+            );
+            frame.render_widget(
+                Paragraph::new("\u{754c}"),
+                Rect::new(WIDE_TEXT_COORD.X as u16, WIDE_TEXT_COORD.Y as u16, 2, 1),
+            );
+        })?;
+
+        // Replace a double-width glyph with a single-width one in the same two-cell area. Reading
+        // the real console buffer catches a stale trailing cell instead of merely proving that the
+        // UTF-8 bytes passed through ConPTY.
+        terminal::draw(&mut tui, |frame| {
+            frame.render_widget(
+                Paragraph::new("X"),
+                Rect::new(WIDE_TEXT_COORD.X as u16, WIDE_TEXT_COORD.Y as u16, 2, 1),
+            );
+        })?;
+        assert_console_text_at(bindings.console_output_handle(), WIDE_TEXT_COORD, "X ")
+            .context("verify that the wide-character trailing cell was cleared")?;
+        child_marker(WIDE_CLEARED_MARKER)?;
+
+        let suspended = terminal::with_suspended(&mut tui, || {
+            assert_console_snapshot(&before, bindings.pipe_input_handle(), "successful suspend")?;
+            Ok(())
+        })?;
+        suspended?;
+        terminal::draw(&mut tui, |frame| {
+            frame.render_widget(
+                Paragraph::new("S"),
+                Rect::new(RESUME_TEXT_COORD.X as u16, RESUME_TEXT_COORD.Y as u16, 1, 1),
+            );
+        })?;
+        assert_console_text_at(bindings.console_output_handle(), RESUME_TEXT_COORD, "S")
+            .context("verify redraw after a successful suspended operation")?;
+
+        let suspended_error = terminal::with_suspended(&mut tui, || -> Result<()> {
+            assert_console_snapshot(
+                &before,
+                bindings.pipe_input_handle(),
+                "failing operation suspend",
+            )?;
+            bail!("expected suspended operation failure")
+        })?;
+        let error = suspended_error.expect_err("the suspended operation should fail");
+        if !error
+            .to_string()
+            .contains("expected suspended operation failure")
+        {
+            bail!("with_suspended lost the operation error: {error:#}");
+        }
+        terminal::draw(&mut tui, |frame| {
+            frame.render_widget(
+                Paragraph::new("E"),
+                Rect::new(RESUME_TEXT_COORD.X as u16, RESUME_TEXT_COORD.Y as u16, 1, 1),
+            );
+        })?;
+        assert_console_text_at(bindings.console_output_handle(), RESUME_TEXT_COORD, "E")
+            .context("verify redraw after a failing suspended operation")?;
+        // Emit both markers only after both suspend/resume cycles. A later alternate-screen switch
+        // can otherwise coalesce away text written to the preceding screen before the parent sees
+        // it, even though the child-side state and redraw assertions succeeded.
+        child_marker(SUSPENDED_SUCCESS_MARKER)?;
+        child_marker(SUSPENDED_ERROR_MARKER)?;
+        child_marker(READY_MARKER)?;
+
+        loop {
+            match read_interaction()? {
+                Event::Resize(width, height)
+                    if width == RESIZED_SIZE.X as u16 && height == RESIZED_SIZE.Y as u16 =>
+                {
+                    terminal::draw(&mut tui, |frame| {
+                        frame.render_widget(
+                            Paragraph::new(format!(
+                                "Windows ConPTY resized to {width}x{height} 涓枃 馃榾"
+                            ))
+                            .block(Block::default().borders(Borders::ALL).title("sivtr")),
+                            frame.area(),
+                        );
+                    })?;
+                    child_marker(RESIZED_MARKER)?;
+                }
+                Event::Key(key)
+                    if key.kind == KeyEventKind::Press && key.code == KeyCode::Char('q') =>
+                {
+                    break;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    })();
+
+    terminal::finish(&mut tui, operation)?;
+    let after = ConsoleSnapshot::capture(bindings.pipe_input_handle())?;
+    if before != after {
+        bail!("console state was not restored exactly: before={before:?}, after={after:?}");
+    }
+    child_marker(RESTORED_MARKER)?;
+    Ok(())
+}
+
+fn assert_console_snapshot(
+    expected: &ConsoleSnapshot,
+    expected_standard_input: HANDLE,
+    operation: &str,
+) -> Result<()> {
+    let actual = ConsoleSnapshot::capture(expected_standard_input)?;
+    if &actual == expected {
+        Ok(())
+    } else {
+        bail!(
+            "console state was not restored during {operation}: expected={expected:?}, actual={actual:?}"
+        )
+    }
+}
+
+fn assert_console_text_at(handle: HANDLE, coordinate: COORD, expected: &str) -> Result<()> {
+    let expected = expected.encode_utf16().collect::<Vec<_>>();
+    let mut actual = vec![0; expected.len()];
+    let mut read = 0;
+    if unsafe {
+        ReadConsoleOutputCharacterW(
+            handle,
+            actual.as_mut_ptr(),
+            actual.len() as DWORD,
+            coordinate,
+            &mut read,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error()).context("ReadConsoleOutputCharacterW failed");
+    }
+    actual.truncate(read as usize);
+    if actual == expected {
+        Ok(())
+    } else {
+        bail!(
+            "unexpected console text at ({}, {}): expected {:?}, actual {:?}",
+            coordinate.X,
+            coordinate.Y,
+            String::from_utf16_lossy(&expected),
+            String::from_utf16_lossy(&actual)
+        )
+    }
+}
+
+fn child_marker(marker: &[u8]) -> Result<()> {
+    let mut stderr = io::stderr().lock();
+    stderr.write_all(b"\r\n")?;
+    stderr.write_all(marker)?;
+    stderr.write_all(b"\r\n")?;
+    stderr.flush()?;
+    Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ConsoleSnapshot {
+    input_mode: DWORD,
+    output_mode: DWORD,
+    output_code_page: DWORD,
+}
+
+impl ConsoleSnapshot {
+    fn capture(expected_standard_input: HANDLE) -> Result<Self> {
+        let input = unsafe { GetStdHandle(STD_INPUT_HANDLE) };
+        let output = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) };
+        if input != expected_standard_input {
+            bail!(
+                "terminal did not preserve the test's piped stdin handle: expected {expected_standard_input:p}, got {input:p}"
+            );
+        }
+        if !valid_handle(output) {
+            bail!("ConPTY child has an invalid standard output handle");
+        }
+
+        let console_input = open_console_handle("CONIN$", GENERIC_READ | GENERIC_WRITE)?;
+        let mut input_mode = 0;
+        let mut output_mode = 0;
+        if unsafe { GetConsoleMode(console_input.as_raw(), &mut input_mode) } == 0 {
+            return Err(io::Error::last_os_error()).context("read initial console input mode");
+        }
+        if unsafe { GetConsoleMode(output, &mut output_mode) } == 0 {
+            return Err(io::Error::last_os_error()).context("read initial console output mode");
+        }
+
+        Ok(Self {
+            input_mode,
+            output_mode,
+            output_code_page: unsafe { GetConsoleOutputCP() },
+        })
+    }
+}
+
+struct OwnedHandle(HANDLE);
+
+impl OwnedHandle {
+    fn new(handle: HANDLE) -> Result<Self> {
+        if !valid_handle(handle) {
+            Err(io::Error::last_os_error()).context("Win32 returned an invalid handle")
+        } else {
+            Ok(Self(handle))
+        }
+    }
+
+    fn as_raw(&self) -> HANDLE {
+        self.0
+    }
+
+    fn into_raw_handle(mut self) -> RawHandle {
+        let handle = self.0;
+        self.0 = ptr::null_mut();
+        handle.cast()
+    }
+}
+
+impl Drop for OwnedHandle {
+    fn drop(&mut self) {
+        if valid_handle(self.0) {
+            unsafe {
+                CloseHandle(self.0);
+            }
+        }
+    }
+}
+
+fn valid_handle(handle: HANDLE) -> bool {
+    !handle.is_null() && handle != INVALID_HANDLE_VALUE
+}
+
+fn create_pipe() -> Result<(OwnedHandle, OwnedHandle)> {
+    let mut read = ptr::null_mut();
+    let mut write = ptr::null_mut();
+    if unsafe { CreatePipe(&mut read, &mut write, ptr::null_mut(), 0) } == 0 {
+        return Err(io::Error::last_os_error()).context("CreatePipe failed");
+    }
+    // Both handles are valid together after a successful CreatePipe call.
+    Ok((OwnedHandle::new(read)?, OwnedHandle::new(write)?))
+}
+
+fn open_console_handle(name: &str, access: DWORD) -> Result<OwnedHandle> {
+    let name = OsStr::new(name)
+        .encode_wide()
+        .chain(Some(0))
+        .collect::<Vec<_>>();
+    let handle = unsafe {
+        CreateFileW(
+            name.as_ptr(),
+            access,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            ptr::null_mut(),
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            ptr::null_mut(),
+        )
+    };
+    OwnedHandle::new(handle).with_context(|| format!("open {name:?}"))
+}
+
+/// Test-only standard handle bindings. The child test runner may itself have inherited pipe
+/// handles from `cargo test`, even though it is attached to the new pseudo-console. Bind output to
+/// `CONOUT$` and deliberately bind input to a pipe so production `terminal::init` must exercise
+/// its `CONIN$` fallback. Drop restores the test runner's original handles before closing ours.
+struct ChildConsoleBindings {
+    original_input: HANDLE,
+    original_output: HANDLE,
+    original_error: HANDLE,
+    pipe_input: OwnedHandle,
+    _pipe_writer: OwnedHandle,
+    _console_output: OwnedHandle,
+    input_bound: bool,
+    output_bound: bool,
+    error_bound: bool,
+}
+
+impl ChildConsoleBindings {
+    fn install() -> Result<Self> {
+        let (pipe_input, pipe_writer) = create_pipe().context("create child stdin pipe")?;
+        let console_output = open_console_handle("CONOUT$", GENERIC_READ | GENERIC_WRITE)
+            .context("bind child output to ConPTY")?;
+        let mut bindings = Self {
+            original_input: unsafe { GetStdHandle(STD_INPUT_HANDLE) },
+            original_output: unsafe { GetStdHandle(STD_OUTPUT_HANDLE) },
+            original_error: unsafe { GetStdHandle(STD_ERROR_HANDLE) },
+            pipe_input,
+            _pipe_writer: pipe_writer,
+            _console_output: console_output,
+            input_bound: false,
+            output_bound: false,
+            error_bound: false,
+        };
+
+        bindings.set(
+            STD_INPUT_HANDLE,
+            bindings.pipe_input.as_raw(),
+            "piped stdin",
+        )?;
+        bindings.input_bound = true;
+        bindings.set(
+            STD_OUTPUT_HANDLE,
+            bindings._console_output.as_raw(),
+            "ConPTY stdout",
+        )?;
+        bindings.output_bound = true;
+        bindings.set(
+            STD_ERROR_HANDLE,
+            bindings._console_output.as_raw(),
+            "ConPTY stderr",
+        )?;
+        bindings.error_bound = true;
+        Ok(bindings)
+    }
+
+    fn set(&self, kind: DWORD, handle: HANDLE, description: &str) -> Result<()> {
+        if unsafe { SetStdHandle(kind, handle) } == 0 {
+            Err(io::Error::last_os_error()).with_context(|| format!("set test child {description}"))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn pipe_input_handle(&self) -> HANDLE {
+        self.pipe_input.as_raw()
+    }
+
+    fn console_output_handle(&self) -> HANDLE {
+        self._console_output.as_raw()
+    }
+}
+
+impl Drop for ChildConsoleBindings {
+    fn drop(&mut self) {
+        unsafe {
+            if self.error_bound {
+                SetStdHandle(STD_ERROR_HANDLE, self.original_error);
+                self.error_bound = false;
+            }
+            if self.output_bound {
+                SetStdHandle(STD_OUTPUT_HANDLE, self.original_output);
+                self.output_bound = false;
+            }
+            if self.input_bound {
+                SetStdHandle(STD_INPUT_HANDLE, self.original_input);
+                self.input_bound = false;
+            }
+        }
+    }
+}
+
+struct PseudoConsole(HPCON);
+
+impl PseudoConsole {
+    fn create(size: COORD, input: &OwnedHandle, output: &OwnedHandle) -> Result<Self> {
+        let mut handle = ptr::null_mut();
+        let result =
+            unsafe { CreatePseudoConsole(size, input.as_raw(), output.as_raw(), 0, &mut handle) };
+        hresult(result, "CreatePseudoConsole")?;
+        if handle.is_null() {
+            bail!("CreatePseudoConsole succeeded without returning a handle");
+        }
+        Ok(Self(handle))
+    }
+
+    fn resize(&mut self, size: COORD) -> Result<()> {
+        hresult(
+            unsafe { ResizePseudoConsole(self.0, size) },
+            "ResizePseudoConsole",
+        )
+    }
+
+    fn spawn(
+        &self,
+        executable: &OsStr,
+        arguments: &[&OsStr],
+        environment: &[u16],
+    ) -> Result<ChildProcess> {
+        let mut attributes = AttributeList::new()?;
+        attributes.set_pseudoconsole(self.0)?;
+
+        let mut application = executable.encode_wide().chain(Some(0)).collect::<Vec<_>>();
+        let mut command_line = windows_command_line(arguments);
+        let mut startup: STARTUPINFOEXW = unsafe { mem::zeroed() };
+        startup.StartupInfo.cb = size_of::<STARTUPINFOEXW>() as DWORD;
+        startup.lpAttributeList = attributes.as_mut_ptr();
+        let mut information: PROCESS_INFORMATION = unsafe { mem::zeroed() };
+
+        let created = unsafe {
+            CreateProcessW(
+                application.as_mut_ptr(),
+                command_line.as_mut_ptr(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+                FALSE,
+                EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
+                environment.as_ptr().cast::<c_void>() as *mut c_void,
+                ptr::null(),
+                &mut startup.StartupInfo,
+                &mut information,
+            )
+        };
+        if created == 0 {
+            return Err(io::Error::last_os_error()).context("CreateProcessW inside ConPTY failed");
+        }
+
+        let process = OwnedHandle::new(information.hProcess)?;
+        let thread = OwnedHandle::new(information.hThread)?;
+        drop(thread);
+        Ok(ChildProcess {
+            process,
+            exited: false,
+        })
+    }
+}
+
+impl Drop for PseudoConsole {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe {
+                ClosePseudoConsole(self.0);
+            }
+            self.0 = ptr::null_mut();
+        }
+    }
+}
+
+fn hresult(result: HRESULT, operation: &str) -> Result<()> {
+    if result >= 0 {
+        Ok(())
+    } else {
+        bail!("{operation} failed with HRESULT 0x{:08X}", result as u32)
+    }
+}
+
+struct AttributeList {
+    // usize gives the opaque Win32 structure pointer alignment without requiring another heap API.
+    storage: Vec<usize>,
+    initialized: bool,
+}
+
+impl AttributeList {
+    fn new() -> Result<Self> {
+        let mut bytes = 0;
+        unsafe {
+            InitializeProcThreadAttributeList(ptr::null_mut(), 1, 0, &mut bytes);
+        }
+        if bytes == 0 {
+            return Err(io::Error::last_os_error())
+                .context("query process thread attribute list size");
+        }
+
+        let words = bytes.div_ceil(size_of::<usize>());
+        let mut list = Self {
+            storage: vec![0; words],
+            initialized: false,
+        };
+        if unsafe { InitializeProcThreadAttributeList(list.as_mut_ptr(), 1, 0, &mut bytes) } == 0 {
+            return Err(io::Error::last_os_error())
+                .context("initialize process thread attribute list");
+        }
+        list.initialized = true;
+        Ok(list)
+    }
+
+    fn as_mut_ptr(&mut self) -> LPPROC_THREAD_ATTRIBUTE_LIST {
+        self.storage.as_mut_ptr().cast()
+    }
+
+    fn set_pseudoconsole(&mut self, pseudoconsole: HPCON) -> Result<()> {
+        let result = unsafe {
+            UpdateProcThreadAttribute(
+                self.as_mut_ptr(),
+                0,
+                PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
+                pseudoconsole.cast(),
+                size_of::<HPCON>(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+            )
+        };
+        if result == 0 {
+            Err(io::Error::last_os_error()).context("attach ConPTY process attribute")
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Drop for AttributeList {
+    fn drop(&mut self) {
+        if self.initialized {
+            unsafe {
+                DeleteProcThreadAttributeList(self.as_mut_ptr());
+            }
+            self.initialized = false;
+        }
+    }
+}
+
+struct ChildProcess {
+    process: OwnedHandle,
+    exited: bool,
+}
+
+impl ChildProcess {
+    fn wait(&mut self, timeout: Duration) -> Result<DWORD> {
+        let timeout_ms = timeout.as_millis().min((u32::MAX - 1) as u128) as DWORD;
+        match unsafe { WaitForSingleObject(self.process.as_raw(), timeout_ms) } {
+            WAIT_OBJECT_0 => {
+                let mut code = 0;
+                if unsafe { GetExitCodeProcess(self.process.as_raw(), &mut code) } == 0 {
+                    return Err(io::Error::last_os_error()).context("read ConPTY child exit code");
+                }
+                self.exited = true;
+                Ok(code)
+            }
+            WAIT_TIMEOUT => bail!("timed out waiting for ConPTY child after {timeout:?}"),
+            WAIT_FAILED => Err(io::Error::last_os_error()).context("wait for ConPTY child"),
+            status => bail!("unexpected WaitForSingleObject status {status}"),
+        }
+    }
+}
+
+impl Drop for ChildProcess {
+    fn drop(&mut self) {
+        if !self.exited {
+            unsafe {
+                TerminateProcess(self.process.as_raw(), 1);
+                WaitForSingleObject(self.process.as_raw(), 2_000);
+            }
+        }
+    }
+}
+
+enum ReaderMessage {
+    Bytes(Vec<u8>),
+    Eof,
+    Error(io::Error),
+}
+
+struct OutputReader(Option<JoinHandle<()>>);
+
+impl OutputReader {
+    fn spawn(mut output: File) -> Result<(Self, Receiver<ReaderMessage>)> {
+        let (sender, receiver) = mpsc::channel();
+        let handle = thread::Builder::new()
+            .name("sivtr-conpty-output".into())
+            .spawn(move || {
+                let mut buffer = [0; 4096];
+                loop {
+                    match output.read(&mut buffer) {
+                        Ok(0) => {
+                            let _ = sender.send(ReaderMessage::Eof);
+                            break;
+                        }
+                        Ok(count) => {
+                            if sender
+                                .send(ReaderMessage::Bytes(buffer[..count].to_vec()))
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Err(error) => {
+                            let _ = sender.send(ReaderMessage::Error(error));
+                            break;
+                        }
+                    }
+                }
+            })
+            .context("spawn ConPTY output reader")?;
+        Ok((Self(Some(handle)), receiver))
+    }
+
+    fn join(mut self) -> Result<()> {
+        if let Some(handle) = self.0.take() {
+            handle
+                .join()
+                .map_err(|_| anyhow!("ConPTY output reader panicked"))?;
+        }
+        Ok(())
+    }
+}
+
+fn receive_until(
+    receiver: &Receiver<ReaderMessage>,
+    captured: &mut Vec<u8>,
+    marker: &[u8],
+    timeout: Duration,
+) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    while !contains_bytes(captured, marker) {
+        if !receive_one(receiver, captured, deadline)? {
+            bail!(
+                "ConPTY output reached EOF before marker {}",
+                String::from_utf8_lossy(marker)
+            );
+        }
+    }
+    Ok(())
+}
+
+fn receive_to_eof(
+    receiver: &Receiver<ReaderMessage>,
+    captured: &mut Vec<u8>,
+    timeout: Duration,
+) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match receive_one(receiver, captured, deadline) {
+            Ok(false) => return Ok(()),
+            Ok(true) => {}
+            Err(error) => return Err(error).context("drain ConPTY output"),
+        }
+    }
+}
+
+/// Returns false after EOF and true after receiving bytes.
+fn receive_one(
+    receiver: &Receiver<ReaderMessage>,
+    captured: &mut Vec<u8>,
+    deadline: Instant,
+) -> Result<bool> {
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if remaining.is_zero() {
+        bail!("timed out waiting for ConPTY output");
+    }
+    match receiver.recv_timeout(remaining) {
+        Ok(ReaderMessage::Bytes(bytes)) => {
+            captured.extend_from_slice(&bytes);
+            Ok(true)
+        }
+        Ok(ReaderMessage::Eof) => Ok(false),
+        Ok(ReaderMessage::Error(error)) => Err(error).context("read ConPTY output"),
+        Err(RecvTimeoutError::Timeout) => bail!("timed out waiting for ConPTY output"),
+        Err(RecvTimeoutError::Disconnected) => bail!("ConPTY output reader disconnected"),
+    }
+}
+
+fn assert_output(captured: &[u8], expected: &str, description: &str) -> Result<()> {
+    let output =
+        String::from_utf8(captured.to_vec()).context("ConPTY output was not valid UTF-8")?;
+    if output.contains(expected) {
+        Ok(())
+    } else {
+        bail!(
+            "missing {description}; output: {}",
+            output_excerpt(captured)
+        )
+    }
+}
+
+fn assert_bytes(captured: &[u8], expected: &[u8], description: &str) -> Result<()> {
+    if contains_bytes(captured, expected) {
+        Ok(())
+    } else {
+        bail!(
+            "missing {description}; output: {}",
+            output_excerpt(captured)
+        )
+    }
+}
+
+fn assert_balanced_sequences(
+    captured: &[u8],
+    begin: &[u8],
+    end: &[u8],
+    description: &str,
+) -> Result<()> {
+    let begin_count = count_bytes(captured, begin);
+    let end_count = count_bytes(captured, end);
+    if begin_count > 0 && begin_count == end_count {
+        Ok(())
+    } else {
+        bail!(
+            "unbalanced {description}: begin={begin_count}, end={end_count}; output: {}",
+            output_excerpt(captured)
+        )
+    }
+}
+
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+    !needle.is_empty()
+        && haystack
+            .windows(needle.len())
+            .any(|window| window == needle)
+}
+
+fn count_bytes(haystack: &[u8], needle: &[u8]) -> usize {
+    if needle.is_empty() {
+        return 0;
+    }
+    haystack
+        .windows(needle.len())
+        .filter(|window| *window == needle)
+        .count()
+}
+
+fn output_excerpt(output: &[u8]) -> String {
+    const LIMIT: usize = 8 * 1024;
+    let start = output.len().saturating_sub(LIMIT);
+    String::from_utf8_lossy(&output[start..])
+        .escape_debug()
+        .to_string()
+}
+
+fn child_environment_block() -> Result<Vec<u16>> {
+    let mut variables = std::env::vars_os()
+        .filter(|(key, _)| !key.to_string_lossy().eq_ignore_ascii_case(CHILD_ENV))
+        .collect::<Vec<_>>();
+    variables.push((OsString::from(CHILD_ENV), OsString::from("1")));
+    variables.sort_by_cached_key(|(key, _)| key.to_string_lossy().to_uppercase());
+
+    let mut block = Vec::new();
+    for (key, value) in variables {
+        if key.is_empty() || key.to_string_lossy().contains('=') {
+            bail!("cannot encode invalid environment variable name {key:?}");
+        }
+        block.extend(key.encode_wide());
+        block.push('=' as u16);
+        block.extend(value.encode_wide());
+        block.push(0);
+    }
+    block.push(0);
+    Ok(block)
+}
+
+fn windows_command_line(arguments: &[&OsStr]) -> Vec<u16> {
+    let mut command = OsString::new();
+    for (index, argument) in arguments.iter().enumerate() {
+        if index > 0 {
+            command.push(" ");
+        }
+        command.push(quote_windows_argument(argument));
+    }
+    command.encode_wide().chain(Some(0)).collect()
+}
+
+fn quote_windows_argument(argument: &OsStr) -> OsString {
+    let text = argument.to_string_lossy();
+    if !text.is_empty()
+        && !text
+            .chars()
+            .any(|character| character.is_whitespace() || character == '"')
+    {
+        return argument.to_os_string();
+    }
+
+    let mut quoted = String::from("\"");
+    let mut backslashes = 0;
+    for character in text.chars() {
+        match character {
+            '\\' => backslashes += 1,
+            '"' => {
+                quoted.extend(std::iter::repeat_n('\\', backslashes * 2 + 1));
+                quoted.push('"');
+                backslashes = 0;
+            }
+            _ => {
+                quoted.extend(std::iter::repeat_n('\\', backslashes));
+                quoted.push(character);
+                backslashes = 0;
+            }
+        }
+    }
+    quoted.extend(std::iter::repeat_n('\\', backslashes * 2));
+    quoted.push('"');
+    OsString::from(quoted)
+}

--- a/src/tui/conpty_tests.rs
+++ b/src/tui/conpty_tests.rs
@@ -232,7 +232,7 @@ fn run_child_smoke() -> Result<()> {
             .context("verify that the wide-character trailing cell was cleared")?;
         child_marker(WIDE_CLEARED_MARKER)?;
 
-        let suspended = terminal::with_suspended(&mut tui, || {
+        let suspended = terminal::suspend(&mut tui, || {
             assert_console_snapshot(&before, bindings.pipe_input_handle(), "successful suspend")?;
             Ok(())
         })?;
@@ -246,7 +246,7 @@ fn run_child_smoke() -> Result<()> {
         assert_console_text_at(bindings.console_output_handle(), RESUME_TEXT_COORD, "S")
             .context("verify redraw after a successful suspended operation")?;
 
-        let suspended_error = terminal::with_suspended(&mut tui, || -> Result<()> {
+        let suspended_error = terminal::suspend(&mut tui, || -> Result<()> {
             assert_console_snapshot(
                 &before,
                 bindings.pipe_input_handle(),
@@ -259,7 +259,7 @@ fn run_child_smoke() -> Result<()> {
             .to_string()
             .contains("expected suspended operation failure")
         {
-            bail!("with_suspended lost the operation error: {error:#}");
+            bail!("suspend lost the operation error: {error:#}");
         }
         terminal::draw(&mut tui, |frame| {
             frame.render_widget(

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -10,3 +10,6 @@ pub mod search;
 pub mod terminal;
 pub mod theme;
 pub mod workspace;
+
+#[cfg(all(test, windows))]
+mod conpty_tests;

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -1,32 +1,1227 @@
-use anyhow::Result;
+use anyhow::{anyhow, bail, Context, Result};
+#[cfg(not(windows))]
+use crossterm::terminal::disable_raw_mode;
+#[cfg(windows)]
+use crossterm::terminal::{BeginSynchronizedUpdate, EndSynchronizedUpdate};
 use crossterm::{
-    event::{DisableMouseCapture, EnableMouseCapture},
+    cursor::Show,
+    event::{DisableMouseCapture, EnableMouseCapture, Event, MouseEvent, MouseEventKind},
     execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    terminal::{enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::prelude::*;
-use std::io::{self, Stdout};
+use ratatui::{buffer::CellDiffOption, prelude::*};
+use std::io::IsTerminal;
+use std::{
+    fmt::Display,
+    io::{self, Stdout},
+    mem,
+    ops::{Deref, DerefMut},
+};
+use unicode_width::UnicodeWidthStr;
 
-pub type Tui = Terminal<CrosstermBackend<Stdout>>;
+type InnerTui = Terminal<CrosstermBackend<Stdout>>;
+
+/// An active terminal session that restores terminal state when it is dropped.
+///
+/// Explicit restoration is used when errors can be reported. `Drop` is the final safety net for
+/// early returns, draw/event failures, and panics.
+pub struct Tui {
+    terminal: InnerTui,
+    drawing_active: bool,
+    state: TerminalState,
+    #[cfg(windows)]
+    previous_frame_had_wide_cells: bool,
+    #[cfg(windows)]
+    synchronized_updates_supported: bool,
+}
+
+impl Deref for Tui {
+    type Target = InnerTui;
+
+    fn deref(&self) -> &Self::Target {
+        &self.terminal
+    }
+}
+
+impl DerefMut for Tui {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.terminal
+    }
+}
+
+impl Drop for Tui {
+    fn drop(&mut self) {
+        if self.state.has_pending_cleanup() {
+            let _ = restore_terminal_state(&mut self.terminal, &mut self.state);
+        }
+        self.drawing_active = false;
+    }
+}
 
 /// Initialize the terminal for TUI rendering.
 pub fn init() -> Result<Tui> {
-    enable_raw_mode()?;
+    ensure_tui_stdout()?;
+
+    let mut setup = TerminalSetup::default();
+    match ConsoleInputHandle::ensure_console() {
+        Ok(input) => setup.state.console_input = input,
+        Err(error) => return setup.fail(error.context("Failed to acquire console input")),
+    }
+
+    match ConsoleCodePages::capture() {
+        Ok(code_pages) => setup.state.code_pages = code_pages,
+        Err(error) => return setup.fail(error),
+    }
+    if let Some(code_pages) = setup.state.code_pages.as_ref() {
+        if let Err(error) = code_pages.enable_utf8() {
+            return setup.fail(error);
+        }
+    }
+
+    match TerminalModes::capture() {
+        Ok(modes) => setup.state.modes = Some(modes),
+        Err(error) => return setup.fail(error),
+    }
+    #[cfg(windows)]
+    let synchronized_updates_supported = setup
+        .state
+        .modes
+        .as_ref()
+        .is_some_and(TerminalModes::enable_virtual_terminal_processing);
+    if let Err(error) = enable_raw_mode().context("Failed to enable terminal raw mode") {
+        return setup.fail(error);
+    }
+
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    // Arm before issuing each command: a failed write may still have partially reached the
+    // terminal, so rollback must conservatively send the inverse command.
+    setup.state.alternate_screen = true;
+    if let Err(error) = execute!(stdout, EnterAlternateScreen)
+        .context("Failed to enter the terminal alternate screen")
+    {
+        return setup.fail(error);
+    }
+
+    setup.state.mouse_capture = true;
+    if let Err(error) =
+        execute!(stdout, EnableMouseCapture).context("Failed to enable terminal mouse capture")
+    {
+        return setup.fail(error);
+    }
+
+    setup.state.cursor_restore_pending = true;
     let backend = CrosstermBackend::new(stdout);
-    let terminal = Terminal::new(backend)?;
-    Ok(terminal)
+    let terminal = match Terminal::new(backend).context("Failed to initialize terminal buffers") {
+        Ok(terminal) => terminal,
+        Err(error) => return setup.fail(error),
+    };
+
+    Ok(Tui {
+        terminal,
+        drawing_active: true,
+        state: setup.commit(),
+        #[cfg(windows)]
+        previous_frame_had_wide_cells: false,
+        #[cfg(windows)]
+        synchronized_updates_supported,
+    })
+}
+
+/// Draw one TUI frame.
+///
+/// Windows terminals can leave stale trailing cells when an incremental diff replaces CJK or
+/// other wide glyphs. A frame containing wide cells, the frame after one, and a resized frame are
+/// fully refreshed. ASCII-only steady-state frames keep Ratatui's incremental rendering policy.
+pub fn draw<F>(terminal: &mut Tui, render: F) -> Result<()>
+where
+    F: FnOnce(&mut Frame),
+{
+    if !terminal.drawing_active {
+        bail!("Cannot draw while the terminal session is suspended");
+    }
+
+    #[cfg(windows)]
+    {
+        let resized = synchronize_terminal_size(&mut terminal.terminal, || {
+            Ok(CrosstermBackend::new(io::stdout()))
+        })
+        .context("Failed to synchronize the Windows terminal size")?;
+        let force_full_redraw = resized || terminal.previous_frame_had_wide_cells;
+
+        let draw_result = if terminal.synchronized_updates_supported {
+            let update = SynchronizedUpdateGuard::begin()?;
+            let result = draw_terminal_frame(&mut terminal.terminal, force_full_redraw, render)
+                .context("Failed to draw a Windows terminal frame");
+            combine_results(
+                result,
+                update.finish(),
+                "additionally failed to end the synchronized terminal update",
+            )
+        } else {
+            draw_terminal_frame(&mut terminal.terminal, force_full_redraw, render)
+                .context("Failed to draw a Windows terminal frame")
+        };
+
+        match draw_result {
+            Ok(has_wide_cells) => {
+                terminal.previous_frame_had_wide_cells = has_wide_cells;
+                Ok(())
+            }
+            Err(error) => {
+                // If a partial frame reached the terminal, make the next successful draw a full
+                // refresh rather than trusting Ratatui's previous-buffer assumptions.
+                terminal.previous_frame_had_wide_cells = true;
+                Err(error)
+            }
+        }
+    }
+
+    #[cfg(not(windows))]
+    {
+        draw_terminal_frame(&mut terminal.terminal, false, render)
+            .context("Failed to draw terminal frame")?;
+        Ok(())
+    }
+}
+
+#[cfg(any(windows, test))]
+fn synchronize_terminal_size<B, F>(
+    terminal: &mut Terminal<B>,
+    create_backend: F,
+) -> std::result::Result<bool, B::Error>
+where
+    B: Backend,
+    F: FnOnce() -> std::result::Result<B, B::Error>,
+{
+    let backend_size = terminal.backend().size()?;
+    let viewport_size = terminal.get_frame().area().as_size();
+    if backend_size == viewport_size {
+        return Ok(false);
+    }
+
+    // Recreate Ratatui's buffers without calling Terminal::resize, whose physical clear can leave
+    // stale wide-character continuation cells in Windows consoles.
+    *terminal = Terminal::new(create_backend()?)?;
+    Ok(true)
+}
+
+fn draw_terminal_frame<B, F>(
+    terminal: &mut Terminal<B>,
+    force_full_redraw: bool,
+    render: F,
+) -> std::result::Result<bool, B::Error>
+where
+    B: Backend,
+    F: FnOnce(&mut Frame),
+{
+    let mut has_wide_cells = false;
+    terminal.draw(|frame| {
+        render(frame);
+        has_wide_cells = frame
+            .buffer_mut()
+            .content
+            .iter()
+            .any(|cell| UnicodeWidthStr::width(cell.symbol()) > 1);
+
+        if force_full_redraw || has_wide_cells {
+            apply_full_redraw_policy(frame.buffer_mut());
+        }
+    })?;
+    Ok(has_wide_cells)
+}
+
+fn apply_full_redraw_policy(buffer: &mut Buffer) {
+    for cell in &mut buffer.content {
+        if cell.diff_option == CellDiffOption::None {
+            cell.set_diff_option(CellDiffOption::AlwaysUpdate);
+        }
+    }
 }
 
 /// Restore the terminal to its original state.
+///
+/// Each resource is tracked separately. Successful cleanup steps are disarmed once later cleanup
+/// cannot invalidate them. On Windows, the exact input-mode restore remains armed while mouse
+/// cleanup is pending because crossterm can write its cached raw mode during a retry.
 pub fn restore(terminal: &mut Tui) -> Result<()> {
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        DisableMouseCapture,
-        LeaveAlternateScreen
-    )?;
-    terminal.show_cursor()?;
+    terminal.drawing_active = false;
+    restore_terminal_state(&mut terminal.terminal, &mut terminal.state)
+}
+
+/// Restore a terminal and preserve both the operation error and a cleanup error, if both occur.
+pub fn finish<T>(terminal: &mut Tui, operation: Result<T>) -> Result<T> {
+    combine_results(
+        operation,
+        restore(terminal),
+        "additionally failed to restore terminal state",
+    )
+}
+
+/// Temporarily restore the terminal while an external program runs, then resume the TUI.
+///
+/// The outer result reports suspend/resume failures. The inner result is the external operation's
+/// result, allowing callers such as the main browser to display editor errors and continue.
+pub fn with_suspended<T, F>(terminal: &mut Tui, operation: F) -> Result<Result<T>>
+where
+    F: FnOnce() -> Result<T>,
+{
+    restore(terminal)?;
+    let operation_result = operation();
+
+    match init() {
+        Ok(resumed) => {
+            *terminal = resumed;
+            Ok(operation_result)
+        }
+        Err(resume_error) => match operation_result {
+            Ok(_) => Err(resume_error.context("Failed to resume the terminal interface")),
+            Err(operation_error) => Err(anyhow!(
+                "{operation_error:#}; additionally failed to resume the terminal interface: {resume_error:#}"
+            )),
+        },
+    }
+}
+
+fn restore_terminal_state(terminal: &mut InnerTui, state: &mut TerminalState) -> Result<()> {
+    let mut failures = CleanupFailures::default();
+
+    if state.mouse_capture {
+        failures.record_flag(
+            "disable mouse capture",
+            &mut state.mouse_capture,
+            execute!(terminal.backend_mut(), DisableMouseCapture),
+        );
+    }
+    if state.alternate_screen {
+        failures.record_flag(
+            "leave alternate screen",
+            &mut state.alternate_screen,
+            execute!(terminal.backend_mut(), LeaveAlternateScreen),
+        );
+    }
+    if state.cursor_restore_pending {
+        failures.record_flag(
+            "show cursor",
+            &mut state.cursor_restore_pending,
+            terminal.show_cursor(),
+        );
+    }
+    restore_owned_state(&mut failures, state);
+
+    failures.finish("Failed to restore terminal state")
+}
+
+fn rollback_setup(state: &mut TerminalState) -> Result<()> {
+    let mut failures = CleanupFailures::default();
+    let mut stdout = io::stdout();
+
+    if state.mouse_capture {
+        failures.record_flag(
+            "disable mouse capture",
+            &mut state.mouse_capture,
+            execute!(stdout, DisableMouseCapture),
+        );
+    }
+    if state.alternate_screen {
+        failures.record_flag(
+            "leave alternate screen",
+            &mut state.alternate_screen,
+            execute!(stdout, LeaveAlternateScreen),
+        );
+    }
+    if state.cursor_restore_pending {
+        failures.record_flag(
+            "show cursor",
+            &mut state.cursor_restore_pending,
+            execute!(stdout, Show),
+        );
+    }
+    restore_owned_state(&mut failures, state);
+
+    failures.finish("Failed to roll back partial terminal initialization")
+}
+
+fn restore_owned_state(failures: &mut CleanupFailures, state: &mut TerminalState) {
+    let display_commands_restored =
+        !state.mouse_capture && !state.alternate_screen && !state.cursor_restore_pending;
+    let mut input_mode_restored = true;
+
+    if let Some(modes) = state.modes.as_mut() {
+        let input_result = modes.restore_input(state.mouse_capture);
+        failures.record("restore console input mode", input_result);
+        input_mode_restored = modes.is_input_restored();
+
+        // Mouse capture, alternate-screen, and cursor cleanup are emitted as ANSI sequences on
+        // Windows. Keep virtual-terminal output enabled until every such sequence succeeds, so a
+        // later Drop retry can still take effect instead of merely writing inert escape bytes.
+        if display_commands_restored {
+            let output_result = modes.restore_output();
+            failures.record("restore console output mode", output_result);
+        }
+
+        if modes.is_restored() {
+            state.modes = None;
+        }
+    }
+
+    if display_commands_restored {
+        if let Some(code_pages) = state.code_pages.as_mut() {
+            let result = code_pages.restore();
+            failures.record("restore Windows console code page", result);
+            if code_pages.is_restored() {
+                state.code_pages = None;
+            }
+        }
+    }
+
+    // TerminalModes holds the current CONIN$ handle. Do not restore STDIN or close that handle
+    // until its exact input mode has been restored; otherwise a cleanup retry would target a
+    // closed handle and could leave the console in raw mode permanently.
+    if input_mode_restored {
+        if let Some(console_input) = state.console_input.as_mut() {
+            let result = console_input.restore();
+            failures.record("restore standard console input", result);
+            if console_input.is_restored() {
+                state.console_input = None;
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct TerminalState {
+    mouse_capture: bool,
+    alternate_screen: bool,
+    cursor_restore_pending: bool,
+    modes: Option<TerminalModes>,
+    code_pages: Option<ConsoleCodePages>,
+    console_input: Option<ConsoleInputHandle>,
+}
+
+impl TerminalState {
+    fn has_pending_cleanup(&self) -> bool {
+        self.mouse_capture
+            || self.alternate_screen
+            || self.cursor_restore_pending
+            || self.modes.is_some()
+            || self.code_pages.is_some()
+            || self.console_input.is_some()
+    }
+}
+
+struct TerminalSetup {
+    state: TerminalState,
+    retry_cleanup_on_drop: bool,
+}
+
+impl Default for TerminalSetup {
+    fn default() -> Self {
+        Self {
+            state: TerminalState::default(),
+            retry_cleanup_on_drop: true,
+        }
+    }
+}
+
+impl TerminalSetup {
+    fn fail<T>(&mut self, error: anyhow::Error) -> Result<T> {
+        let cleanup = rollback_setup(&mut self.state);
+        // Successful rollback steps clear their own state flags. Keep Drop armed only for failed
+        // steps so it makes one final best-effort retry instead of abandoning terminal state.
+        self.retry_cleanup_on_drop = self.state.has_pending_cleanup();
+        setup_failure(error, cleanup)
+    }
+
+    fn commit(mut self) -> TerminalState {
+        self.retry_cleanup_on_drop = false;
+        mem::take(&mut self.state)
+    }
+}
+
+impl Drop for TerminalSetup {
+    fn drop(&mut self) {
+        if self.retry_cleanup_on_drop && self.state.has_pending_cleanup() {
+            let _ = rollback_setup(&mut self.state);
+        }
+    }
+}
+
+fn setup_failure<T>(error: anyhow::Error, cleanup: Result<()>) -> Result<T> {
+    match cleanup {
+        Ok(()) => Err(error),
+        Err(cleanup_error) => Err(anyhow!(
+            "{error:#}; additionally failed to roll back terminal state: {cleanup_error:#}"
+        )),
+    }
+}
+
+fn combine_results<T>(
+    primary: Result<T>,
+    secondary: Result<()>,
+    secondary_context: &str,
+) -> Result<T> {
+    match (primary, secondary) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+        (Err(error), Err(secondary_error)) => Err(anyhow!(
+            "{error:#}; {secondary_context}: {secondary_error:#}"
+        )),
+    }
+}
+
+#[derive(Default)]
+struct CleanupFailures(Vec<String>);
+
+impl CleanupFailures {
+    fn record<E>(&mut self, operation: &str, result: std::result::Result<(), E>)
+    where
+        E: Display,
+    {
+        if let Err(error) = result {
+            self.0.push(format!("{operation}: {error}"));
+        }
+    }
+
+    fn record_flag<E>(
+        &mut self,
+        operation: &str,
+        pending: &mut bool,
+        result: std::result::Result<(), E>,
+    ) where
+        E: Display,
+    {
+        match result {
+            Ok(()) => *pending = false,
+            Err(error) => self.0.push(format!("{operation}: {error}")),
+        }
+    }
+
+    fn finish(self, context: &str) -> Result<()> {
+        if self.0.is_empty() {
+            Ok(())
+        } else {
+            bail!("{context}: {}", self.0.join("; "))
+        }
+    }
+}
+
+fn ensure_tui_stdout() -> Result<()> {
+    ensure_tui_stdout_value(std::io::stdout().is_terminal())
+}
+
+fn ensure_tui_stdout_value(is_terminal: bool) -> Result<()> {
+    if is_terminal {
+        return Ok(());
+    }
+
+    bail!(
+        "sivtr: TUI mode requires an interactive terminal\n  hint: run inside a terminal or set `general.open_mode = \"editor\"` in config"
+    )
+}
+
+/// Read the next event that can affect the rendered interface.
+///
+/// Windows Terminal reports passive pointer movement while mouse capture is active. Those events
+/// do not change application state, so returning them would only cause unnecessary redraws.
+pub fn read_interaction() -> Result<Event> {
+    loop {
+        let event = crossterm::event::read()?;
+        if !is_passive_mouse_motion(&event) {
+            return Ok(event);
+        }
+    }
+}
+
+fn is_passive_mouse_motion(event: &Event) -> bool {
+    matches!(
+        event,
+        Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Moved,
+            ..
+        })
+    )
+}
+
+#[cfg(windows)]
+struct ConsoleInputHandle {
+    original: winapi::um::winnt::HANDLE,
+    replacement: winapi::um::winnt::HANDLE,
+    standard_handle_pending: bool,
+    close_pending: bool,
+}
+
+#[cfg(windows)]
+impl ConsoleInputHandle {
+    fn ensure_console() -> Result<Option<Self>> {
+        use std::{ffi::OsStr, os::windows::ffi::OsStrExt, ptr};
+        use winapi::um::{
+            consoleapi::GetConsoleMode,
+            fileapi::{CreateFileW, OPEN_EXISTING},
+            handleapi::{CloseHandle, INVALID_HANDLE_VALUE},
+            processenv::{GetStdHandle, SetStdHandle},
+            winbase::STD_INPUT_HANDLE,
+            winnt::{
+                FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, FILE_SHARE_WRITE, GENERIC_READ,
+                GENERIC_WRITE,
+            },
+        };
+
+        let original = unsafe { GetStdHandle(STD_INPUT_HANDLE) };
+        let mut mode = 0;
+        if !original.is_null()
+            && original != INVALID_HANDLE_VALUE
+            && unsafe { GetConsoleMode(original, &mut mode) } != 0
+        {
+            return Ok(None);
+        }
+
+        let name = OsStr::new("CONIN$\0").encode_wide().collect::<Vec<_>>();
+        let replacement = unsafe {
+            CreateFileW(
+                name.as_ptr(),
+                GENERIC_READ | GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                ptr::null_mut(),
+                OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL,
+                ptr::null_mut(),
+            )
+        };
+        if replacement == INVALID_HANDLE_VALUE {
+            bail!("Failed to open CONIN$: {}", io::Error::last_os_error());
+        }
+        if unsafe { SetStdHandle(STD_INPUT_HANDLE, replacement) } == 0 {
+            let error = io::Error::last_os_error();
+            unsafe {
+                CloseHandle(replacement);
+            }
+            bail!("Failed to bind standard input to CONIN$: {error}");
+        }
+
+        Ok(Some(Self {
+            original,
+            replacement,
+            standard_handle_pending: true,
+            close_pending: true,
+        }))
+    }
+
+    fn restore(&mut self) -> Result<()> {
+        use winapi::um::{
+            handleapi::CloseHandle, processenv::SetStdHandle, winbase::STD_INPUT_HANDLE,
+        };
+
+        let mut failures = CleanupFailures::default();
+        if self.standard_handle_pending {
+            let result = win32_console_call("restore standard input handle", unsafe {
+                SetStdHandle(STD_INPUT_HANDLE, self.original)
+            });
+            if result.is_ok() {
+                self.standard_handle_pending = false;
+            }
+            failures.record("restore standard input handle", result);
+        }
+        if !self.standard_handle_pending && self.close_pending {
+            let result = win32_console_call("close temporary CONIN$ handle", unsafe {
+                CloseHandle(self.replacement)
+            });
+            if result.is_ok() {
+                self.close_pending = false;
+            }
+            failures.record("close temporary CONIN$ handle", result);
+        }
+        failures.finish("Failed to restore console input handle")
+    }
+
+    fn is_restored(&self) -> bool {
+        !self.standard_handle_pending && !self.close_pending
+    }
+}
+
+#[cfg(not(windows))]
+struct ConsoleInputHandle;
+
+#[cfg(not(windows))]
+impl ConsoleInputHandle {
+    fn ensure_console() -> Result<Option<Self>> {
+        Ok(None)
+    }
+
+    fn restore(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    fn is_restored(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(windows)]
+struct InputModeRestoreState {
+    pending: bool,
+}
+
+#[cfg(windows)]
+impl InputModeRestoreState {
+    fn pending() -> Self {
+        Self { pending: true }
+    }
+
+    fn is_pending(&self) -> bool {
+        self.pending
+    }
+
+    fn record_success(&mut self, mouse_capture_pending: bool) {
+        // DisableMouseCapture restores the input mode cached by crossterm when capture was
+        // enabled. That cached mode is raw, so a later mouse-cleanup retry can invalidate an exact
+        // mode restore that already succeeded. Keep the restore armed until mouse cleanup has
+        // completed, then replay it once more before releasing CONIN$.
+        if !mouse_capture_pending {
+            self.pending = false;
+        }
+    }
+}
+
+#[cfg(windows)]
+struct TerminalModes {
+    input_handle: winapi::um::winnt::HANDLE,
+    input_mode: u32,
+    output_handle: winapi::um::winnt::HANDLE,
+    output_mode: u32,
+    input_restore: InputModeRestoreState,
+    output_pending: bool,
+}
+
+#[cfg(windows)]
+impl TerminalModes {
+    fn capture() -> Result<Self> {
+        use winapi::um::{
+            consoleapi::GetConsoleMode,
+            handleapi::INVALID_HANDLE_VALUE,
+            processenv::GetStdHandle,
+            winbase::{STD_INPUT_HANDLE, STD_OUTPUT_HANDLE},
+        };
+
+        let input_handle = unsafe { GetStdHandle(STD_INPUT_HANDLE) };
+        let output_handle = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) };
+        if input_handle.is_null()
+            || input_handle == INVALID_HANDLE_VALUE
+            || output_handle.is_null()
+            || output_handle == INVALID_HANDLE_VALUE
+        {
+            bail!("Failed to resolve Windows console handles");
+        }
+
+        let mut input_mode = 0;
+        let mut output_mode = 0;
+        win32_console_call("read console input mode", unsafe {
+            GetConsoleMode(input_handle, &mut input_mode)
+        })?;
+        win32_console_call("read console output mode", unsafe {
+            GetConsoleMode(output_handle, &mut output_mode)
+        })?;
+
+        Ok(Self {
+            input_handle,
+            input_mode,
+            output_handle,
+            output_mode,
+            input_restore: InputModeRestoreState::pending(),
+            output_pending: true,
+        })
+    }
+
+    fn restore_input(&mut self, mouse_capture_pending: bool) -> Result<()> {
+        use winapi::um::consoleapi::SetConsoleMode;
+
+        if self.input_restore.is_pending() {
+            win32_console_call("restore console input mode", unsafe {
+                SetConsoleMode(self.input_handle, self.input_mode)
+            })?;
+            self.input_restore.record_success(mouse_capture_pending);
+        }
+        Ok(())
+    }
+
+    fn restore_output(&mut self) -> Result<()> {
+        use winapi::um::consoleapi::SetConsoleMode;
+
+        if self.output_pending {
+            win32_console_call("restore console output mode", unsafe {
+                SetConsoleMode(self.output_handle, self.output_mode)
+            })?;
+            self.output_pending = false;
+        }
+        Ok(())
+    }
+
+    fn enable_virtual_terminal_processing(&self) -> bool {
+        use winapi::um::{consoleapi::SetConsoleMode, wincon::ENABLE_VIRTUAL_TERMINAL_PROCESSING};
+
+        unsafe {
+            SetConsoleMode(
+                self.output_handle,
+                self.output_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING,
+            ) != 0
+        }
+    }
+
+    fn is_restored(&self) -> bool {
+        !self.input_restore.is_pending() && !self.output_pending
+    }
+
+    fn is_input_restored(&self) -> bool {
+        !self.input_restore.is_pending()
+    }
+}
+
+#[cfg(not(windows))]
+struct TerminalModes {
+    pending: bool,
+}
+
+#[cfg(not(windows))]
+impl TerminalModes {
+    fn capture() -> Result<Self> {
+        Ok(Self { pending: true })
+    }
+
+    fn restore_input(&mut self, _mouse_capture_pending: bool) -> Result<()> {
+        if self.pending {
+            disable_raw_mode()?;
+            self.pending = false;
+        }
+        Ok(())
+    }
+
+    fn restore_output(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    fn is_restored(&self) -> bool {
+        !self.pending
+    }
+
+    fn is_input_restored(&self) -> bool {
+        !self.pending
+    }
+}
+
+#[cfg(windows)]
+struct ConsoleCodePages {
+    output: u32,
+    pending: bool,
+}
+
+#[cfg(windows)]
+impl ConsoleCodePages {
+    fn capture() -> Result<Option<Self>> {
+        use winapi::um::consoleapi::GetConsoleOutputCP;
+
+        let output = unsafe { GetConsoleOutputCP() };
+        if output == 0 {
+            bail!(
+                "Failed to read Windows console output code page: {}",
+                io::Error::last_os_error()
+            );
+        }
+        Ok(Some(Self {
+            output,
+            pending: true,
+        }))
+    }
+
+    fn enable_utf8(&self) -> Result<()> {
+        use winapi::um::wincon::SetConsoleOutputCP;
+
+        const CP_UTF8: u32 = 65_001;
+        win32_console_call("set console output to UTF-8", unsafe {
+            SetConsoleOutputCP(CP_UTF8)
+        })
+    }
+
+    fn restore(&mut self) -> Result<()> {
+        use winapi::um::wincon::SetConsoleOutputCP;
+
+        if self.pending {
+            win32_console_call("restore console output code page", unsafe {
+                SetConsoleOutputCP(self.output)
+            })?;
+            self.pending = false;
+        }
+        Ok(())
+    }
+
+    fn is_restored(&self) -> bool {
+        !self.pending
+    }
+}
+
+#[cfg(not(windows))]
+struct ConsoleCodePages;
+
+#[cfg(not(windows))]
+impl ConsoleCodePages {
+    fn capture() -> Result<Option<Self>> {
+        Ok(None)
+    }
+
+    fn enable_utf8(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn restore(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    fn is_restored(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(windows)]
+fn win32_console_call(operation: &str, succeeded: i32) -> Result<()> {
+    if succeeded == 0 {
+        bail!("{operation}: {}", io::Error::last_os_error());
+    }
     Ok(())
+}
+
+#[cfg(windows)]
+struct SynchronizedUpdateGuard {
+    active: bool,
+}
+
+#[cfg(windows)]
+impl SynchronizedUpdateGuard {
+    fn begin() -> Result<Self> {
+        // Arm before writing Begin: an I/O error can occur after bytes have partially reached the
+        // terminal, so Drop must still attempt End.
+        let guard = Self { active: true };
+        execute!(io::stdout(), BeginSynchronizedUpdate)
+            .context("Failed to begin synchronized terminal update")?;
+        Ok(guard)
+    }
+
+    fn finish(mut self) -> Result<()> {
+        let result = execute!(io::stdout(), EndSynchronizedUpdate)
+            .context("Failed to end synchronized terminal update");
+        if result.is_ok() {
+            self.active = false;
+        }
+        result
+    }
+}
+
+#[cfg(windows)]
+impl Drop for SynchronizedUpdateGuard {
+    fn drop(&mut self) {
+        if self.active {
+            let _ = execute!(io::stdout(), EndSynchronizedUpdate);
+            self.active = false;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{io, num::NonZeroU16};
+
+    use ratatui::{
+        backend::TestBackend, buffer::Buffer, layout::Rect, text::Line, widgets::Paragraph,
+        Terminal,
+    };
+
+    use super::{
+        apply_full_redraw_policy, combine_results, draw_terminal_frame, ensure_tui_stdout_value,
+        is_passive_mouse_motion, CleanupFailures, Event, MouseEvent, MouseEventKind,
+    };
+    use crossterm::event::{KeyModifiers, MouseButton};
+
+    #[test]
+    fn wide_frame_overwrites_stale_cells_and_forces_output() {
+        let backend = TestBackend::with_lines([
+            "鏃у抚涓枃娈嬬暀 ABC    ",
+            "頃滉竴 stale 馃榾      ",
+            "should disappear   ",
+        ]);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+
+        let has_wide = draw_terminal_frame(&mut terminal, false, |frame| {
+            frame.render_widget(
+                Paragraph::new(vec![
+                    Line::from("[x] 鏂颁細璇?涓枃 頃滉竴 馃榾"),
+                    Line::from("[ ] second row"),
+                ]),
+                frame.area(),
+            );
+        })
+        .expect("wide redraw");
+
+        assert!(has_wide);
+        assert_eq!(terminal.backend().buffer()[(0, 0)].symbol(), "[");
+    }
+
+    #[test]
+    fn frame_after_wide_content_clears_stale_tail_cells() {
+        let backend = TestBackend::new(20, 3);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+
+        draw_terminal_frame(&mut terminal, false, |frame| {
+            frame.render_widget(Paragraph::new("涓枃 wide 馃榾"), frame.area());
+        })
+        .expect("wide frame");
+        draw_terminal_frame(&mut terminal, true, |frame| {
+            frame.render_widget(Paragraph::new("short"), frame.area());
+        })
+        .expect("short frame");
+
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(0, 0)].symbol(), "s");
+        assert!(buffer.content[5..].iter().all(|cell| cell.symbol() == " "));
+    }
+
+    #[test]
+    fn full_redraw_preserves_special_cell_diff_options() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 4, 1));
+        let cells = &mut buffer.content;
+        cells[0].set_diff_option(ratatui::buffer::CellDiffOption::Skip);
+        cells[1].set_diff_option(ratatui::buffer::CellDiffOption::ForcedWidth(
+            NonZeroU16::new(2).unwrap(),
+        ));
+
+        apply_full_redraw_policy(&mut buffer);
+
+        let cells = &buffer.content;
+        assert_eq!(cells[0].diff_option, ratatui::buffer::CellDiffOption::Skip);
+        assert_eq!(
+            cells[1].diff_option,
+            ratatui::buffer::CellDiffOption::ForcedWidth(NonZeroU16::new(2).unwrap())
+        );
+        assert_eq!(
+            cells[2].diff_option,
+            ratatui::buffer::CellDiffOption::AlwaysUpdate
+        );
+    }
+
+    #[test]
+    fn incremental_ascii_draw_keeps_default_diff_policy() {
+        let backend = TestBackend::new(12, 2);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+
+        let has_wide = draw_terminal_frame(&mut terminal, false, |frame| {
+            frame.render_widget(Paragraph::new("plain frame"), frame.area());
+        })
+        .expect("incremental redraw");
+
+        assert!(!has_wide);
+        terminal
+            .backend()
+            .assert_buffer_lines(["plain frame ", "            "]);
+        assert!(terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .all(|cell| cell.diff_option == ratatui::buffer::CellDiffOption::None));
+    }
+
+    #[test]
+    fn resize_recreates_buffers_without_terminal_clear() {
+        let backend = TestBackend::new(8, 2);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal.backend_mut().resize(14, 4);
+
+        let recreated =
+            super::synchronize_terminal_size(&mut terminal, || Ok(TestBackend::new(14, 4)))
+                .expect("resize synchronization");
+
+        assert!(recreated);
+        assert_eq!(terminal.get_frame().area().as_size(), (14, 4).into());
+    }
+
+    #[test]
+    fn successful_cleanup_is_disarmed_while_failed_cleanup_remains_pending() {
+        let mut failures = CleanupFailures::default();
+        let mut succeeded = true;
+        let mut failed = true;
+
+        failures.record_flag("success", &mut succeeded, Ok::<(), io::Error>(()));
+        failures.record_flag(
+            "failure",
+            &mut failed,
+            Err(io::Error::other("still pending")),
+        );
+
+        assert!(!succeeded);
+        assert!(failed);
+        assert!(failures
+            .finish("cleanup failed")
+            .unwrap_err()
+            .to_string()
+            .contains("failure: still pending"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn setup_failure_keeps_only_pending_cleanup_armed_for_drop_retry() {
+        use winapi::um::handleapi::INVALID_HANDLE_VALUE;
+
+        let mut setup = super::TerminalSetup {
+            state: super::TerminalState {
+                modes: Some(super::TerminalModes {
+                    input_handle: INVALID_HANDLE_VALUE,
+                    input_mode: 0,
+                    output_handle: INVALID_HANDLE_VALUE,
+                    output_mode: 0,
+                    input_restore: super::InputModeRestoreState::pending(),
+                    output_pending: false,
+                }),
+                ..super::TerminalState::default()
+            },
+            retry_cleanup_on_drop: true,
+        };
+
+        let error = setup
+            .fail::<()>(anyhow::anyhow!("setup failed"))
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("setup failed"));
+        assert!(error.contains("restore console input mode"));
+        assert!(setup.retry_cleanup_on_drop);
+        assert!(setup.state.has_pending_cleanup());
+
+        // Avoid a second Win32 call from this test's own Drop; the assertion above verifies that
+        // production Drop would perform the intended final best-effort retry.
+        setup.retry_cleanup_on_drop = false;
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn exact_input_restore_stays_armed_until_mouse_cleanup_succeeds() {
+        let mut input_restore = super::InputModeRestoreState::pending();
+
+        // The first mouse cleanup fails. Restoring the exact input mode protects the current shell
+        // state, but it must remain armed because crossterm's retry can write cached raw mode.
+        input_restore.record_success(true);
+        assert!(input_restore.is_pending());
+
+        // Once mouse cleanup succeeds, replaying the exact mode is final and can be disarmed.
+        input_restore.record_success(false);
+        assert!(!input_restore.is_pending());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn pending_display_commands_keep_vt_mode_and_code_page_available_for_retry() {
+        use winapi::um::handleapi::INVALID_HANDLE_VALUE;
+
+        let mut state = super::TerminalState {
+            mouse_capture: true,
+            modes: Some(super::TerminalModes {
+                input_handle: INVALID_HANDLE_VALUE,
+                input_mode: 0,
+                output_handle: INVALID_HANDLE_VALUE,
+                output_mode: 0,
+                input_restore: super::InputModeRestoreState { pending: false },
+                output_pending: true,
+            }),
+            code_pages: Some(super::ConsoleCodePages {
+                output: 65001,
+                pending: true,
+            }),
+            ..super::TerminalState::default()
+        };
+        let mut failures = CleanupFailures::default();
+
+        super::restore_owned_state(&mut failures, &mut state);
+
+        assert!(state.modes.as_ref().unwrap().output_pending);
+        assert!(state.code_pages.as_ref().unwrap().pending);
+        assert!(failures.finish("cleanup").is_ok());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn failed_input_mode_restore_keeps_conin_handle_open_for_retry() {
+        use winapi::um::handleapi::INVALID_HANDLE_VALUE;
+
+        let mut state = super::TerminalState {
+            modes: Some(super::TerminalModes {
+                input_handle: INVALID_HANDLE_VALUE,
+                input_mode: 0,
+                output_handle: INVALID_HANDLE_VALUE,
+                output_mode: 0,
+                input_restore: super::InputModeRestoreState::pending(),
+                output_pending: false,
+            }),
+            console_input: Some(super::ConsoleInputHandle {
+                original: INVALID_HANDLE_VALUE,
+                replacement: INVALID_HANDLE_VALUE,
+                standard_handle_pending: true,
+                close_pending: true,
+            }),
+            ..super::TerminalState::default()
+        };
+        let mut failures = CleanupFailures::default();
+
+        super::restore_owned_state(&mut failures, &mut state);
+
+        let console_input = state.console_input.as_ref().unwrap();
+        assert!(console_input.standard_handle_pending);
+        assert!(console_input.close_pending);
+        assert!(failures.finish("cleanup").is_err());
+    }
+
+    #[test]
+    fn primary_and_cleanup_errors_are_both_preserved() {
+        let error = combine_results::<()>(
+            Err(anyhow::anyhow!("draw failed")),
+            Err(anyhow::anyhow!("restore failed")),
+            "cleanup also failed",
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("draw failed"));
+        assert!(error.contains("cleanup also failed: restore failed"));
+    }
+
+    #[test]
+    fn rejects_non_interactive_tui_stdout() {
+        let error = ensure_tui_stdout_value(false).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("TUI mode requires an interactive terminal"));
+    }
+
+    fn mouse_event(kind: MouseEventKind) -> Event {
+        Event::Mouse(MouseEvent {
+            kind,
+            column: 12,
+            row: 8,
+            modifiers: KeyModifiers::NONE,
+        })
+    }
+
+    #[test]
+    fn passive_mouse_movement_does_not_request_a_redraw() {
+        assert!(is_passive_mouse_motion(&mouse_event(MouseEventKind::Moved)));
+    }
+
+    #[test]
+    fn mouse_actions_still_reach_the_interface() {
+        for kind in [
+            MouseEventKind::Down(MouseButton::Left),
+            MouseEventKind::Drag(MouseButton::Left),
+            MouseEventKind::Up(MouseButton::Left),
+            MouseEventKind::ScrollUp,
+            MouseEventKind::ScrollDown,
+        ] {
+            assert!(!is_passive_mouse_motion(&mouse_event(kind)));
+        }
+    }
 }

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -52,7 +52,7 @@ impl DerefMut for Tui {
 impl Drop for Tui {
     fn drop(&mut self) {
         if self.state.has_pending_cleanup() {
-            let _ = restore_terminal_state(&mut self.terminal, &mut self.state);
+            let _ = restore_terminal_state(&mut self.state);
         }
         self.drawing_active = false;
     }
@@ -245,7 +245,7 @@ fn apply_full_redraw_policy(buffer: &mut Buffer) {
 /// cleanup is pending because crossterm can write its cached raw mode during a retry.
 pub fn restore(terminal: &mut Tui) -> Result<()> {
     terminal.drawing_active = false;
-    restore_terminal_state(&mut terminal.terminal, &mut terminal.state)
+    restore_terminal_state(&mut terminal.state)
 }
 
 /// Restore a terminal and preserve both the operation error and a cleanup error, if both occur.
@@ -282,36 +282,7 @@ where
     }
 }
 
-fn restore_terminal_state(terminal: &mut InnerTui, state: &mut TerminalState) -> Result<()> {
-    let mut failures = CleanupFailures::default();
-
-    if state.mouse_capture {
-        failures.record_flag(
-            "disable mouse capture",
-            &mut state.mouse_capture,
-            execute!(terminal.backend_mut(), DisableMouseCapture),
-        );
-    }
-    if state.alternate_screen {
-        failures.record_flag(
-            "leave alternate screen",
-            &mut state.alternate_screen,
-            execute!(terminal.backend_mut(), LeaveAlternateScreen),
-        );
-    }
-    if state.cursor_restore_pending {
-        failures.record_flag(
-            "show cursor",
-            &mut state.cursor_restore_pending,
-            terminal.show_cursor(),
-        );
-    }
-    restore_owned_state(&mut failures, state);
-
-    failures.finish("Failed to restore terminal state")
-}
-
-fn rollback_setup(state: &mut TerminalState) -> Result<()> {
+fn restore_terminal_state(state: &mut TerminalState) -> Result<()> {
     let mut failures = CleanupFailures::default();
     let mut stdout = io::stdout();
 
@@ -338,7 +309,7 @@ fn rollback_setup(state: &mut TerminalState) -> Result<()> {
     }
     restore_owned_state(&mut failures, state);
 
-    failures.finish("Failed to roll back partial terminal initialization")
+    failures.finish("Failed to restore terminal state")
 }
 
 fn restore_owned_state(failures: &mut CleanupFailures, state: &mut TerminalState) {
@@ -409,49 +380,23 @@ impl TerminalState {
     }
 }
 
+#[derive(Default)]
 struct TerminalSetup {
     state: TerminalState,
-    retry_cleanup_on_drop: bool,
-}
-
-impl Default for TerminalSetup {
-    fn default() -> Self {
-        Self {
-            state: TerminalState::default(),
-            retry_cleanup_on_drop: true,
-        }
-    }
 }
 
 impl TerminalSetup {
     fn fail<T>(&mut self, error: anyhow::Error) -> Result<T> {
-        let cleanup = rollback_setup(&mut self.state);
-        // Successful rollback steps clear their own state flags. Keep Drop armed only for failed
-        // steps so it makes one final best-effort retry instead of abandoning terminal state.
-        self.retry_cleanup_on_drop = self.state.has_pending_cleanup();
-        setup_failure(error, cleanup)
+        match restore_terminal_state(&mut self.state) {
+            Ok(()) => Err(error),
+            Err(cleanup_error) => Err(anyhow!(
+                "{error:#}; additionally failed to roll back terminal state: {cleanup_error:#}"
+            )),
+        }
     }
 
     fn commit(mut self) -> TerminalState {
-        self.retry_cleanup_on_drop = false;
         mem::take(&mut self.state)
-    }
-}
-
-impl Drop for TerminalSetup {
-    fn drop(&mut self) {
-        if self.retry_cleanup_on_drop && self.state.has_pending_cleanup() {
-            let _ = rollback_setup(&mut self.state);
-        }
-    }
-}
-
-fn setup_failure<T>(error: anyhow::Error, cleanup: Result<()>) -> Result<T> {
-    match cleanup {
-        Ok(()) => Err(error),
-        Err(cleanup_error) => Err(anyhow!(
-            "{error:#}; additionally failed to roll back terminal state: {cleanup_error:#}"
-        )),
     }
 }
 
@@ -1061,41 +1006,6 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("failure: still pending"));
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn setup_failure_keeps_only_pending_cleanup_armed_for_drop_retry() {
-        use winapi::um::handleapi::INVALID_HANDLE_VALUE;
-
-        let mut setup = super::TerminalSetup {
-            state: super::TerminalState {
-                modes: Some(super::TerminalModes {
-                    input_handle: INVALID_HANDLE_VALUE,
-                    input_mode: 0,
-                    output_handle: INVALID_HANDLE_VALUE,
-                    output_mode: 0,
-                    input_restore: super::InputModeRestoreState::pending(),
-                    output_pending: false,
-                }),
-                ..super::TerminalState::default()
-            },
-            retry_cleanup_on_drop: true,
-        };
-
-        let error = setup
-            .fail::<()>(anyhow::anyhow!("setup failed"))
-            .unwrap_err()
-            .to_string();
-
-        assert!(error.contains("setup failed"));
-        assert!(error.contains("restore console input mode"));
-        assert!(setup.retry_cleanup_on_drop);
-        assert!(setup.state.has_pending_cleanup());
-
-        // Avoid a second Win32 call from this test's own Drop; the assertion above verifies that
-        // production Drop would perform the intended final best-effort retry.
-        setup.retry_cleanup_on_drop = false;
     }
 
     #[cfg(windows)]

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -257,11 +257,11 @@ pub fn finish<T>(terminal: &mut Tui, operation: Result<T>) -> Result<T> {
     )
 }
 
-/// Temporarily restore the terminal while an external program runs, then resume the TUI.
+/// Temporarily exit the TUI while an external program runs, then re-enter it.
 ///
 /// The outer result reports suspend/resume failures. The inner result is the external operation's
 /// result, allowing callers such as the main browser to display editor errors and continue.
-pub fn with_suspended<T, F>(terminal: &mut Tui, operation: F) -> Result<Result<T>>
+pub fn suspend<T, F>(terminal: &mut Tui, operation: F) -> Result<Result<T>>
 where
     F: FnOnce() -> Result<T>,
 {


### PR DESCRIPTION
## What changed

- Wrap TUI startup and shutdown in an RAII lifecycle that rolls back partial initialization and preserves cleanup errors.
- On Windows, capture and restore the exact console input/output modes and code page; use `CONIN$` when stdin is piped, and keep failed cleanup steps armed for retry.
- Suspend and resume the TUI safely around external editor/Vim launches without losing terminal state.
- Handle Ctrl+C explicitly, ignore passive mouse movement redraws, and make status/search cursor layout use display width for CJK text.
- Force a full redraw after wide glyphs and resize events to clear stale trailing cells.
- Add deterministic lifecycle/rendering tests plus a real Windows ConPTY smoke test to the CI matrix, including resize and Win32 screen-buffer assertions.

## Why

The previous lifecycle could leak raw mode, alternate-screen, mouse-capture, cursor, VT-mode, or code-page state when initialization or cleanup failed. Windows also exposed stale cells after wide-character rendering and resize, and piped stdin did not reliably point interactive input at the console.

These failures are stateful: one missed rollback can leave the user's terminal unusable after sivtr exits. The new lifecycle treats terminal setup as a transaction and keeps incomplete restoration retryable.

## Scope and impact

- Windows receives exact Win32 state restoration and ConPTY coverage.
- Non-Windows platforms retain the normal crossterm path while sharing the safer suspend/resume and redraw behavior.
- This PR is independent of the editor-command safety PR (#32) and does not include its parser or temporary-file changes.
- Existing upstream TUI theme, pane, and workspace layout changes are preserved unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --locked`
- `cargo test --workspace --locked` (423 tests passed; the real ConPTY test is intentionally ignored in the regular suite)
- `cargo test --locked tui::conpty_tests::windows_conpty_tui_smoke -- --ignored --exact --nocapture`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `git diff --check upstream/main...HEAD`
