### PR TITLE
feat(remote): add group mode for multi-device memory sharing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **sivtr** is a terminal output workspace that captures, browses, searches, and reuses terminal command output and AI coding assistant sessions. Agent providers are registry-driven (Codex, Claude Code, Cursor, OpenCode, OpenClaw, Grok, Hermes, Pi, …) and four shells (Bash, Zsh, PowerShell, Nushell). Cross-device remote memory uses a local daemon with Share/Grant/Mount over encrypted iroh transport.
 
-Architecture: CLI binary (`src/`) wrapping a core library (`crates/sivtr-core/`). Clap-based subcommands for copy, search, show, work, filter, var, nav, zoom, init, diff, hotkey, doctor, serve, share, remote, peer, and workspace. TUI mode for browse/search views.
+Architecture: CLI binary (`src/`) wrapping a core library (`crates/sivtr-core/`). Clap-based subcommands for copy, search, show, work, filter, var, nav, zoom, init, diff, hotkey, doctor, serve, share, group, remote, peer, and workspace. TUI mode for browse/search views.
 
 ## Development Commands
 
@@ -111,6 +111,19 @@ sivtr s desk:terminal --status failure --latest 5 --refs
 sivtr serve status            # daemon identity + share/peer counts
 sivtr ws list                 # local workspace origin labels
 ```
+
+Groups (mesh: every member publishes their memory to the group):
+```bash
+sivtr group create team         # create group + share current workspace
+sivtr group invite team         # reusable join link (expires, optional --max-uses)
+sivtr group join <link>         # join + contribute current workspace
+sivtr group list / members team # roster with last-seen
+sivtr group remove team alice   # owner kicks (members self-heal on next sync)
+sivtr group leave team          # leave; owner leaving disbands the group
+sivtr s team:terminal "q"       # fan out to all members, merged
+sivtr s team/alice:terminal "q" # one member (device/workspace scope form)
+```
+Group membership is a roster overlay on share/grant/mount: join = one multi-use invite with the owner, mirror roster locally, grant every member read on your group share. Owner is the roster source of truth; members pull-sync on a 5-min TTL (`GroupSync`), kicked devices drop the group on the next sync. `team:` refs are qualified per member (`team/alice:...`) so `show`/`zoom`/`nav` round-trip.
 
 State lives under `data_dir()` (`SIVTR_DATA_DIR` override, else platform config dir `/sivtr`): `identity.key`, `remote-state.db`, `daemon.json`, `daemon.lock`, `daemon.log`.
 

--- a/crates/sivtr-core/src/record/refs.rs
+++ b/crates/sivtr-core/src/record/refs.rs
@@ -438,20 +438,24 @@ fn parse_path_and_at(value: &str) -> Result<(WorkPath, WorkAt)> {
     ))
 }
 
-/// Normalize a scope name: `name` or `device/workspace`, lowercase, `local` reserved.
+/// Normalize a scope name: `name`, `device/workspace`, or `group/member/share`
+/// (up to three segments), lowercase, `local` reserved.
 pub fn normalize_scope_name(name: &str) -> Result<String> {
     parse_scope_name(name)
 }
 
-/// Scope rules: `name` or `device/workspace`, each segment `[A-Za-z0-9_-]+`,
+/// Scope rules: up to three `/`-separated segments, each `[A-Za-z0-9_-]+`,
 /// case-insensitive (normalized to lowercase). `local` is reserved.
+/// Three segments support group member share selection (`team/alice/proj-b`).
 fn parse_scope_name(name: &str) -> Result<String> {
     if name.is_empty() {
         bail!("Invalid work ref; empty scope before `:`");
     }
     let segments: Vec<&str> = name.split('/').collect();
-    if segments.is_empty() || segments.len() > 2 {
-        bail!("Invalid work ref; scope must be `name` or `device/workspace`");
+    if segments.is_empty() || segments.len() > 3 {
+        bail!(
+            "Invalid work ref; scope must be `name`, `device/workspace`, or `group/member/share`"
+        );
     }
     let mut normalized = Vec::with_capacity(segments.len());
     for segment in segments {
@@ -657,6 +661,8 @@ mod tests {
         assert!("dev_2:terminal/x/1".parse::<WorkRef>().is_ok());
         assert!("my-box:terminal/x/1".parse::<WorkRef>().is_ok());
         assert!("alice/sivtr:terminal/x/1".parse::<WorkRef>().is_ok());
+        // Three segments: group member share selection (`team/alice/proj-b`).
+        assert!("team/alice/proj-b:terminal/x/1".parse::<WorkRef>().is_ok());
         assert_eq!(
             "Dev_2:terminal/x/1"
                 .parse::<WorkRef>()
@@ -668,7 +674,8 @@ mod tests {
         assert!("dev!:terminal/x/1".parse::<WorkRef>().is_err());
         assert!(":terminal/x/1".parse::<WorkRef>().is_err());
         assert!("desk://terminal/x/1".parse::<WorkRef>().is_err());
-        assert!("a/b/c:terminal/x/1".parse::<WorkRef>().is_err());
+        // Four segments exceed the group/device/workspace hierarchy.
+        assert!("a/b/c/d:terminal/x/1".parse::<WorkRef>().is_err());
         assert!("local:terminal/x/1".parse::<WorkRef>().is_ok());
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -357,6 +357,10 @@ pub enum Commands {
     /// Manage remotes for the current workspace (like `git remote`)
     Remote(RemoteCommand),
 
+    /// Manage groups: a named set of devices that share memory with each other
+    #[command(visible_alias = "g")]
+    Group(GroupCommand),
+
     /// Manage configuration
     Config(ConfigCommand),
 

--- a/src/cli/remote.rs
+++ b/src/cli/remote.rs
@@ -125,3 +125,58 @@ pub enum WorkspaceAction {
     /// List known local workspaces (origin labels for `name:body` refs)
     List,
 }
+
+#[derive(Parser, Debug)]
+pub struct GroupCommand {
+    #[command(subcommand)]
+    pub action: GroupAction,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum GroupAction {
+    /// Create a group and share the current workspace with it
+    Create {
+        /// Group name used in refs, e.g. `team:terminal/...`
+        name: String,
+        /// Workspace path to contribute; defaults to the current directory
+        #[arg(long)]
+        workspace: Option<PathBuf>,
+        /// Share name for the contributed workspace; defaults to the directory name
+        #[arg(long)]
+        share_name: Option<String>,
+    },
+    /// Print a reusable join link (expires, optionally capped at max_uses)
+    Invite {
+        group: String,
+        /// Invitation lifetime, such as 10m, 2h, or 1d
+        #[arg(long, default_value = "1d")]
+        expires: String,
+        /// Cap on how many peers may join with this link
+        #[arg(long)]
+        max_uses: Option<u32>,
+    },
+    /// Join a group with a join link and contribute the current workspace
+    Join {
+        /// Join link from `sivtr group invite` (bare key only)
+        invite: String,
+        /// Workspace path to contribute; defaults to the current directory
+        #[arg(long)]
+        workspace: Option<PathBuf>,
+        /// Share name for the contributed workspace; defaults to the directory name
+        #[arg(long)]
+        share_name: Option<String>,
+        /// Disable secret redaction for the contributed workspace
+        #[arg(long)]
+        no_redact: bool,
+    },
+    /// List groups this device has joined
+    List,
+    /// List group members with their last-seen state
+    Members { group: String },
+    /// Owner only: remove a member from the group
+    Remove { group: String, peer: String },
+    /// Leave a group (owner leaving disbands the group)
+    Leave { group: String },
+    /// Force a roster refresh from the group owner
+    Sync { group: String },
+}

--- a/src/commands/memory/workset/source.rs
+++ b/src/commands/memory/workset/source.rs
@@ -12,11 +12,16 @@ use sivtr_core::workspace;
 
 use crate::commands::memory::filter::{self, Filter};
 use crate::commands::memory::records::warn_skipped;
+use crate::output;
 
 use super::WorkSet;
 
 /// Default deadline for one remote source inside [`query_many`].
 pub const REMOTE_QUERY_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Minimum deadline for one group fan-out inside [`query`]; a group query
+/// fans out to every member, so it needs headroom beyond a single remote hop.
+const GROUP_QUERY_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// How one source is scheduled inside [`query_many`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -98,6 +103,13 @@ pub fn query(source: &str, filter: Filter, cwd: Option<&Path>) -> Result<WorkSet
             if let Some(set) = try_remote(&ws.key, &scope, path, filter.clone(), &cwd)? {
                 return Ok(set);
             }
+        }
+
+        // Group fan-out: `team:terminal` (all members) or `team/alice:terminal`
+        // (one member). Groups are device-global, resolved after mounts so a
+        // mount alias always wins over a same-named group.
+        if let Some(set) = try_group(&scope, path, filter.clone(), &cwd)? {
+            return Ok(set);
         }
 
         if !scope.contains('/') {
@@ -245,17 +257,20 @@ fn query_remote_bounded(
     // Prefer the timed IPC path for `scope:path` remotes so the daemon socket
     // itself respects the interactive deadline.
     if let Some((scope, path)) = selector.split_once(':') {
-        if !path.is_empty()
-            && !path.starts_with('/')
-            && !scope.eq_ignore_ascii_case("local")
-            && !scope.contains('/')
-        {
-            if let Some(ws) = workspace::resolve_workspace_for_dir(cwd)? {
-                if let Some(set) =
-                    try_remote_timed(&ws.key, scope, path, filter.clone(), cwd, read_timeout)?
-                {
-                    return Ok(set);
+        if !path.is_empty() && !path.starts_with('/') && !scope.eq_ignore_ascii_case("local") {
+            if !scope.contains('/') {
+                if let Some(ws) = workspace::resolve_workspace_for_dir(cwd)? {
+                    if let Some(set) =
+                        try_remote_timed(&ws.key, scope, path, filter.clone(), cwd, read_timeout)?
+                    {
+                        return Ok(set);
+                    }
                 }
+            }
+            // Groups (`team` or `team/alice`) are device-global; mount aliases
+            // are workspace-scoped and were checked above.
+            if let Some(set) = try_group_timed(scope, path, filter.clone(), cwd, read_timeout)? {
+                return Ok(set);
             }
         }
     }
@@ -362,6 +377,94 @@ fn try_remote_timed(
     }
 }
 
+fn try_group(scope: &str, path: &str, filter: Filter, cwd: &Path) -> Result<Option<WorkSet>> {
+    try_group_timed(scope, path, filter, cwd, GROUP_QUERY_TIMEOUT)
+}
+
+/// Group fan-out with a deadline. Returns `Ok(None)` when `scope` is not a
+/// group on this device so the caller can continue the scope cascade.
+fn try_group_timed(
+    scope: &str,
+    path: &str,
+    filter: Filter,
+    cwd: &Path,
+    read_timeout: Duration,
+) -> Result<Option<WorkSet>> {
+    use crate::remote::ipc;
+    use crate::remote::protocol::{LocalRequest, LocalResponse};
+
+    let Some((group, member, share)) = split_group_scope(scope) else {
+        return Ok(None);
+    };
+    crate::commands::remote::serve::ensure_running()?;
+    let exists = match ipc::call(LocalRequest::GroupList)? {
+        LocalResponse::Groups(groups) => groups.iter().any(|group_info| group_info.name == group),
+        _ => return Ok(None),
+    };
+    if !exists {
+        return Ok(None);
+    }
+    // Fan-out happens inside the daemon (parallel per-member dials); give the
+    // socket read enough headroom beyond the daemon's per-peer budget.
+    let read_timeout = read_timeout.max(GROUP_QUERY_TIMEOUT);
+    match ipc::call_with_read_timeout(
+        LocalRequest::GroupQuery {
+            group,
+            member,
+            share,
+            source: path.to_string(),
+            filter,
+        },
+        read_timeout,
+    )? {
+        LocalResponse::GroupQuery(response) => {
+            if !response.skipped.is_empty() {
+                output::info(format!(
+                    "group members offline: {}",
+                    response.skipped.join(", ")
+                ));
+            }
+            Ok(Some(WorkSet::with_anchors(
+                cwd.display().to_string(),
+                response.query.records,
+                response.query.anchors,
+            )))
+        }
+        response => anyhow::bail!("Unexpected daemon response: {response:?}"),
+    }
+}
+
+/// Split a group scope: `team` (all members), `team/alice` (one member), or
+/// `team/alice/proj-b` (one member, one contributed share). Returns `None` for
+/// anything that is not a valid group scope so the caller can fall through to
+/// the local-workspace cascade.
+fn split_group_scope(scope: &str) -> Option<(String, Option<String>, Option<String>)> {
+    let parts: Vec<&str> = scope.split('/').collect();
+    match parts.as_slice() {
+        [group] if is_identifier(group) => Some((group.to_string(), None, None)),
+        [group, member] if is_identifier(group) && is_identifier(member) => {
+            Some((group.to_string(), Some(member.to_string()), None))
+        }
+        [group, member, share]
+            if is_identifier(group) && is_identifier(member) && is_identifier(share) =>
+        {
+            Some((
+                group.to_string(),
+                Some(member.to_string()),
+                Some(share.to_string()),
+            ))
+        }
+        _ => None,
+    }
+}
+
+fn is_identifier(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-'))
+}
+
 fn read_stdin() -> Result<WorkSet> {
     let mut input = String::new();
     io::stdin()
@@ -410,4 +513,35 @@ pub fn load_context_records(
         }
     }
     Ok(records)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::split_group_scope;
+
+    #[test]
+    fn group_scope_splits_team_and_member_forms() {
+        assert_eq!(
+            split_group_scope("team"),
+            Some(("team".to_string(), None, None))
+        );
+        assert_eq!(
+            split_group_scope("team/alice"),
+            Some(("team".to_string(), Some("alice".to_string()), None))
+        );
+        assert_eq!(
+            split_group_scope("team/alice/proj-b"),
+            Some((
+                "team".to_string(),
+                Some("alice".to_string()),
+                Some("proj-b".to_string())
+            ))
+        );
+        // Not group-shaped: falls through to the local-workspace cascade.
+        assert_eq!(split_group_scope("team/a/b/c"), None);
+        assert_eq!(split_group_scope("team@alice"), None);
+        assert_eq!(split_group_scope(""), None);
+        assert_eq!(split_group_scope("team/"), None);
+        assert_eq!(split_group_scope("a b"), None);
+    }
 }

--- a/src/commands/remote/group.rs
+++ b/src/commands/remote/group.rs
@@ -1,0 +1,334 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use anyhow::{bail, Context, Result};
+use chrono::{TimeZone, Utc};
+use sivtr_core::workspace;
+
+use crate::cli::{GroupAction, GroupCommand};
+use crate::commands::interactive;
+use crate::output;
+use crate::remote::ipc;
+use crate::remote::protocol::{InviteTicket, LocalRequest, LocalResponse, ShareInfo};
+
+use super::serve;
+
+pub fn execute(command: GroupCommand) -> Result<()> {
+    serve::ensure_running()?;
+    match command.action {
+        GroupAction::Create {
+            name,
+            workspace,
+            share_name,
+        } => create(&name, workspace, share_name),
+        GroupAction::Invite {
+            group,
+            expires,
+            max_uses,
+        } => invite(&group, &expires, max_uses),
+        GroupAction::Join {
+            invite,
+            workspace,
+            share_name,
+            no_redact,
+        } => join(&invite, workspace, share_name, !no_redact),
+        GroupAction::List => list(),
+        GroupAction::Members { group } => members(&group),
+        GroupAction::Remove { group, peer } => remove(&group, &peer),
+        GroupAction::Leave { group } => leave(&group),
+        GroupAction::Sync { group } => sync(&group),
+    }
+}
+
+fn create(name: &str, path: Option<PathBuf>, share_name: Option<String>) -> Result<()> {
+    let (share, root) = ensure_share(path, share_name, true)?;
+    match ipc::call(LocalRequest::GroupCreate {
+        name: name.to_string(),
+        share_id: share.id.clone(),
+        share_name: share.name.clone(),
+    })? {
+        LocalResponse::Group(group) => {
+            output::success(format!("created group `{}`", group.name));
+            output::detail("id", group.id);
+            output::detail("share", format!("{} ({})", share.name, root.display()));
+            output::hint(format!(
+                "invite others with: sivtr group invite {}",
+                group.name
+            ));
+            output::hint(format!(
+                "query the group with: sivtr s {}:terminal --latest 5",
+                group.name
+            ));
+            Ok(())
+        }
+        response => bail!("Unexpected daemon response: {response:?}"),
+    }
+}
+
+fn invite(group: &str, expires: &str, max_uses: Option<u32>) -> Result<()> {
+    let valid_for_seconds = super::share::parse_duration(expires)?;
+    match ipc::call(LocalRequest::GroupInvite {
+        group: group.to_string(),
+        valid_for_seconds,
+        max_uses: max_uses.map(i64::from),
+    })? {
+        LocalResponse::Invitation {
+            share_name,
+            ticket,
+            expires_at,
+        } => {
+            let expires_at = Utc
+                .timestamp_opt(expires_at, 0)
+                .single()
+                .context("Invalid invitation expiration")?;
+            // Keep stdout clean for copy: one status line on stderr, key alone on stdout.
+            output::info(format!(
+                "join link for group `{share_name}` (expires {}). Peer: sivtr group join <link>",
+                expires_at.to_rfc3339()
+            ));
+            println!("{ticket}");
+            Ok(())
+        }
+        response => bail!("Unexpected daemon response: {response:?}"),
+    }
+}
+
+fn join(
+    encoded_invite: &str,
+    path: Option<PathBuf>,
+    share_name: Option<String>,
+    redact: bool,
+) -> Result<()> {
+    let shares = select_contributions(encoded_invite, path, share_name, redact)?;
+    match ipc::call(LocalRequest::GroupJoin {
+        invite: encoded_invite.to_string(),
+        shares,
+    })? {
+        LocalResponse::GroupJoined {
+            group_name,
+            member_count,
+        } => {
+            output::success(format!(
+                "joined group `{group_name}` ({member_count} members)"
+            ));
+            output::hint(format!(
+                "query the group with: sivtr s {group_name}:terminal --latest 5"
+            ));
+            Ok(())
+        }
+        response => bail!("Unexpected daemon response: {response:?}"),
+    }
+}
+
+/// Decide which workspaces to contribute: an explicit `--workspace` (append),
+/// the current workspace when non-interactive (append), or an interactive
+/// multi-select whose checkboxes default to already-contributed workspaces —
+/// unchecking one withdraws that contribution. In every case the returned
+/// list is the *final* contribution set; the daemon diffs it against current
+/// contributions (additions register, withdrawals revoke).
+fn select_contributions(
+    encoded_invite: &str,
+    path: Option<PathBuf>,
+    share_name: Option<String>,
+    redact: bool,
+) -> Result<Vec<(String, String)>> {
+    // Explicit workspace or non-interactive: append that workspace to the
+    // current contributions (re-running join in another workspace adds it).
+    let picker = interactive::is_interactive() && path.is_none();
+    if !picker {
+        let (share, _) = ensure_share(path, share_name, redact)?;
+        let group_id = ticket_group_id(encoded_invite)?;
+        return append_contribution(&group_id, &share);
+    }
+
+    let group_id = ticket_group_id(encoded_invite)?;
+    let contributed: HashSet<String> = match ipc::call(LocalRequest::GroupShares {
+        group: group_id.clone(),
+    })? {
+        LocalResponse::GroupShares(shares) => {
+            shares.into_iter().map(|share| share.share_id).collect()
+        }
+        response => bail!("Unexpected daemon response: {response:?}"),
+    };
+    let local_shares = match ipc::call(LocalRequest::ShareList)? {
+        LocalResponse::Shares(shares) => shares,
+        response => bail!("Unexpected daemon response: {response:?}"),
+    };
+    let choices = super::share::list_workspace_choices()?;
+    if choices.is_empty() {
+        bail!("no workspaces to contribute; run inside a git repo first");
+    }
+    let labels: Vec<String> = choices.iter().map(|choice| choice.label()).collect();
+    let is_contributed = |choice: &super::share::WorkspaceChoice| {
+        local_shares
+            .iter()
+            .find(|share| share.workspace_key == choice.key)
+            .map(|share| contributed.contains(&share.id))
+            .unwrap_or(false)
+    };
+    // Already-contributed workspaces default to checked; first join defaults
+    // the current workspace so the picker is useful.
+    let mut defaults: Vec<usize> = choices
+        .iter()
+        .enumerate()
+        .filter(|(_, choice)| is_contributed(choice))
+        .map(|(index, _)| index)
+        .collect();
+    if defaults.is_empty() {
+        if let Some(index) = choices.iter().position(|choice| choice.current) {
+            defaults.push(index);
+        }
+    }
+    let selected = interactive::multi_select(
+        "Contribute which workspaces to the group?",
+        &labels,
+        &defaults,
+    )?;
+    let mut shares = Vec::with_capacity(selected.len());
+    for index in selected {
+        let choice = &choices[index];
+        let (share, _) = ensure_share(Some(PathBuf::from(&choice.root)), None, redact)?;
+        shares.push((share.id, share.name));
+    }
+    Ok(shares)
+}
+
+/// Extract the group id from a join link.
+fn ticket_group_id(encoded_invite: &str) -> Result<String> {
+    let ticket = InviteTicket::parse(encoded_invite)?;
+    ticket.group_id.context("Invitation is not a group invite")
+}
+
+/// Append one contribution to the current set (idempotent).
+fn append_contribution(group_id: &str, share: &ShareInfo) -> Result<Vec<(String, String)>> {
+    let mut shares: Vec<(String, String)> = match ipc::call(LocalRequest::GroupShares {
+        group: group_id.to_string(),
+    })? {
+        LocalResponse::GroupShares(shares) => shares
+            .into_iter()
+            .map(|share| (share.share_id, share.share_name))
+            .collect(),
+        response => bail!("Unexpected daemon response: {response:?}"),
+    };
+    if !shares.iter().any(|(id, _)| *id == share.id) {
+        shares.push((share.id.clone(), share.name.clone()));
+    }
+    Ok(shares)
+}
+
+fn list() -> Result<()> {
+    match ipc::call(LocalRequest::GroupList)? {
+        LocalResponse::Groups(groups) => {
+            if groups.is_empty() {
+                output::plain("no groups on this device");
+            }
+            for group in groups {
+                output::detail(
+                    group.name,
+                    format!("{} members ({})", group.member_count, group.id),
+                );
+            }
+            Ok(())
+        }
+        response => bail!("Unexpected daemon response: {response:?}"),
+    }
+}
+
+fn members(group: &str) -> Result<()> {
+    match ipc::call(LocalRequest::GroupMembers {
+        group: group.to_string(),
+    })? {
+        LocalResponse::Members(members) => {
+            if members.is_empty() {
+                output::plain("no members");
+            }
+            for member in members {
+                let marker = if member.role == "owner" {
+                    " [owner]"
+                } else {
+                    ""
+                };
+                let last_seen = member
+                    .last_seen_at
+                    .map(|timestamp| format!(", last seen {timestamp}"))
+                    .unwrap_or_default();
+                output::detail(
+                    format!("{}{marker}", member.peer_name),
+                    format!(
+                        "{} workspaces ({}){}",
+                        member.share_count, member.peer_id, last_seen
+                    ),
+                );
+            }
+            Ok(())
+        }
+        response => bail!("Unexpected daemon response: {response:?}"),
+    }
+}
+
+fn remove(group: &str, peer: &str) -> Result<()> {
+    match ipc::call(LocalRequest::GroupRemoveMember {
+        group: group.to_string(),
+        peer: peer.to_string(),
+    })? {
+        LocalResponse::Ok => {
+            output::success(format!("removed `{peer}` from `{group}`"));
+            Ok(())
+        }
+        response => bail!("Unexpected daemon response: {response:?}"),
+    }
+}
+
+fn leave(group: &str) -> Result<()> {
+    match ipc::call(LocalRequest::GroupLeave {
+        group: group.to_string(),
+    })? {
+        LocalResponse::Ok => {
+            output::success(format!("left group `{group}`"));
+            Ok(())
+        }
+        response => bail!("Unexpected daemon response: {response:?}"),
+    }
+}
+
+fn sync(group: &str) -> Result<()> {
+    match ipc::call(LocalRequest::GroupSync {
+        group: group.to_string(),
+    })? {
+        LocalResponse::Group(info) => {
+            output::success(format!(
+                "synced group `{}` ({} members)",
+                info.name, info.member_count
+            ));
+            Ok(())
+        }
+        response => bail!("Unexpected daemon response: {response:?}"),
+    }
+}
+
+/// Contribute a workspace to the group: reuse the existing share for this
+/// workspace when one exists, otherwise create it.
+fn ensure_share(
+    path: Option<PathBuf>,
+    share_name: Option<String>,
+    redact: bool,
+) -> Result<(ShareInfo, PathBuf)> {
+    let path =
+        path.unwrap_or(std::env::current_dir().context("Failed to resolve current directory")?);
+    let paths = workspace::ensure_workspace_for_dir(&path)?
+        .with_context(|| format!("{} is not inside a git workspace", path.display()))?;
+    let name = share_name.unwrap_or_else(|| super::share::default_share_name(&paths.root));
+    let share = match super::share::find_share_for_workspace(&paths.key) {
+        Ok(existing) => existing,
+        Err(_) => match ipc::call(LocalRequest::ShareAdd {
+            workspace_key: paths.key,
+            root: paths.root.display().to_string(),
+            name,
+            redact,
+        })? {
+            LocalResponse::Share(share) => share,
+            response => bail!("Unexpected daemon response: {response:?}"),
+        },
+    };
+    Ok((share, paths.root))
+}

--- a/src/commands/remote/group.rs
+++ b/src/commands/remote/group.rs
@@ -319,7 +319,19 @@ fn ensure_share(
         .with_context(|| format!("{} is not inside a git workspace", path.display()))?;
     let name = share_name.unwrap_or_else(|| super::share::default_share_name(&paths.root));
     let share = match super::share::find_share_for_workspace(&paths.key) {
-        Ok(existing) => existing,
+        Ok(existing) if existing.enabled => existing,
+        Ok(existing) => {
+            // Re-enable a disabled share, mirroring `sivtr share add`: a
+            // contributed workspace must be queryable, or members' `authorize`
+            // would deny every read.
+            match ipc::call(LocalRequest::ShareSetEnabled {
+                share: existing.id,
+                enabled: true,
+            })? {
+                LocalResponse::Share(share) => share,
+                response => bail!("Unexpected daemon response: {response:?}"),
+            }
+        }
         Err(_) => match ipc::call(LocalRequest::ShareAdd {
             workspace_key: paths.key,
             root: paths.root.display().to_string(),

--- a/src/commands/remote/mod.rs
+++ b/src/commands/remote/mod.rs
@@ -1,3 +1,4 @@
+pub mod group;
 pub mod mounts;
 pub mod peer;
 pub mod serve;

--- a/src/commands/remote/share.rs
+++ b/src/commands/remote/share.rs
@@ -107,16 +107,23 @@ fn finish_share(
 }
 
 #[derive(Clone)]
-struct WorkspaceChoice {
-    key: String,
-    root: String,
-    name: String,
-    current: bool,
+pub(crate) struct WorkspaceChoice {
+    pub(crate) key: String,
+    pub(crate) root: String,
+    pub(crate) name: String,
+    pub(crate) current: bool,
 }
 
-fn pick_workspace() -> Result<WorkspaceChoice> {
-    interactive::require_interactive("share")?;
+impl WorkspaceChoice {
+    pub(crate) fn label(&self) -> String {
+        let marker = if self.current { " [current]" } else { "" };
+        format!("{}  {}{marker}", self.name, self.root)
+    }
+}
 
+/// Enumerate registered workspaces, current first then by recency. Shared by
+/// `sivtr share` (single select) and `sivtr group join` (multi select).
+pub(crate) fn list_workspace_choices() -> Result<Vec<WorkspaceChoice>> {
     let current = workspace::resolve_current_workspace()?;
     // Ensure the current repo is registered so it appears in the list.
     if let Some(ref paths) = current {
@@ -151,7 +158,7 @@ fn pick_workspace() -> Result<WorkspaceChoice> {
             .then_with(|| b.last_seen_at.cmp(&a.last_seen_at))
     });
 
-    let choices: Vec<WorkspaceChoice> = metas
+    Ok(metas
         .into_iter()
         .map(|meta| {
             let current = Some(meta.key.as_str()) == current_key;
@@ -162,20 +169,17 @@ fn pick_workspace() -> Result<WorkspaceChoice> {
                 current,
             }
         })
-        .collect();
+        .collect())
+}
 
+fn pick_workspace() -> Result<WorkspaceChoice> {
+    interactive::require_interactive("share")?;
+    let choices = list_workspace_choices()?;
     let default_index = choices
         .iter()
         .position(|choice| choice.current)
         .unwrap_or(0);
-    let labels: Vec<String> = choices
-        .iter()
-        .map(|choice| {
-            let marker = if choice.current { " [current]" } else { "" };
-            format!("{}  {}{marker}", choice.name, choice.root)
-        })
-        .collect();
-
+    let labels: Vec<String> = choices.iter().map(WorkspaceChoice::label).collect();
     let index = interactive::select("Share which workspace?", &labels, default_index)?;
     Ok(choices[index].clone())
 }
@@ -219,7 +223,8 @@ fn add(path: Option<PathBuf>, name: Option<String>, redact: bool) -> Result<Shar
     }
 }
 
-fn find_share_for_workspace(workspace_key: &str) -> Result<ShareInfo> {
+/// Find the share for a workspace, if any. Shared with group join.
+pub(crate) fn find_share_for_workspace(workspace_key: &str) -> Result<ShareInfo> {
     match ipc::call(LocalRequest::ShareList)? {
         LocalResponse::Shares(shares) => shares
             .into_iter()
@@ -229,7 +234,7 @@ fn find_share_for_workspace(workspace_key: &str) -> Result<ShareInfo> {
     }
 }
 
-fn default_share_name(root: &Path) -> String {
+pub(crate) fn default_share_name(root: &Path) -> String {
     root.file_name()
         .and_then(|value| value.to_str())
         .unwrap_or("workspace")
@@ -347,7 +352,7 @@ fn revoke(share: &str, peer: &str) -> Result<()> {
     }
 }
 
-fn parse_duration(value: &str) -> Result<i64> {
+pub(crate) fn parse_duration(value: &str) -> Result<i64> {
     let split = value
         .find(|character: char| !character.is_ascii_digit())
         .context("Duration must include a unit, such as 10m, 2h, or 1d")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,9 @@ fn run() -> Result<()> {
         Some(Commands::Remote(cmd)) => {
             commands::remote::execute(cmd)?;
         }
+        Some(Commands::Group(cmd)) => {
+            commands::remote::group::execute(cmd)?;
+        }
         Some(Commands::Hotkey(cmd)) => {
             commands::system::hotkey::execute(cmd)?;
         }

--- a/src/remote/daemon.rs
+++ b/src/remote/daemon.rs
@@ -780,7 +780,7 @@ async fn process_remote(
             {
                 context
                     .store
-                    .group_grant(&share.share_id, &member.peer_id)?;
+                    .group_grant(&group_id, &share.share_id, &member.peer_id)?;
             }
             Ok(RemoteResponse::GroupAck)
         }
@@ -995,7 +995,9 @@ async fn redeem_group_remote(
                 .add_group_share(&group_id, &member.peer_id, share_id, share_name)?;
         }
         for (share_id, _) in shares {
-            context.store.group_grant(share_id, &member.peer_id)?;
+            context
+                .store
+                .group_grant(&group_id, share_id, &member.peer_id)?;
         }
     }
     context.store.touch_group_sync(&group_id)?;
@@ -1011,6 +1013,11 @@ async fn adjust_group_shares(
     group_name_or_id: &str,
     shares: &[(String, String)],
 ) -> Result<()> {
+    // The mesh contract requires at least one contribution; an empty final
+    // set would keep the membership while consuming everyone else's memory.
+    if shares.is_empty() {
+        bail!("A group member must contribute at least one workspace");
+    }
     let group = context.store.group(group_name_or_id)?;
     let self_id = context.identity.id();
     let members = context.store.members(&group.id)?;
@@ -1027,7 +1034,9 @@ async fn adjust_group_shares(
                 .add_group_share(&group.id, &self_id, share_id, share_name)?;
             for member in &members {
                 if member.peer_id != self_id {
-                    context.store.group_grant(share_id, &member.peer_id)?;
+                    context
+                        .store
+                        .group_grant(&group.id, share_id, &member.peer_id)?;
                 }
             }
             broadcast(
@@ -1155,7 +1164,7 @@ async fn sync_group(context: &Arc<DaemonContext>, group_name_or_id: &str) -> Res
                     for share in &self_shares {
                         context
                             .store
-                            .group_grant(&share.share_id, &remote.peer_id)?;
+                            .group_grant(&group.id, &share.share_id, &remote.peer_id)?;
                     }
                 }
             }
@@ -1392,12 +1401,26 @@ async fn group_fan_out(
                 let source = source.to_string();
                 let filter = bounds.clone();
                 move || {
-                    let (records, anchors) = crate::commands::memory::workset::run_on_share(
+                    let result = crate::commands::memory::workset::run_on_share(
                         std::path::Path::new(&root),
                         &source,
                         filter,
                         share.redact,
-                    )?;
+                    );
+                    // An empty workspace has no sessions; report it as an
+                    // empty result (same convention as the remote path), so
+                    // one member's empty contribution cannot abort the group.
+                    let (records, anchors) = match result {
+                        Ok(result) => result,
+                        Err(error)
+                            if error
+                                .to_string()
+                                .starts_with("No record found for ref selector") =>
+                        {
+                            (Vec::new(), Vec::new())
+                        }
+                        Err(error) => return Err(error),
+                    };
                     Ok::<_, anyhow::Error>(QueryResponse { records, anchors })
                 }
             })

--- a/src/remote/daemon.rs
+++ b/src/remote/daemon.rs
@@ -1223,24 +1223,15 @@ async fn leave_group(context: &Arc<DaemonContext>, group_name_or_id: &str) -> Re
         .iter()
         .find(|member| member.peer_id == self_id)
         .context("You are not a member of this group")?;
-    let self_shares = context.store.group_shares(&group.id, &self_id)?;
-    if self_member.role == "owner" {
-        // Owner leaving disbands the group: revoke all grants and kick everyone.
-        for member in &members {
-            if member.peer_id != self_id {
-                for share in &self_shares {
-                    context.store.revoke_group_grant(
-                        &group.id,
-                        &share.share_id,
-                        &member.peer_id,
-                    )?;
-                }
-            }
-        }
-        context.store.remove_group(&group.id)?;
-        // Kick every remaining member: each request names its own target
-        // (`peer_id` differs per recipient), so broadcast's shared template
-        // does not fit — send them individually.
+    let is_owner = self_member.role == "owner";
+    // Leaving revokes the grants we handed out on our shares and drops the
+    // local group row (membership and contributions cascade), so `group list`
+    // stops showing it immediately - even while the owner is offline.
+    drop_group(context, &group.id).await?;
+    if is_owner {
+        // Owner leaving disbands the group: kick every remaining member. Each
+        // request names its own target (`peer_id` differs per recipient), so
+        // broadcast's shared template does not fit - send them individually.
         for member in &members {
             if member.peer_id == self_id {
                 continue;
@@ -1259,20 +1250,7 @@ async fn leave_group(context: &Arc<DaemonContext>, group_name_or_id: &str) -> Re
             )
             .await;
         }
-        return Ok(());
-    }
-    // Regular member: revoke the grants we gave the group on our shares.
-    for member in &members {
-        if member.peer_id != self_id {
-            for share in &self_shares {
-                context
-                    .store
-                    .revoke_group_grant(&group.id, &share.share_id, &member.peer_id)?;
-            }
-        }
-    }
-    context.store.remove_member(&group.id, &self_id)?;
-    if let Some(owner) = members.iter().find(|member| member.role == "owner") {
+    } else if let Some(owner) = members.iter().find(|member| member.role == "owner") {
         let _ = tokio::time::timeout(
             Duration::from_secs(3),
             exchange_with_peer(
@@ -1285,11 +1263,6 @@ async fn leave_group(context: &Arc<DaemonContext>, group_name_or_id: &str) -> Re
         )
         .await;
     }
-    // Leaving drops the local group row (members and contributions cascade),
-    // so `group list` stops showing it immediately instead of waiting for the
-    // owner's next roster sync - which may never come while the owner is
-    // offline.
-    context.store.remove_group(&group.id)?;
     Ok(())
 }
 

--- a/src/remote/daemon.rs
+++ b/src/remote/daemon.rs
@@ -833,7 +833,9 @@ async fn process_remote(
                     .store
                     .group_shares(&group_id, &context.identity.id())?
                 {
-                    revoke_peer_grant(&context.store, &share.share_id, &removed_peer)?;
+                    context
+                        .store
+                        .revoke_group_grant(&group_id, &share.share_id, &removed_peer)?;
                 }
                 context.store.remove_member(&group_id, &removed_peer)?;
             }
@@ -850,7 +852,9 @@ async fn process_remote(
             // Revoke every owner contribution from the leaver.
             if let Some(owner) = members_before.iter().find(|row| row.role == "owner") {
                 for share in context.store.group_shares(&group_id, &owner.peer_id)? {
-                    revoke_peer_grant(&context.store, &share.share_id, peer_id)?;
+                    context
+                        .store
+                        .revoke_group_grant(&group_id, &share.share_id, peer_id)?;
                 }
             }
             broadcast(
@@ -1160,7 +1164,11 @@ async fn sync_group(context: &Arc<DaemonContext>, group_name_or_id: &str) -> Res
                 if !members.iter().any(|remote| remote.peer_id == local.peer_id) {
                     context.store.remove_member(&group.id, &local.peer_id)?;
                     for share in &self_shares {
-                        revoke_peer_grant(&context.store, &share.share_id, &local.peer_id)?;
+                        context.store.revoke_group_grant(
+                            &group.id,
+                            &share.share_id,
+                            &local.peer_id,
+                        )?;
                     }
                 }
             }
@@ -1197,7 +1205,9 @@ async fn drop_group(context: &Arc<DaemonContext>, group_name_or_id: &str) -> Res
     for share in context.store.group_shares(&group.id, &self_id)? {
         for member in &members {
             if member.peer_id != self_id {
-                revoke_peer_grant(&context.store, &share.share_id, &member.peer_id)?;
+                context
+                    .store
+                    .revoke_group_grant(&group.id, &share.share_id, &member.peer_id)?;
             }
         }
     }
@@ -1219,7 +1229,11 @@ async fn leave_group(context: &Arc<DaemonContext>, group_name_or_id: &str) -> Re
         for member in &members {
             if member.peer_id != self_id {
                 for share in &self_shares {
-                    revoke_peer_grant(&context.store, &share.share_id, &member.peer_id)?;
+                    context.store.revoke_group_grant(
+                        &group.id,
+                        &share.share_id,
+                        &member.peer_id,
+                    )?;
                 }
             }
         }
@@ -1251,7 +1265,9 @@ async fn leave_group(context: &Arc<DaemonContext>, group_name_or_id: &str) -> Re
     for member in &members {
         if member.peer_id != self_id {
             for share in &self_shares {
-                revoke_peer_grant(&context.store, &share.share_id, &member.peer_id)?;
+                context
+                    .store
+                    .revoke_group_grant(&group.id, &share.share_id, &member.peer_id)?;
             }
         }
     }
@@ -1269,6 +1285,11 @@ async fn leave_group(context: &Arc<DaemonContext>, group_name_or_id: &str) -> Re
         )
         .await;
     }
+    // Leaving drops the local group row (members and contributions cascade),
+    // so `group list` stops showing it immediately instead of waiting for the
+    // owner's next roster sync - which may never come while the owner is
+    // offline.
+    context.store.remove_group(&group.id)?;
     Ok(())
 }
 
@@ -1298,7 +1319,9 @@ async fn remove_group_member(
         bail!("The group owner cannot remove itself; leave the group to disband it");
     }
     for share in context.store.group_shares(&group.id, &self_id)? {
-        revoke_peer_grant(&context.store, &share.share_id, &target.peer_id)?;
+        context
+            .store
+            .revoke_group_grant(&group.id, &share.share_id, &target.peer_id)?;
     }
     context.store.remove_member(&group.id, &target.peer_id)?;
     // Everyone hears about the removal — the removed peer clears the group
@@ -1374,13 +1397,13 @@ async fn group_fan_out(
     let self_id = context.identity.id();
     let mut records = Vec::new();
     let mut anchors = Vec::new();
-    // Every result is scoped `team/alice/proj-b` so members stay apart and
-    // records round-trip through show/zoom/nav.
-    let mut merge = |peer_name: &str, share_name: &str, mut query: QueryResponse| {
-        qualify_query_scope(
-            &format!("{group_name}/{peer_name}/{share_name}"),
-            &mut query,
-        );
+    // Every result is scoped `team/<peer-id>/proj-b` so members stay apart and
+    // records round-trip through show/zoom/nav. The member segment is the
+    // stable peer id, not the display name: two devices can share a hostname
+    // (and a workspace name), and a name-based scope would collide and make
+    // the refs ambiguous.
+    let mut merge = |peer_id: &str, share_name: &str, mut query: QueryResponse| {
+        qualify_query_scope(&format!("{group_name}/{peer_id}/{share_name}"), &mut query);
         records.extend(query.records);
         anchors.extend(query.anchors);
     };
@@ -1406,7 +1429,7 @@ async fn group_fan_out(
                 }
             })
             .await??;
-            merge(&member.peer_name, share_name, query);
+            merge(&member.peer_id, share_name, query);
         }
     }
 
@@ -1415,7 +1438,6 @@ async fn group_fan_out(
         for (share_id, share_name) in &member.shares {
             let context = context.clone();
             let peer_id = member.peer_id.clone();
-            let peer_name = member.peer_name.clone();
             let share_id = share_id.clone();
             let share_name = share_name.clone();
             let source = source.to_string();
@@ -1434,7 +1456,7 @@ async fn group_fan_out(
                     ),
                 )
                 .await;
-                (peer_id, peer_name, share_name, result)
+                (peer_id, share_name, result)
             });
         }
     }
@@ -1443,11 +1465,11 @@ async fn group_fan_out(
     // whose records were already merged.
     let mut online: HashSet<String> = HashSet::new();
     while let Some(joined) = tasks.join_next().await {
-        let Ok((peer_id, peer_name, share_name, result)) = joined else {
+        let Ok((peer_id, share_name, result)) = joined else {
             continue;
         };
         if let Ok(Ok(RemoteResponse::Query(query))) = result {
-            merge(&peer_name, &share_name, query);
+            merge(&peer_id, &share_name, query);
             online.insert(peer_id);
         }
     }
@@ -1544,17 +1566,6 @@ fn member_info_from_store(
         role: member.role.clone(),
         endpoint,
     })
-}
-
-/// Revoke a grant. A missing grant is an idempotent no-op (`revoke` returns
-/// `Ok(None)`); every storage failure is propagated, so kick/leave/disband
-/// cannot report success while access remains active.
-fn revoke_peer_grant(
-    store: &StateStore,
-    share_name_or_id: &str,
-    peer_name_or_id: &str,
-) -> Result<()> {
-    store.revoke(share_name_or_id, peer_name_or_id).map(|_| ())
 }
 
 fn random_token() -> String {

--- a/src/remote/daemon.rs
+++ b/src/remote/daemon.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fs::OpenOptions;
 use std::io::ErrorKind;
 use std::path::PathBuf;
@@ -1079,14 +1080,20 @@ async fn sync_group(context: &Arc<DaemonContext>, group_name_or_id: &str) -> Res
         context.store.touch_group_sync(&group.id)?;
         return Ok(());
     }
-    let response = exchange_with_peer(
-        context,
-        &owner.peer_id,
-        RemoteRequest::GroupSync {
-            group_id: group.id.clone(),
-        },
+    // Pulling the roster must never hang a local operation on an unreachable
+    // owner; callers fall back to the cached roster after this bound.
+    let response = tokio::time::timeout(
+        Duration::from_secs(5),
+        exchange_with_peer(
+            context,
+            &owner.peer_id,
+            RemoteRequest::GroupSync {
+                group_id: group.id.clone(),
+            },
+        ),
     )
-    .await?;
+    .await
+    .context("Group roster sync with the owner timed out")??;
     match response {
         RemoteResponse::GroupSynced {
             group_name: _,
@@ -1287,6 +1294,9 @@ async fn remove_group_member(
                 || member.peer_name.eq_ignore_ascii_case(peer_name_or_id)
         })
         .context("Unknown group member")?;
+    if target.peer_id == self_id {
+        bail!("The group owner cannot remove itself; leave the group to disband it");
+    }
     for share in context.store.group_shares(&group.id, &self_id)? {
         revoke_peer_grant(&context.store, &share.share_id, &target.peer_id)?;
     }
@@ -1350,6 +1360,17 @@ async fn group_fan_out(
     filter: Filter,
 ) -> Result<GroupQueryResponse> {
     const PER_PEER_TIMEOUT: Duration = Duration::from_millis(2500);
+    // Shares only bound the set (pattern/status/time/…). Ordering, the
+    // `latest` window, and `limit` are group-wide: pushed down, they would
+    // return a per-share top-k (five per share for `--latest 5`) instead of
+    // the group's global top results, so they are applied once on the merged
+    // corpus below.
+    let full = filter.for_remote_peer();
+    let mut bounds = full.clone();
+    bounds.rank = None;
+    bounds.latest = None;
+    bounds.limit = None;
+
     let self_id = context.identity.id();
     let mut records = Vec::new();
     let mut anchors = Vec::new();
@@ -1373,7 +1394,7 @@ async fn group_fan_out(
             let query = tokio::task::spawn_blocking({
                 let root = share.root.clone();
                 let source = source.to_string();
-                let filter = filter.clone();
+                let filter = bounds.clone();
                 move || {
                     let (records, anchors) = crate::commands::memory::workset::run_on_share(
                         std::path::Path::new(&root),
@@ -1398,7 +1419,7 @@ async fn group_fan_out(
             let share_id = share_id.clone();
             let share_name = share_name.clone();
             let source = source.to_string();
-            let filter = filter.clone();
+            let filter = bounds.clone();
             tasks.spawn(async move {
                 let result = tokio::time::timeout(
                     PER_PEER_TIMEOUT,
@@ -1417,30 +1438,35 @@ async fn group_fan_out(
             });
         }
     }
-    let mut offline: Vec<(String, String)> = Vec::new();
+    // A member is online when any of its shares answered, decided only after
+    // every share task completes so a later failure cannot reclassify a peer
+    // whose records were already merged.
+    let mut online: HashSet<String> = HashSet::new();
     while let Some(joined) = tasks.join_next().await {
         let Ok((peer_id, peer_name, share_name, result)) = joined else {
             continue;
         };
-        match result {
-            Ok(Ok(RemoteResponse::Query(query))) => {
-                merge(&peer_name, &share_name, query);
-                // A member is online if any share answered.
-                offline.retain(|(id, _)| *id != peer_id);
-            }
-            _ => {
-                if !offline.iter().any(|(id, _)| *id == peer_id) {
-                    offline.push((peer_id, peer_name));
-                }
-            }
+        if let Ok(Ok(RemoteResponse::Query(query))) = result {
+            merge(&peer_name, &share_name, query);
+            online.insert(peer_id);
         }
     }
-    let skipped: Vec<String> = offline
-        .into_iter()
-        .map(|(_, peer_name)| peer_name)
+    let skipped: Vec<String> = members
+        .iter()
+        .filter(|member| member.peer_id != self_id && !online.contains(&member.peer_id))
+        .map(|member| member.peer_name.clone())
         .collect();
+
+    // Order the merged corpus once, as one group: `latest` window → sort →
+    // `limit`. Re-running the pipeline here is idempotent for the bounds each
+    // share already applied; the shared code also ranks the merged corpus as
+    // a whole when the sort is relevance.
+    let merged = crate::commands::memory::filter::apply(PathBuf::new(), records, anchors, full)?;
     Ok(GroupQueryResponse {
-        query: QueryResponse { records, anchors },
+        query: QueryResponse {
+            records: merged.records,
+            anchors: merged.anchors,
+        },
         skipped,
     })
 }

--- a/src/remote/daemon.rs
+++ b/src/remote/daemon.rs
@@ -23,7 +23,7 @@ use super::protocol::{
     LocalResponse, MemberInfo, QueryResponse, RemoteRequest, RemoteResponse, MAX_MESSAGE_SIZE,
     REMOTE_ALPN,
 };
-use super::state::{GroupMemberInfo, MountInfo, StateStore};
+use super::state::{GroupInfo, GroupMemberInfo, MountInfo, StateStore};
 use crate::commands::memory::filter::Filter;
 
 pub fn run() -> Result<()> {
@@ -444,44 +444,12 @@ async fn process_local(
         } => {
             let group_info = context.store.group(&group)?;
             maybe_sync_group(context, &group).await;
-            let roster = context.store.members(&group_info.id)?;
-            let all: Vec<MemberInfo> = roster
-                .iter()
-                .filter(|member| member.peer_id != context.identity.id())
-                .map(|member| member_info_from_store(&context.store, &group_info.id, member))
-                .collect::<Result<_>>()?;
-            let mut targets: Vec<MemberInfo> = match member {
-                Some(name) => {
-                    let needle = name.to_ascii_lowercase();
-                    let matches: Vec<MemberInfo> = all
-                        .into_iter()
-                        .filter(|member| {
-                            member.peer_name.to_ascii_lowercase() == needle
-                                || member.peer_id == needle
-                        })
-                        .collect();
-                    if matches.is_empty() {
-                        bail!("No group member named `{name}` in `{}`", group_info.name);
-                    }
-                    matches
-                }
-                None => all,
-            };
-            // Three-segment scope `team/alice/proj-b` pins one contributed share.
-            if let Some(share_name) = share {
-                for target in &mut targets {
-                    target
-                        .shares
-                        .retain(|(_, name)| name.eq_ignore_ascii_case(&share_name));
-                }
-                targets.retain(|target| !target.shares.is_empty());
-                if targets.is_empty() {
-                    bail!(
-                        "No member contributes a share named `{share_name}` in `{}`",
-                        group_info.name
-                    );
-                }
-            }
+            let targets = group_targets(
+                &context.store,
+                &group_info,
+                member.as_deref(),
+                share.as_deref(),
+            )?;
             if targets.is_empty() {
                 return Ok((
                     LocalResponse::GroupQuery(GroupQueryResponse {
@@ -495,7 +463,7 @@ async fn process_local(
                 ));
             }
             let response =
-                group_fan_out(context, &group_info.name, &targets, &source, filter).await;
+                group_fan_out(context, &group_info.name, &targets, &source, filter).await?;
             LocalResponse::GroupQuery(response)
         }
     };
@@ -722,7 +690,6 @@ async fn process_remote(
             })
         }
         RemoteRequest::RedeemGroupInvite {
-            group_id,
             invite_id,
             secret,
             peer_name,
@@ -736,11 +703,16 @@ async fn process_remote(
                 shares: &shares,
                 endpoint_json: &endpoint_json,
             };
-            let roster = context
+            let redeemed = context
                 .store
                 .redeem_group_invite(&invite_id, &secret, &joiner)?;
+            // The invite row is the authority: the group is derived from the
+            // ticket, never from the joiner's request, and used for every
+            // follow-up (name lookup, roster, broadcast).
+            let group_id = redeemed.group_id;
             let group_name = context.store.group(&group_id)?.name;
-            let members: Vec<MemberInfo> = roster
+            let members: Vec<MemberInfo> = redeemed
+                .roster
                 .iter()
                 .map(|member| member_info_from_store(&context.store, &group_id, member))
                 .collect::<Result<_>>()?;
@@ -766,14 +738,14 @@ async fn process_remote(
                 endpoint,
             };
             let context = context.clone();
-            let group_id = group_id.clone();
             let newcomer_id = newcomer.peer_id.clone();
+            let broadcast_group_id = group_id.clone();
             tokio::spawn(async move {
                 broadcast(
                     &context,
-                    &group_id,
+                    &broadcast_group_id,
                     RemoteRequest::GroupMemberAdded {
-                        group_id: group_id.clone(),
+                        group_id: broadcast_group_id.clone(),
                         member: newcomer,
                     },
                     Some(&newcomer_id),
@@ -781,6 +753,7 @@ async fn process_remote(
                 .await;
             });
             Ok(RemoteResponse::GroupJoined {
+                group_id,
                 group_name,
                 members,
             })
@@ -964,15 +937,13 @@ async fn redeem_group_remote(
     if invite.expires_at < Utc::now().timestamp() {
         bail!("Invitation is expired");
     }
-    let group_id = invite
-        .group_id
-        .as_deref()
-        .context("Invitation is not a group invite")?;
+    if invite.group_id.is_none() {
+        bail!("Invitation is not a group invite");
+    }
     let (response, _observed) = exchange(
         context,
         invite.endpoint,
         RemoteRequest::RedeemGroupInvite {
-            group_id: group_id.to_string(),
             invite_id: invite.invite_id,
             secret: invite.secret,
             peer_name: context.identity.name.clone(),
@@ -981,11 +952,13 @@ async fn redeem_group_remote(
         },
     )
     .await?;
-    let (group_name, members) = match response {
+    // The owner derives the group from the invite row; register under that id.
+    let (group_id, group_name, members) = match response {
         RemoteResponse::GroupJoined {
+            group_id,
             group_name,
             members,
-        } => (group_name, members),
+        } => (group_id, group_name, members),
         response => bail!("Unexpected invitation response: {response:?}"),
     };
     // Our own device is a peer of itself (FK target in group_members).
@@ -993,14 +966,14 @@ async fn redeem_group_remote(
         .store
         .save_remote_peer(&context.identity.id(), &context.identity.name, "{}")?;
     // Mirror the owner-assigned group identity and join it.
-    context.store.register_group(group_id, &group_name)?;
+    context.store.register_group(&group_id, &group_name)?;
     context
         .store
-        .add_member(group_id, &context.identity.id(), "member")?;
+        .add_member(&group_id, &context.identity.id(), "member")?;
     for (share_id, share_name) in shares {
         context
             .store
-            .add_group_share(group_id, &context.identity.id(), share_id, share_name)?;
+            .add_group_share(&group_id, &context.identity.id(), share_id, share_name)?;
     }
     // Mirror the roster and grant every member read access to our shares.
     for member in &members {
@@ -1010,17 +983,17 @@ async fn redeem_group_remote(
             .save_remote_peer(&member.peer_id, &member.peer_name, &member_endpoint)?;
         context
             .store
-            .add_member(group_id, &member.peer_id, &member.role)?;
+            .add_member(&group_id, &member.peer_id, &member.role)?;
         for (share_id, share_name) in &member.shares {
             context
                 .store
-                .add_group_share(group_id, &member.peer_id, share_id, share_name)?;
+                .add_group_share(&group_id, &member.peer_id, share_id, share_name)?;
         }
         for (share_id, _) in shares {
             context.store.group_grant(share_id, &member.peer_id)?;
         }
     }
-    context.store.touch_group_sync(group_id)?;
+    context.store.touch_group_sync(&group_id)?;
     // The returned roster already includes this device; it is the full count.
     Ok((group_name, members.len()))
 }
@@ -1365,19 +1338,59 @@ async fn broadcast(
     while tasks.join_next().await.is_some() {}
 }
 
-/// Parallel fan-out: query every (member, contributed share), merge results
-/// qualified per member and share, and report members that did not answer
-/// within the budget. A member counts as online if any share answered.
+/// Fan out a group query: the caller's own contributions run in-process (a
+/// failure is a real error), every remote (member, share) is dialed in parallel
+/// under a per-peer budget, and results are merged qualified per member and
+/// share. Members that did not answer are reported as skipped.
 async fn group_fan_out(
     context: &Arc<DaemonContext>,
     group_name: &str,
     members: &[MemberInfo],
     source: &str,
     filter: Filter,
-) -> GroupQueryResponse {
+) -> Result<GroupQueryResponse> {
     const PER_PEER_TIMEOUT: Duration = Duration::from_millis(2500);
+    let self_id = context.identity.id();
+    let mut records = Vec::new();
+    let mut anchors = Vec::new();
+    // Every result is scoped `team/alice/proj-b` so members stay apart and
+    // records round-trip through show/zoom/nav.
+    let mut merge = |peer_name: &str, share_name: &str, mut query: QueryResponse| {
+        qualify_query_scope(
+            &format!("{group_name}/{peer_name}/{share_name}"),
+            &mut query,
+        );
+        records.extend(query.records);
+        anchors.extend(query.anchors);
+    };
+
+    // The local member's contributions are part of the group, so they are
+    // queried like any other share — just in-process instead of over the wire.
+    // Local failures propagate; they are not "offline" peers.
+    for member in members.iter().filter(|member| member.peer_id == self_id) {
+        for (share_id, share_name) in &member.shares {
+            let share = context.store.share(share_id)?;
+            let query = tokio::task::spawn_blocking({
+                let root = share.root.clone();
+                let source = source.to_string();
+                let filter = filter.clone();
+                move || {
+                    let (records, anchors) = crate::commands::memory::workset::run_on_share(
+                        std::path::Path::new(&root),
+                        &source,
+                        filter,
+                        share.redact,
+                    )?;
+                    Ok::<_, anyhow::Error>(QueryResponse { records, anchors })
+                }
+            })
+            .await??;
+            merge(&member.peer_name, share_name, query);
+        }
+    }
+
     let mut tasks = JoinSet::new();
-    for member in members {
+    for member in members.iter().filter(|member| member.peer_id != self_id) {
         for (share_id, share_name) in &member.shares {
             let context = context.clone();
             let peer_id = member.peer_id.clone();
@@ -1404,23 +1417,14 @@ async fn group_fan_out(
             });
         }
     }
-    let mut records = Vec::new();
-    let mut anchors = Vec::new();
     let mut offline: Vec<(String, String)> = Vec::new();
     while let Some(joined) = tasks.join_next().await {
         let Ok((peer_id, peer_name, share_name, result)) = joined else {
             continue;
         };
         match result {
-            Ok(Ok(RemoteResponse::Query(mut query))) => {
-                // `team/alice/proj-b` — distinct scopes keep members apart and
-                // make results round-trip through show/zoom/nav.
-                qualify_query_scope(
-                    &format!("{group_name}/{peer_name}/{share_name}"),
-                    &mut query,
-                );
-                records.extend(query.records);
-                anchors.extend(query.anchors);
+            Ok(Ok(RemoteResponse::Query(query))) => {
+                merge(&peer_name, &share_name, query);
                 // A member is online if any share answered.
                 offline.retain(|(id, _)| *id != peer_id);
             }
@@ -1435,10 +1439,59 @@ async fn group_fan_out(
         .into_iter()
         .map(|(_, peer_name)| peer_name)
         .collect();
-    GroupQueryResponse {
+    Ok(GroupQueryResponse {
         query: QueryResponse { records, anchors },
         skipped,
+    })
+}
+
+/// Resolve which (member, share) pairs a group query fans out to. The caller's
+/// own contribution is a target like any other member's — the local member is
+/// queried in-process by [`group_fan_out`]. `member` and `share` pin the
+/// three-segment scopes `team/alice` and `team/alice/proj-b`.
+fn group_targets(
+    store: &StateStore,
+    group: &GroupInfo,
+    member: Option<&str>,
+    share: Option<&str>,
+) -> Result<Vec<MemberInfo>> {
+    let all: Vec<MemberInfo> = store
+        .members(&group.id)?
+        .iter()
+        .map(|member| member_info_from_store(store, &group.id, member))
+        .collect::<Result<_>>()?;
+    let mut targets: Vec<MemberInfo> = match member {
+        Some(name) => {
+            let needle = name.to_ascii_lowercase();
+            let matches: Vec<MemberInfo> = all
+                .into_iter()
+                .filter(|member| {
+                    member.peer_name.to_ascii_lowercase() == needle || member.peer_id == needle
+                })
+                .collect();
+            if matches.is_empty() {
+                bail!("No group member named `{name}` in `{}`", group.name);
+            }
+            matches
+        }
+        None => all,
+    };
+    // `team/alice/proj-b` pins one contributed share per member.
+    if let Some(share_name) = share {
+        for target in &mut targets {
+            target
+                .shares
+                .retain(|(_, name)| name.eq_ignore_ascii_case(share_name));
+        }
+        targets.retain(|target| !target.shares.is_empty());
+        if targets.is_empty() {
+            bail!(
+                "No member contributes a share named `{share_name}` in `{}`",
+                group.name
+            );
+        }
     }
+    Ok(targets)
 }
 
 fn member_info_from_store(
@@ -1494,6 +1547,7 @@ pub fn remove_stale_daemon_info() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use super::group_targets;
     use super::require_group_owner;
     use super::StateStore;
 
@@ -1523,5 +1577,67 @@ mod tests {
         let (_temp, store) = group_store();
         let error = require_group_owner(&store, "missing", "self-1").expect_err("unknown group");
         assert!(error.to_string().contains("Unknown group"));
+    }
+
+    #[test]
+    fn group_targets_include_the_local_member() {
+        let (_temp, store, self_id) = group_with_members();
+        let group = store.group("team").expect("group");
+        let targets = group_targets(&store, &group, None, None).expect("targets");
+        assert!(
+            targets.iter().any(|member| member.peer_id == self_id),
+            "the caller's own contribution is a fan-out target"
+        );
+        assert!(targets.iter().any(|member| member.peer_name == "bob"));
+    }
+
+    #[test]
+    fn group_targets_pin_one_member_by_name_or_id() {
+        let (_temp, store, self_id) = group_with_members();
+        let group = store.group("team").expect("group");
+        let targets = group_targets(&store, &group, Some("self"), None).expect("targets");
+        assert_eq!(targets.len(), 1);
+        assert_eq!(
+            targets[0].peer_id, self_id,
+            "self-query resolves to the local member"
+        );
+        let error =
+            group_targets(&store, &group, Some("nobody"), None).expect_err("unknown member");
+        assert!(error.to_string().contains("No group member named"));
+    }
+
+    #[test]
+    fn group_targets_pin_one_contributed_share() {
+        let (_temp, store, _self_id) = group_with_members();
+        let group = store.group("team").expect("group");
+        let targets = group_targets(&store, &group, None, Some("project")).expect("targets");
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].peer_name, "self");
+        assert_eq!(targets[0].shares.len(), 1);
+
+        let error =
+            group_targets(&store, &group, None, Some("missing")).expect_err("unknown share");
+        assert!(error.to_string().contains("No member contributes a share"));
+    }
+
+    /// Group with the owner contributing `project` and a second member `bob`,
+    /// using real node ids so `member_info_from_store` can build fan-out targets.
+    fn group_with_members() -> (tempfile::TempDir, StateStore, String) {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir(&workspace).expect("workspace dir");
+        let store = StateStore::open(temp.path().join("state.db")).expect("store");
+        let share = store
+            .add_share("workspace-key", &workspace, "project", true)
+            .expect("share");
+        let self_id = iroh::SecretKey::generate().public().to_string();
+        let bob_id = iroh::SecretKey::generate().public().to_string();
+        store.add_group("team", &self_id, "self").expect("group");
+        store
+            .add_group_share("team", &self_id, &share.id, &share.name)
+            .expect("contribution");
+        store.save_remote_peer(&bob_id, "bob", "{}").expect("peer");
+        store.add_member("team", &bob_id, "member").expect("member");
+        (temp, store, self_id)
     }
 }

--- a/src/remote/daemon.rs
+++ b/src/remote/daemon.rs
@@ -238,7 +238,13 @@ async fn process_local(
         }
         LocalRequest::ShareGrants { share } => LocalResponse::Grants(context.store.grants(&share)?),
         LocalRequest::ShareRevoke { share, peer } => {
-            LocalResponse::Grant(context.store.revoke(&share, &peer)?)
+            match context.store.revoke(&share, &peer)? {
+                Some(grant) => LocalResponse::Grant(grant),
+                // An explicit revoke of a grant that never existed is an error
+                // on the CLI path, even though the group paths treat it as an
+                // idempotent no-op.
+                None => bail!("Peer `{peer}` has no active grant for `{share}`"),
+            }
         }
         LocalRequest::PeerList => LocalResponse::Peers(context.store.peers()?),
         LocalRequest::PeerForget { peer } => LocalResponse::Peer(context.store.forget_peer(&peer)?),
@@ -344,12 +350,15 @@ async fn process_local(
             LocalResponse::Members(context.store.members(&group)?)
         }
         LocalRequest::GroupShares { group } => {
-            let group = context.store.group(&group)?;
-            LocalResponse::GroupShares(
-                context
+            // First-time join runs before any local group row exists; an
+            // unknown group simply means nothing is contributed yet.
+            let shares = match context.store.group_opt(&group)? {
+                Some(group) => context
                     .store
                     .group_shares(&group.id, &context.identity.id())?,
-            )
+                None => Vec::new(),
+            };
+            LocalResponse::GroupShares(shares)
         }
         LocalRequest::GroupInvite {
             group,
@@ -634,6 +643,25 @@ async fn handle_remote(connection: Connection, context: Arc<DaemonContext>) -> R
     Ok(())
 }
 
+/// Require `sender` to be the group's owner before roster-changing requests.
+///
+/// Membership changes are always owner-driven: joins, kicks, and leaves are
+/// broadcast by the owner after it updates its authoritative roster. Binding
+/// them to the transport-authenticated sender prevents a member from forging
+/// additions (which would grant an attacker read access to other members'
+/// contributions) or removals.
+fn require_group_owner(store: &StateStore, group_id: &str, sender: &str) -> Result<()> {
+    let owner = store
+        .members(group_id)?
+        .into_iter()
+        .find(|member| member.role == "owner")
+        .context("Group has no owner")?;
+    if owner.peer_id != sender {
+        bail!("Only the group owner may change membership");
+    }
+    Ok(())
+}
+
 async fn process_remote(
     context: &Arc<DaemonContext>,
     peer_id: &str,
@@ -758,6 +786,7 @@ async fn process_remote(
             })
         }
         RemoteRequest::GroupMemberAdded { group_id, member } => {
+            require_group_owner(&context.store, &group_id, peer_id)?;
             let endpoint_json = serde_json::to_string(&member.endpoint)?;
             context
                 .store
@@ -783,36 +812,46 @@ async fn process_remote(
         }
         RemoteRequest::GroupShareAdded {
             group_id,
-            peer_id,
+            peer_id: contributor,
             peer_name: _,
             share_id,
             share_name,
         } => {
+            // Only the contributor may register its own contribution; a forged
+            // peer_id would otherwise let a member attach arbitrary shares to
+            // other members' rosters.
+            if contributor != peer_id {
+                bail!("Only the contributor may register its own share");
+            }
             // The contributor granted everyone access locally; members only
             // need to register the new contribution so fan-out can reach it.
             context
                 .store
-                .add_group_share(&group_id, &peer_id, &share_id, &share_name)?;
+                .add_group_share(&group_id, &contributor, &share_id, &share_name)?;
             Ok(RemoteResponse::GroupAck)
         }
         RemoteRequest::GroupShareRemoved {
             group_id,
-            peer_id,
+            peer_id: contributor,
             share_id,
         } => {
+            if contributor != peer_id {
+                bail!("Only the contributor may withdraw its own share");
+            }
             // The share is no longer part of the group; drop the local
             // registration so fan-out stops dialing it.
             context
                 .store
-                .remove_group_share(&group_id, &peer_id, &share_id)?;
+                .remove_group_share(&group_id, &contributor, &share_id)?;
             Ok(RemoteResponse::GroupAck)
         }
         RemoteRequest::GroupMemberRemoved {
             group_id,
-            peer_id,
+            peer_id: removed_peer,
             peer_name: _,
         } => {
-            if peer_id == context.identity.id() {
+            require_group_owner(&context.store, &group_id, peer_id)?;
+            if removed_peer == context.identity.id() {
                 // We were kicked (or the owner disbanded the group).
                 drop_group(context, &group_id).await?;
             } else {
@@ -820,9 +859,9 @@ async fn process_remote(
                     .store
                     .group_shares(&group_id, &context.identity.id())?
                 {
-                    revoke_peer_grant(&context.store, &share.share_id, &peer_id);
+                    revoke_peer_grant(&context.store, &share.share_id, &removed_peer)?;
                 }
-                context.store.remove_member(&group_id, &peer_id)?;
+                context.store.remove_member(&group_id, &removed_peer)?;
             }
             Ok(RemoteResponse::GroupAck)
         }
@@ -831,58 +870,66 @@ async fn process_remote(
             let leaver = members_before
                 .iter()
                 .find(|row| row.peer_id == peer_id)
-                .cloned();
+                .cloned()
+                .context("Unknown group member")?;
             context.store.remove_member(&group_id, peer_id)?;
             // Revoke every owner contribution from the leaver.
             if let Some(owner) = members_before.iter().find(|row| row.role == "owner") {
                 for share in context.store.group_shares(&group_id, &owner.peer_id)? {
-                    revoke_peer_grant(&context.store, &share.share_id, peer_id);
+                    revoke_peer_grant(&context.store, &share.share_id, peer_id)?;
                 }
             }
-            if let Some(leaver) = leaver {
-                broadcast(
-                    context,
-                    &group_id,
-                    RemoteRequest::GroupMemberRemoved {
-                        group_id: group_id.clone(),
-                        peer_id: leaver.peer_id.clone(),
-                        peer_name: leaver.peer_name.clone(),
-                    },
-                    None,
-                )
-                .await;
-            }
+            broadcast(
+                context,
+                &group_id,
+                RemoteRequest::GroupMemberRemoved {
+                    group_id: group_id.clone(),
+                    peer_id: leaver.peer_id.clone(),
+                    peer_name: leaver.peer_name.clone(),
+                },
+                None,
+            )
+            .await;
             Ok(RemoteResponse::GroupAck)
         }
         RemoteRequest::GroupSync { group_id } => {
-            let (group_name, member, members) = match context.store.group(&group_id) {
-                Ok(group) => {
-                    let roster: Vec<MemberInfo> = context
-                        .store
-                        .members(&group.id)?
-                        .iter()
-                        .map(|member| member_info_from_store(&context.store, &group.id, member))
-                        .collect::<Result<_>>()?;
-                    let is_member = roster.iter().any(|row| row.peer_id == peer_id);
-                    // Live endpoint for the owner's own entry.
-                    let owner_addr = context.endpoint.addr();
-                    let roster = roster
-                        .into_iter()
-                        .map(|mut row| {
-                            if row.peer_id == context.identity.id() {
-                                row.endpoint = owner_addr.clone();
-                            }
-                            row
-                        })
-                        .collect();
-                    (group.name, is_member, roster)
-                }
-                Err(_) => (group_id.clone(), false, Vec::new()),
+            let Ok(group) = context.store.group(&group_id) else {
+                return Ok(RemoteResponse::GroupSynced {
+                    group_name: group_id.clone(),
+                    member: false,
+                    members: Vec::new(),
+                });
             };
+            let roster: Vec<MemberInfo> = context
+                .store
+                .members(&group.id)?
+                .iter()
+                .map(|member| member_info_from_store(&context.store, &group.id, member))
+                .collect::<Result<_>>()?;
+            // The roster is membership data: only members may read it, so a
+            // non-member learns only that it is not a member.
+            if !roster.iter().any(|row| row.peer_id == peer_id) {
+                return Ok(RemoteResponse::GroupSynced {
+                    group_name: group.name,
+                    member: false,
+                    members: Vec::new(),
+                });
+            }
+            // Live endpoint for the owner's own entry.
+            let owner_addr = context.endpoint.addr();
+            let roster = roster
+                .into_iter()
+                .map(|mut row| {
+                    if row.peer_id == context.identity.id() {
+                        row.endpoint = owner_addr.clone();
+                    }
+                    row
+                })
+                .collect();
             Ok(RemoteResponse::GroupSynced {
-                group_name,
-                member,
-                members,
+                group_name: group.name,
+                member: true,
+                members: roster,
             })
         }
     }
@@ -1088,6 +1135,26 @@ async fn sync_group(context: &Arc<DaemonContext>, group_name_or_id: &str) -> Res
                 context
                     .store
                     .add_member(&group.id, &remote.peer_id, &remote.role)?;
+                // Reconcile this member's full contribution set: a share the
+                // owner no longer lists (e.g. a lost GroupShareRemoved push)
+                // must not keep fan-out dialing it. Our own contributions are
+                // local authority and never pruned here.
+                if remote.peer_id != self_id {
+                    let local = context.store.group_shares(&group.id, &remote.peer_id)?;
+                    for existing in local {
+                        if !remote
+                            .shares
+                            .iter()
+                            .any(|(share_id, _)| *share_id == existing.share_id)
+                        {
+                            context.store.remove_group_share(
+                                &group.id,
+                                &remote.peer_id,
+                                &existing.share_id,
+                            )?;
+                        }
+                    }
+                }
                 for (share_id, share_name) in &remote.shares {
                     context.store.add_group_share(
                         &group.id,
@@ -1113,7 +1180,7 @@ async fn sync_group(context: &Arc<DaemonContext>, group_name_or_id: &str) -> Res
                 if !members.iter().any(|remote| remote.peer_id == local.peer_id) {
                     context.store.remove_member(&group.id, &local.peer_id)?;
                     for share in &self_shares {
-                        revoke_peer_grant(&context.store, &share.share_id, &local.peer_id);
+                        revoke_peer_grant(&context.store, &share.share_id, &local.peer_id)?;
                     }
                 }
             }
@@ -1150,7 +1217,7 @@ async fn drop_group(context: &Arc<DaemonContext>, group_name_or_id: &str) -> Res
     for share in context.store.group_shares(&group.id, &self_id)? {
         for member in &members {
             if member.peer_id != self_id {
-                revoke_peer_grant(&context.store, &share.share_id, &member.peer_id);
+                revoke_peer_grant(&context.store, &share.share_id, &member.peer_id)?;
             }
         }
     }
@@ -1172,7 +1239,7 @@ async fn leave_group(context: &Arc<DaemonContext>, group_name_or_id: &str) -> Re
         for member in &members {
             if member.peer_id != self_id {
                 for share in &self_shares {
-                    revoke_peer_grant(&context.store, &share.share_id, &member.peer_id);
+                    revoke_peer_grant(&context.store, &share.share_id, &member.peer_id)?;
                 }
             }
         }
@@ -1204,7 +1271,7 @@ async fn leave_group(context: &Arc<DaemonContext>, group_name_or_id: &str) -> Re
     for member in &members {
         if member.peer_id != self_id {
             for share in &self_shares {
-                revoke_peer_grant(&context.store, &share.share_id, &member.peer_id);
+                revoke_peer_grant(&context.store, &share.share_id, &member.peer_id)?;
             }
         }
     }
@@ -1248,7 +1315,7 @@ async fn remove_group_member(
         })
         .context("Unknown group member")?;
     for share in context.store.group_shares(&group.id, &self_id)? {
-        revoke_peer_grant(&context.store, &share.share_id, &target.peer_id);
+        revoke_peer_grant(&context.store, &share.share_id, &target.peer_id)?;
     }
     context.store.remove_member(&group.id, &target.peer_id)?;
     // Everyone hears about the removal — the removed peer clears the group
@@ -1400,9 +1467,15 @@ fn member_info_from_store(
     })
 }
 
-/// Revoke a grant if one exists; ignore the "no active grant" case.
-fn revoke_peer_grant(store: &StateStore, share_name_or_id: &str, peer_name_or_id: &str) {
-    store.revoke(share_name_or_id, peer_name_or_id).ok();
+/// Revoke a grant. A missing grant is an idempotent no-op (`revoke` returns
+/// `Ok(None)`); every storage failure is propagated, so kick/leave/disband
+/// cannot report success while access remains active.
+fn revoke_peer_grant(
+    store: &StateStore,
+    share_name_or_id: &str,
+    peer_name_or_id: &str,
+) -> Result<()> {
+    store.revoke(share_name_or_id, peer_name_or_id).map(|_| ())
 }
 
 fn random_token() -> String {
@@ -1416,5 +1489,39 @@ pub fn remove_stale_daemon_info() -> Result<()> {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
         Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::require_group_owner;
+    use super::StateStore;
+
+    fn group_store() -> (tempfile::TempDir, StateStore) {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let store = StateStore::open(temp.path().join("state.db")).expect("store");
+        store.add_group("team", "self-1", "self").expect("group");
+        store.save_remote_peer("peer-2", "bob", "{}").expect("peer");
+        store
+            .add_member("team", "peer-2", "member")
+            .expect("member");
+        (temp, store)
+    }
+
+    #[test]
+    fn only_the_owner_may_change_membership() {
+        let (_temp, store) = group_store();
+        require_group_owner(&store, "team", "self-1").expect("owner passes");
+        let error = require_group_owner(&store, "team", "peer-2").expect_err("member rejected");
+        assert!(error.to_string().contains("Only the group owner"));
+        let error = require_group_owner(&store, "team", "stranger").expect_err("outsider rejected");
+        assert!(error.to_string().contains("Only the group owner"));
+    }
+
+    #[test]
+    fn unknown_group_has_no_owner() {
+        let (_temp, store) = group_store();
+        let error = require_group_owner(&store, "missing", "self-1").expect_err("unknown group");
+        assert!(error.to_string().contains("Unknown group"));
     }
 }

--- a/src/remote/daemon.rs
+++ b/src/remote/daemon.rs
@@ -2,6 +2,7 @@ use std::fs::OpenOptions;
 use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use base64::Engine;
@@ -13,14 +14,17 @@ use iroh::{Endpoint, EndpointAddr};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::watch;
+use tokio::task::JoinSet;
 
 use super::identity::Identity;
 use super::ipc;
 use super::protocol::{
-    DaemonInfo, DaemonStatus, InviteTicket, LocalEnvelope, LocalRequest, LocalResponse,
-    QueryResponse, RemoteRequest, RemoteResponse, MAX_MESSAGE_SIZE, REMOTE_ALPN,
+    DaemonInfo, DaemonStatus, GroupQueryResponse, InviteTicket, LocalEnvelope, LocalRequest,
+    LocalResponse, MemberInfo, QueryResponse, RemoteRequest, RemoteResponse, MAX_MESSAGE_SIZE,
+    REMOTE_ALPN,
 };
-use super::state::{MountInfo, StateStore};
+use super::state::{GroupMemberInfo, MountInfo, StateStore};
+use crate::commands::memory::filter::Filter;
 
 pub fn run() -> Result<()> {
     let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -179,7 +183,7 @@ async fn handle_local(
 }
 
 async fn process_local(
-    context: &DaemonContext,
+    context: &Arc<DaemonContext>,
     request: LocalRequest,
 ) -> Result<(LocalResponse, bool)> {
     let response = match request {
@@ -220,6 +224,7 @@ async fn process_local(
                 version: 1,
                 endpoint: context.endpoint.addr(),
                 share_id: invite.share_id,
+                group_id: None,
                 invite_id: invite.id,
                 secret: invite.secret,
                 expires_at: invite.expires_at,
@@ -309,6 +314,180 @@ async fn process_local(
                 }
                 response => bail!("Unexpected remote response: {response:?}"),
             }
+        }
+        LocalRequest::GroupCreate {
+            name,
+            share_id,
+            share_name,
+        } => {
+            let group =
+                context
+                    .store
+                    .add_group(&name, &context.identity.id(), &context.identity.name)?;
+            // The owner's first contribution is the workspace they created from.
+            context.store.add_group_share(
+                &group.id,
+                &context.identity.id(),
+                &share_id,
+                &share_name,
+            )?;
+            LocalResponse::Group(group)
+        }
+        LocalRequest::GroupList => {
+            for group in context.store.groups()? {
+                maybe_sync_group(context, &group.name).await;
+            }
+            LocalResponse::Groups(context.store.groups()?)
+        }
+        LocalRequest::GroupMembers { group } => {
+            maybe_sync_group(context, &group).await;
+            LocalResponse::Members(context.store.members(&group)?)
+        }
+        LocalRequest::GroupShares { group } => {
+            let group = context.store.group(&group)?;
+            LocalResponse::GroupShares(
+                context
+                    .store
+                    .group_shares(&group.id, &context.identity.id())?,
+            )
+        }
+        LocalRequest::GroupInvite {
+            group,
+            valid_for_seconds,
+            max_uses,
+        } => {
+            let invite = context
+                .store
+                .create_group_invite(&group, valid_for_seconds, max_uses)?;
+            let ticket = InviteTicket {
+                version: 1,
+                endpoint: context.endpoint.addr(),
+                share_id: String::new(),
+                group_id: Some(invite.share_id.clone()),
+                invite_id: invite.id,
+                secret: invite.secret,
+                expires_at: invite.expires_at,
+            }
+            .encode()?;
+            LocalResponse::Invitation {
+                share_name: invite.share_name,
+                ticket,
+                expires_at: invite.expires_at,
+            }
+        }
+        LocalRequest::GroupJoin { invite, shares } => {
+            let ticket = InviteTicket::parse(&invite)?;
+            if ticket.expires_at < Utc::now().timestamp() {
+                bail!("Invitation is expired");
+            }
+            let group_id = ticket
+                .group_id
+                .as_deref()
+                .context("Invitation is not a group invite")?;
+            // A known member re-running join adjusts contributions (multi-select
+            // checkboxes: additions register + grant, withdrawals revoke).
+            let known = context.store.group(group_id).ok();
+            let is_member = known.as_ref().is_some_and(|group| {
+                context
+                    .store
+                    .members(&group.id)
+                    .map(|members| {
+                        members
+                            .iter()
+                            .any(|member| member.peer_id == context.identity.id())
+                    })
+                    .unwrap_or(false)
+            });
+            if is_member {
+                let group = known.expect("group exists");
+                adjust_group_shares(context, &group.id, &shares).await?;
+                LocalResponse::GroupJoined {
+                    group_name: group.name,
+                    member_count: group.member_count as usize,
+                }
+            } else {
+                let (group_name, member_count) =
+                    redeem_group_remote(context, &invite, &shares).await?;
+                LocalResponse::GroupJoined {
+                    group_name,
+                    member_count,
+                }
+            }
+        }
+        LocalRequest::GroupLeave { group } => {
+            leave_group(context, &group).await?;
+            LocalResponse::Ok
+        }
+        LocalRequest::GroupRemoveMember { group, peer } => {
+            remove_group_member(context, &group, &peer).await?;
+            LocalResponse::Ok
+        }
+        LocalRequest::GroupSync { group } => {
+            sync_group(context, &group).await?;
+            LocalResponse::Group(context.store.group(&group)?)
+        }
+        LocalRequest::GroupQuery {
+            group,
+            member,
+            share,
+            source,
+            filter,
+        } => {
+            let group_info = context.store.group(&group)?;
+            maybe_sync_group(context, &group).await;
+            let roster = context.store.members(&group_info.id)?;
+            let all: Vec<MemberInfo> = roster
+                .iter()
+                .filter(|member| member.peer_id != context.identity.id())
+                .map(|member| member_info_from_store(&context.store, &group_info.id, member))
+                .collect::<Result<_>>()?;
+            let mut targets: Vec<MemberInfo> = match member {
+                Some(name) => {
+                    let needle = name.to_ascii_lowercase();
+                    let matches: Vec<MemberInfo> = all
+                        .into_iter()
+                        .filter(|member| {
+                            member.peer_name.to_ascii_lowercase() == needle
+                                || member.peer_id == needle
+                        })
+                        .collect();
+                    if matches.is_empty() {
+                        bail!("No group member named `{name}` in `{}`", group_info.name);
+                    }
+                    matches
+                }
+                None => all,
+            };
+            // Three-segment scope `team/alice/proj-b` pins one contributed share.
+            if let Some(share_name) = share {
+                for target in &mut targets {
+                    target
+                        .shares
+                        .retain(|(_, name)| name.eq_ignore_ascii_case(&share_name));
+                }
+                targets.retain(|target| !target.shares.is_empty());
+                if targets.is_empty() {
+                    bail!(
+                        "No member contributes a share named `{share_name}` in `{}`",
+                        group_info.name
+                    );
+                }
+            }
+            if targets.is_empty() {
+                return Ok((
+                    LocalResponse::GroupQuery(GroupQueryResponse {
+                        query: QueryResponse {
+                            records: Vec::new(),
+                            anchors: Vec::new(),
+                        },
+                        skipped: Vec::new(),
+                    }),
+                    false,
+                ));
+            }
+            let response =
+                group_fan_out(context, &group_info.name, &targets, &source, filter).await;
+            LocalResponse::GroupQuery(response)
         }
     };
     Ok((response, false))
@@ -456,7 +635,7 @@ async fn handle_remote(connection: Connection, context: Arc<DaemonContext>) -> R
 }
 
 async fn process_remote(
-    context: &DaemonContext,
+    context: &Arc<DaemonContext>,
     peer_id: &str,
     request: RemoteRequest,
 ) -> Result<RemoteResponse> {
@@ -482,12 +661,26 @@ async fn process_remote(
         } => {
             let share = context.store.authorize(peer_id, &share_id, "query")?;
             let response = tokio::task::spawn_blocking(move || {
-                let (records, anchors) = crate::commands::memory::workset::run_on_share(
+                let result = crate::commands::memory::workset::run_on_share(
                     std::path::Path::new(&share.root),
                     &source,
                     filter,
                     share.redact,
-                )?;
+                );
+                // An empty workspace has no sessions; report it as an empty
+                // result instead of an error (matches the client-side
+                // convention in `query_many`).
+                let (records, anchors) = match result {
+                    Ok(result) => result,
+                    Err(error)
+                        if error
+                            .to_string()
+                            .starts_with("No record found for ref selector") =>
+                    {
+                        (Vec::new(), Vec::new())
+                    }
+                    Err(error) => return Err(error),
+                };
                 Ok::<_, anyhow::Error>(QueryResponse { records, anchors })
             })
             .await??;
@@ -498,6 +691,198 @@ async fn process_remote(
             Ok(RemoteResponse::Probe {
                 server_name: context.identity.name.clone(),
                 share_name: share.name,
+            })
+        }
+        RemoteRequest::RedeemGroupInvite {
+            group_id,
+            invite_id,
+            secret,
+            peer_name,
+            shares,
+            endpoint,
+        } => {
+            let endpoint_json = serde_json::to_string(&endpoint)?;
+            let joiner = super::state::JoinerInfo {
+                peer_id,
+                peer_name: &peer_name,
+                shares: &shares,
+                endpoint_json: &endpoint_json,
+            };
+            let roster = context
+                .store
+                .redeem_group_invite(&invite_id, &secret, &joiner)?;
+            let group_name = context.store.group(&group_id)?.name;
+            let members: Vec<MemberInfo> = roster
+                .iter()
+                .map(|member| member_info_from_store(&context.store, &group_id, member))
+                .collect::<Result<_>>()?;
+            // Ensure the owner's own roster entry carries the live endpoint so
+            // the joiner can dial back without relying on discovery alone.
+            let owner_addr = context.endpoint.addr();
+            let members = members
+                .into_iter()
+                .map(|mut member| {
+                    if member.peer_id == context.identity.id() {
+                        member.endpoint = owner_addr.clone();
+                    }
+                    member
+                })
+                .collect();
+            // Notify existing members about the newcomer so they can grant the
+            // newcomer access. Offline members reconcile on their next sync.
+            let newcomer = MemberInfo {
+                peer_id: peer_id.to_string(),
+                peer_name,
+                shares,
+                role: "member".to_string(),
+                endpoint,
+            };
+            let context = context.clone();
+            let group_id = group_id.clone();
+            let newcomer_id = newcomer.peer_id.clone();
+            tokio::spawn(async move {
+                broadcast(
+                    &context,
+                    &group_id,
+                    RemoteRequest::GroupMemberAdded {
+                        group_id: group_id.clone(),
+                        member: newcomer,
+                    },
+                    Some(&newcomer_id),
+                )
+                .await;
+            });
+            Ok(RemoteResponse::GroupJoined {
+                group_name,
+                members,
+            })
+        }
+        RemoteRequest::GroupMemberAdded { group_id, member } => {
+            let endpoint_json = serde_json::to_string(&member.endpoint)?;
+            context
+                .store
+                .save_remote_peer(&member.peer_id, &member.peer_name, &endpoint_json)?;
+            context
+                .store
+                .add_member(&group_id, &member.peer_id, &member.role)?;
+            for (share_id, share_name) in &member.shares {
+                context
+                    .store
+                    .add_group_share(&group_id, &member.peer_id, share_id, share_name)?;
+            }
+            // Grant the newcomer read access to every contribution we make.
+            for share in context
+                .store
+                .group_shares(&group_id, &context.identity.id())?
+            {
+                context
+                    .store
+                    .group_grant(&share.share_id, &member.peer_id)?;
+            }
+            Ok(RemoteResponse::GroupAck)
+        }
+        RemoteRequest::GroupShareAdded {
+            group_id,
+            peer_id,
+            peer_name: _,
+            share_id,
+            share_name,
+        } => {
+            // The contributor granted everyone access locally; members only
+            // need to register the new contribution so fan-out can reach it.
+            context
+                .store
+                .add_group_share(&group_id, &peer_id, &share_id, &share_name)?;
+            Ok(RemoteResponse::GroupAck)
+        }
+        RemoteRequest::GroupShareRemoved {
+            group_id,
+            peer_id,
+            share_id,
+        } => {
+            // The share is no longer part of the group; drop the local
+            // registration so fan-out stops dialing it.
+            context
+                .store
+                .remove_group_share(&group_id, &peer_id, &share_id)?;
+            Ok(RemoteResponse::GroupAck)
+        }
+        RemoteRequest::GroupMemberRemoved {
+            group_id,
+            peer_id,
+            peer_name: _,
+        } => {
+            if peer_id == context.identity.id() {
+                // We were kicked (or the owner disbanded the group).
+                drop_group(context, &group_id).await?;
+            } else {
+                for share in context
+                    .store
+                    .group_shares(&group_id, &context.identity.id())?
+                {
+                    revoke_peer_grant(&context.store, &share.share_id, &peer_id);
+                }
+                context.store.remove_member(&group_id, &peer_id)?;
+            }
+            Ok(RemoteResponse::GroupAck)
+        }
+        RemoteRequest::GroupLeave { group_id } => {
+            let members_before = context.store.members(&group_id)?;
+            let leaver = members_before
+                .iter()
+                .find(|row| row.peer_id == peer_id)
+                .cloned();
+            context.store.remove_member(&group_id, peer_id)?;
+            // Revoke every owner contribution from the leaver.
+            if let Some(owner) = members_before.iter().find(|row| row.role == "owner") {
+                for share in context.store.group_shares(&group_id, &owner.peer_id)? {
+                    revoke_peer_grant(&context.store, &share.share_id, peer_id);
+                }
+            }
+            if let Some(leaver) = leaver {
+                broadcast(
+                    context,
+                    &group_id,
+                    RemoteRequest::GroupMemberRemoved {
+                        group_id: group_id.clone(),
+                        peer_id: leaver.peer_id.clone(),
+                        peer_name: leaver.peer_name.clone(),
+                    },
+                    None,
+                )
+                .await;
+            }
+            Ok(RemoteResponse::GroupAck)
+        }
+        RemoteRequest::GroupSync { group_id } => {
+            let (group_name, member, members) = match context.store.group(&group_id) {
+                Ok(group) => {
+                    let roster: Vec<MemberInfo> = context
+                        .store
+                        .members(&group.id)?
+                        .iter()
+                        .map(|member| member_info_from_store(&context.store, &group.id, member))
+                        .collect::<Result<_>>()?;
+                    let is_member = roster.iter().any(|row| row.peer_id == peer_id);
+                    // Live endpoint for the owner's own entry.
+                    let owner_addr = context.endpoint.addr();
+                    let roster = roster
+                        .into_iter()
+                        .map(|mut row| {
+                            if row.peer_id == context.identity.id() {
+                                row.endpoint = owner_addr.clone();
+                            }
+                            row
+                        })
+                        .collect();
+                    (group.name, is_member, roster)
+                }
+                Err(_) => (group_id.clone(), false, Vec::new()),
+            };
+            Ok(RemoteResponse::GroupSynced {
+                group_name,
+                member,
+                members,
             })
         }
     }
@@ -511,6 +896,513 @@ fn qualify_query_scope(scope: &str, response: &mut QueryResponse) {
     for anchor in &mut response.anchors {
         *anchor = anchor.with_named_scope(scope.clone());
     }
+}
+
+// ---------------------------------------------------------------------------
+// Group mode: a named set of devices that expose their memory to each other.
+// Membership is a mesh overlay on the existing share/grant/mount model: join =
+// redeem a multi-use invite with the owner, mirror the roster (members and
+// their contributed shares) locally, and grant every member read access to
+// every share we contribute.
+// ---------------------------------------------------------------------------
+
+/// Client-side join (first time): redeem the invite with the owner, mirror the
+/// roster, register our contributed shares, and grant members.
+async fn redeem_group_remote(
+    context: &Arc<DaemonContext>,
+    encoded_invite: &str,
+    shares: &[(String, String)],
+) -> Result<(String, usize)> {
+    let invite = InviteTicket::parse(encoded_invite)?;
+    if invite.expires_at < Utc::now().timestamp() {
+        bail!("Invitation is expired");
+    }
+    let group_id = invite
+        .group_id
+        .as_deref()
+        .context("Invitation is not a group invite")?;
+    let (response, _observed) = exchange(
+        context,
+        invite.endpoint,
+        RemoteRequest::RedeemGroupInvite {
+            group_id: group_id.to_string(),
+            invite_id: invite.invite_id,
+            secret: invite.secret,
+            peer_name: context.identity.name.clone(),
+            shares: shares.to_vec(),
+            endpoint: context.endpoint.addr(),
+        },
+    )
+    .await?;
+    let (group_name, members) = match response {
+        RemoteResponse::GroupJoined {
+            group_name,
+            members,
+        } => (group_name, members),
+        response => bail!("Unexpected invitation response: {response:?}"),
+    };
+    // Our own device is a peer of itself (FK target in group_members).
+    context
+        .store
+        .save_remote_peer(&context.identity.id(), &context.identity.name, "{}")?;
+    // Mirror the owner-assigned group identity and join it.
+    context.store.register_group(group_id, &group_name)?;
+    context
+        .store
+        .add_member(group_id, &context.identity.id(), "member")?;
+    for (share_id, share_name) in shares {
+        context
+            .store
+            .add_group_share(group_id, &context.identity.id(), share_id, share_name)?;
+    }
+    // Mirror the roster and grant every member read access to our shares.
+    for member in &members {
+        let member_endpoint = serde_json::to_string(&member.endpoint)?;
+        context
+            .store
+            .save_remote_peer(&member.peer_id, &member.peer_name, &member_endpoint)?;
+        context
+            .store
+            .add_member(group_id, &member.peer_id, &member.role)?;
+        for (share_id, share_name) in &member.shares {
+            context
+                .store
+                .add_group_share(group_id, &member.peer_id, share_id, share_name)?;
+        }
+        for (share_id, _) in shares {
+            context.store.group_grant(share_id, &member.peer_id)?;
+        }
+    }
+    context.store.touch_group_sync(group_id)?;
+    // The returned roster already includes this device; it is the full count.
+    Ok((group_name, members.len()))
+}
+
+/// An existing member re-runs join with the final checkbox list: register new
+/// contributions (granting every member), withdraw unchecked ones (revoking
+/// grants), and broadcast both directions so peers stay in sync.
+async fn adjust_group_shares(
+    context: &Arc<DaemonContext>,
+    group_name_or_id: &str,
+    shares: &[(String, String)],
+) -> Result<()> {
+    let group = context.store.group(group_name_or_id)?;
+    let self_id = context.identity.id();
+    let members = context.store.members(&group.id)?;
+    let current = context.store.group_shares(&group.id, &self_id)?;
+    let wanted: &[(String, String)] = shares;
+
+    for (share_id, share_name) in wanted {
+        if !current
+            .iter()
+            .any(|existing| existing.share_id == *share_id)
+        {
+            context
+                .store
+                .add_group_share(&group.id, &self_id, share_id, share_name)?;
+            for member in &members {
+                if member.peer_id != self_id {
+                    context.store.group_grant(share_id, &member.peer_id)?;
+                }
+            }
+            broadcast(
+                context,
+                &group.id,
+                RemoteRequest::GroupShareAdded {
+                    group_id: group.id.clone(),
+                    peer_id: self_id.clone(),
+                    peer_name: String::new(),
+                    share_id: share_id.clone(),
+                    share_name: share_name.clone(),
+                },
+                Some(&self_id),
+            )
+            .await;
+        }
+    }
+    for existing in current {
+        if !wanted.iter().any(|(id, _)| *id == existing.share_id) {
+            context
+                .store
+                .remove_group_share(&group.id, &self_id, &existing.share_id)?;
+            context
+                .store
+                .revoke_group_share(&group.id, &existing.share_id, &self_id)?;
+            broadcast(
+                context,
+                &group.id,
+                RemoteRequest::GroupShareRemoved {
+                    group_id: group.id.clone(),
+                    peer_id: self_id.clone(),
+                    share_id: existing.share_id.clone(),
+                },
+                Some(&self_id),
+            )
+            .await;
+        }
+    }
+    Ok(())
+}
+
+/// Pull the authoritative roster from the owner and reconcile membership,
+/// contributions, and grants. If the owner says we are no longer a member,
+/// drop the group.
+async fn sync_group(context: &Arc<DaemonContext>, group_name_or_id: &str) -> Result<()> {
+    let group = context.store.group(group_name_or_id)?;
+    let local_members = context.store.members(&group.id)?;
+    let owner = local_members
+        .iter()
+        .find(|member| member.role == "owner")
+        .context("Group has no owner")?;
+    if owner.peer_id == context.identity.id() {
+        // The owner is the roster source of truth; nothing to pull.
+        context.store.touch_group_sync(&group.id)?;
+        return Ok(());
+    }
+    let response = exchange_with_peer(
+        context,
+        &owner.peer_id,
+        RemoteRequest::GroupSync {
+            group_id: group.id.clone(),
+        },
+    )
+    .await?;
+    match response {
+        RemoteResponse::GroupSynced {
+            group_name: _,
+            member,
+            members,
+        } => {
+            if !member {
+                drop_group(context, &group.id).await?;
+                return Ok(());
+            }
+            let self_id = context.identity.id();
+            // Roster is authoritative: upsert peers, membership, contributions.
+            for remote in &members {
+                context.store.save_remote_peer(
+                    &remote.peer_id,
+                    &remote.peer_name,
+                    &serde_json::to_string(&remote.endpoint)?,
+                )?;
+                context
+                    .store
+                    .add_member(&group.id, &remote.peer_id, &remote.role)?;
+                for (share_id, share_name) in &remote.shares {
+                    context.store.add_group_share(
+                        &group.id,
+                        &remote.peer_id,
+                        share_id,
+                        share_name,
+                    )?;
+                }
+            }
+            // Grant every member read access to our contributions.
+            let self_shares = context.store.group_shares(&group.id, &self_id)?;
+            for remote in &members {
+                if remote.peer_id != self_id {
+                    for share in &self_shares {
+                        context
+                            .store
+                            .group_grant(&share.share_id, &remote.peer_id)?;
+                    }
+                }
+            }
+            // Drop members the owner no longer lists, revoking their grants.
+            for local in local_members {
+                if !members.iter().any(|remote| remote.peer_id == local.peer_id) {
+                    context.store.remove_member(&group.id, &local.peer_id)?;
+                    for share in &self_shares {
+                        revoke_peer_grant(&context.store, &share.share_id, &local.peer_id);
+                    }
+                }
+            }
+            context.store.touch_group_sync(&group.id)?;
+            Ok(())
+        }
+        response => bail!("Unexpected group sync response: {response:?}"),
+    }
+}
+
+/// Best-effort sync when the cached roster is stale; never blocks queries.
+/// The owner short-circuits inside [`sync_group`].
+async fn maybe_sync_group(context: &Arc<DaemonContext>, group_name_or_id: &str) {
+    let stale = match context.store.sync_stale(group_name_or_id, 300) {
+        Ok(stale) => stale,
+        Err(_) => return,
+    };
+    if stale {
+        if let Err(error) = sync_group(context, group_name_or_id).await {
+            // Owner unreachable — fall back to the cached roster.
+            crate::output::error(format!(
+                "group sync failed for `{group_name_or_id}`: {error:#}"
+            ));
+        }
+    }
+}
+
+/// Remove the group locally: revoke the grants we handed out on every
+/// contribution, then drop the group row (members + contributions cascade).
+async fn drop_group(context: &Arc<DaemonContext>, group_name_or_id: &str) -> Result<()> {
+    let group = context.store.group(group_name_or_id)?;
+    let members = context.store.members(&group.id)?;
+    let self_id = context.identity.id();
+    for share in context.store.group_shares(&group.id, &self_id)? {
+        for member in &members {
+            if member.peer_id != self_id {
+                revoke_peer_grant(&context.store, &share.share_id, &member.peer_id);
+            }
+        }
+    }
+    context.store.remove_group(&group.id)?;
+    Ok(())
+}
+
+async fn leave_group(context: &Arc<DaemonContext>, group_name_or_id: &str) -> Result<()> {
+    let group = context.store.group(group_name_or_id)?;
+    let members = context.store.members(&group.id)?;
+    let self_id = context.identity.id();
+    let self_member = members
+        .iter()
+        .find(|member| member.peer_id == self_id)
+        .context("You are not a member of this group")?;
+    let self_shares = context.store.group_shares(&group.id, &self_id)?;
+    if self_member.role == "owner" {
+        // Owner leaving disbands the group: revoke all grants and kick everyone.
+        for member in &members {
+            if member.peer_id != self_id {
+                for share in &self_shares {
+                    revoke_peer_grant(&context.store, &share.share_id, &member.peer_id);
+                }
+            }
+        }
+        context.store.remove_group(&group.id)?;
+        // Kick every remaining member: each request names its own target
+        // (`peer_id` differs per recipient), so broadcast's shared template
+        // does not fit — send them individually.
+        for member in &members {
+            if member.peer_id == self_id {
+                continue;
+            }
+            let _ = tokio::time::timeout(
+                Duration::from_secs(3),
+                exchange_with_peer(
+                    context,
+                    &member.peer_id,
+                    RemoteRequest::GroupMemberRemoved {
+                        group_id: group.id.clone(),
+                        peer_id: member.peer_id.clone(),
+                        peer_name: String::new(),
+                    },
+                ),
+            )
+            .await;
+        }
+        return Ok(());
+    }
+    // Regular member: revoke the grants we gave the group on our shares.
+    for member in &members {
+        if member.peer_id != self_id {
+            for share in &self_shares {
+                revoke_peer_grant(&context.store, &share.share_id, &member.peer_id);
+            }
+        }
+    }
+    context.store.remove_member(&group.id, &self_id)?;
+    if let Some(owner) = members.iter().find(|member| member.role == "owner") {
+        let _ = tokio::time::timeout(
+            Duration::from_secs(3),
+            exchange_with_peer(
+                context,
+                &owner.peer_id,
+                RemoteRequest::GroupLeave {
+                    group_id: group.id.clone(),
+                },
+            ),
+        )
+        .await;
+    }
+    Ok(())
+}
+
+async fn remove_group_member(
+    context: &Arc<DaemonContext>,
+    group_name_or_id: &str,
+    peer_name_or_id: &str,
+) -> Result<()> {
+    let group = context.store.group(group_name_or_id)?;
+    let members = context.store.members(&group.id)?;
+    let self_id = context.identity.id();
+    let self_member = members
+        .iter()
+        .find(|member| member.peer_id == self_id)
+        .context("You are not a member of this group")?;
+    if self_member.role != "owner" {
+        bail!("Only the group owner can remove members");
+    }
+    let target = members
+        .iter()
+        .find(|member| {
+            member.peer_id == peer_name_or_id
+                || member.peer_name.eq_ignore_ascii_case(peer_name_or_id)
+        })
+        .context("Unknown group member")?;
+    for share in context.store.group_shares(&group.id, &self_id)? {
+        revoke_peer_grant(&context.store, &share.share_id, &target.peer_id);
+    }
+    context.store.remove_member(&group.id, &target.peer_id)?;
+    // Everyone hears about the removal — the removed peer clears the group
+    // locally when it sees its own peer_id.
+    broadcast(
+        context,
+        &group.id,
+        RemoteRequest::GroupMemberRemoved {
+            group_id: group.id.clone(),
+            peer_id: target.peer_id.clone(),
+            peer_name: target.peer_name.clone(),
+        },
+        None,
+    )
+    .await;
+    Ok(())
+}
+
+/// Best-effort send `request` to every group member except `skip`. The caller
+/// builds the request once from borrowed data; each member task owns a cloned
+/// copy ('static tasks), which is the only clone per member.
+async fn broadcast(
+    context: &Arc<DaemonContext>,
+    group_name_or_id: &str,
+    request: RemoteRequest,
+    skip: Option<&str>,
+) {
+    let Ok(members) = context.store.members(group_name_or_id) else {
+        return;
+    };
+    let mut tasks = JoinSet::new();
+    for member in members {
+        if skip == Some(member.peer_id.as_str()) {
+            continue;
+        }
+        let context = context.clone();
+        let peer_id = member.peer_id.clone();
+        let request = request.clone();
+        tasks.spawn(async move {
+            let _ = tokio::time::timeout(
+                Duration::from_secs(3),
+                exchange_with_peer(&context, &peer_id, request),
+            )
+            .await;
+        });
+    }
+    while tasks.join_next().await.is_some() {}
+}
+
+/// Parallel fan-out: query every (member, contributed share), merge results
+/// qualified per member and share, and report members that did not answer
+/// within the budget. A member counts as online if any share answered.
+async fn group_fan_out(
+    context: &Arc<DaemonContext>,
+    group_name: &str,
+    members: &[MemberInfo],
+    source: &str,
+    filter: Filter,
+) -> GroupQueryResponse {
+    const PER_PEER_TIMEOUT: Duration = Duration::from_millis(2500);
+    let mut tasks = JoinSet::new();
+    for member in members {
+        for (share_id, share_name) in &member.shares {
+            let context = context.clone();
+            let peer_id = member.peer_id.clone();
+            let peer_name = member.peer_name.clone();
+            let share_id = share_id.clone();
+            let share_name = share_name.clone();
+            let source = source.to_string();
+            let filter = filter.clone();
+            tasks.spawn(async move {
+                let result = tokio::time::timeout(
+                    PER_PEER_TIMEOUT,
+                    exchange_with_peer(
+                        &context,
+                        &peer_id,
+                        RemoteRequest::Query {
+                            share_id,
+                            source,
+                            filter,
+                        },
+                    ),
+                )
+                .await;
+                (peer_id, peer_name, share_name, result)
+            });
+        }
+    }
+    let mut records = Vec::new();
+    let mut anchors = Vec::new();
+    let mut offline: Vec<(String, String)> = Vec::new();
+    while let Some(joined) = tasks.join_next().await {
+        let Ok((peer_id, peer_name, share_name, result)) = joined else {
+            continue;
+        };
+        match result {
+            Ok(Ok(RemoteResponse::Query(mut query))) => {
+                // `team/alice/proj-b` — distinct scopes keep members apart and
+                // make results round-trip through show/zoom/nav.
+                qualify_query_scope(
+                    &format!("{group_name}/{peer_name}/{share_name}"),
+                    &mut query,
+                );
+                records.extend(query.records);
+                anchors.extend(query.anchors);
+                // A member is online if any share answered.
+                offline.retain(|(id, _)| *id != peer_id);
+            }
+            _ => {
+                if !offline.iter().any(|(id, _)| *id == peer_id) {
+                    offline.push((peer_id, peer_name));
+                }
+            }
+        }
+    }
+    let skipped: Vec<String> = offline
+        .into_iter()
+        .map(|(_, peer_name)| peer_name)
+        .collect();
+    GroupQueryResponse {
+        query: QueryResponse { records, anchors },
+        skipped,
+    }
+}
+
+fn member_info_from_store(
+    store: &StateStore,
+    group_id: &str,
+    member: &GroupMemberInfo,
+) -> Result<MemberInfo> {
+    let shares = store
+        .group_shares(group_id, &member.peer_id)?
+        .into_iter()
+        .map(|share| (share.share_id, share.share_name))
+        .collect();
+    let id: iroh::EndpointId = member.peer_id.parse().context("Invalid stored node id")?;
+    let endpoint = member
+        .endpoint
+        .as_deref()
+        .filter(|json| !json.is_empty())
+        .and_then(|json| serde_json::from_str::<EndpointAddr>(json).ok())
+        .unwrap_or_else(|| EndpointAddr::new(id));
+    Ok(MemberInfo {
+        peer_id: member.peer_id.clone(),
+        peer_name: member.peer_name.clone(),
+        shares,
+        role: member.role.clone(),
+        endpoint,
+    })
+}
+
+/// Revoke a grant if one exists; ignore the "no active grant" case.
+fn revoke_peer_grant(store: &StateStore, share_name_or_id: &str, peer_name_or_id: &str) {
+    store.revoke(share_name_or_id, peer_name_or_id).ok();
 }
 
 fn random_token() -> String {

--- a/src/remote/protocol.rs
+++ b/src/remote/protocol.rs
@@ -58,8 +58,9 @@ pub enum RemoteRequest {
     },
     /// Joiner → group owner: redeem a multi-use group invite and register the
     /// joiner's contributed workspaces so the owner can grant the joiner access.
+    /// The group is not part of the request: the invite row is the authority,
+    /// and the owner returns the authoritative id in [`RemoteResponse::GroupJoined`].
     RedeemGroupInvite {
-        group_id: String,
         invite_id: String,
         secret: String,
         peer_name: String,
@@ -120,6 +121,8 @@ pub enum RemoteResponse {
         share_name: String,
     },
     GroupJoined {
+        /// Authoritative group id, read from the invite row by the owner.
+        group_id: String,
         group_name: String,
         members: Vec<MemberInfo>,
     },

--- a/src/remote/protocol.rs
+++ b/src/remote/protocol.rs
@@ -7,7 +7,9 @@ use sivtr_core::record::{WorkRecord, WorkRef};
 use crate::commands::memory::filter::Filter;
 
 pub use super::state::ShareInfo;
-use super::state::{GrantInfo, MountInfo, PeerInfo};
+pub use super::state::{
+    GrantInfo, GroupInfo, GroupMemberInfo, GroupShareInfo, MountInfo, PeerInfo,
+};
 
 pub const REMOTE_ALPN: &[u8] = b"sivtr/memory/1";
 pub const MAX_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
@@ -17,6 +19,9 @@ pub struct InviteTicket {
     pub version: u16,
     pub endpoint: EndpointAddr,
     pub share_id: String,
+    /// Present for group invites; share invites leave this empty.
+    #[serde(default)]
+    pub group_id: Option<String>,
     pub invite_id: String,
     pub secret: String,
     pub expires_at: i64,
@@ -51,6 +56,50 @@ pub enum RemoteRequest {
         secret: String,
         peer_name: String,
     },
+    /// Joiner → group owner: redeem a multi-use group invite and register the
+    /// joiner's contributed workspaces so the owner can grant the joiner access.
+    RedeemGroupInvite {
+        group_id: String,
+        invite_id: String,
+        secret: String,
+        peer_name: String,
+        shares: Vec<(String, String)>,
+        endpoint: EndpointAddr,
+    },
+    /// Group owner → existing members: a new member joined; grant them access
+    /// to your group shares. Members also treat this for their own peer_id as a
+    /// revocation signal (kicked).
+    GroupMemberAdded {
+        group_id: String,
+        member: MemberInfo,
+    },
+    GroupMemberRemoved {
+        group_id: String,
+        peer_id: String,
+        peer_name: String,
+    },
+    /// An existing member added another contributed workspace.
+    GroupShareAdded {
+        group_id: String,
+        peer_id: String,
+        peer_name: String,
+        share_id: String,
+        share_name: String,
+    },
+    /// An existing member withdrew one contributed workspace.
+    GroupShareRemoved {
+        group_id: String,
+        peer_id: String,
+        share_id: String,
+    },
+    /// Member → group owner: announce leaving so the roster drops the member.
+    GroupLeave {
+        group_id: String,
+    },
+    /// Member → group owner: pull the authoritative roster for reconciliation.
+    GroupSync {
+        group_id: String,
+    },
     /// Run the same local query the peer would run: load `source` then apply `filter`.
     Query {
         share_id: String,
@@ -70,6 +119,16 @@ pub enum RemoteResponse {
         share_id: String,
         share_name: String,
     },
+    GroupJoined {
+        group_name: String,
+        members: Vec<MemberInfo>,
+    },
+    GroupSynced {
+        group_name: String,
+        member: bool,
+        members: Vec<MemberInfo>,
+    },
+    GroupAck,
     Query(QueryResponse),
     Probe {
         server_name: String,
@@ -81,9 +140,26 @@ pub enum RemoteResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemberInfo {
+    pub peer_id: String,
+    pub peer_name: String,
+    /// Every contributed workspace as `(share_id, share_name)`.
+    pub shares: Vec<(String, String)>,
+    pub role: String,
+    pub endpoint: EndpointAddr,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryResponse {
     pub records: Vec<WorkRecord>,
     pub anchors: Vec<WorkRef>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GroupQueryResponse {
+    pub query: QueryResponse,
+    /// Peer names that did not answer within the fan-out budget.
+    pub skipped: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -173,6 +249,53 @@ pub enum LocalRequest {
         source: String,
         filter: Filter,
     },
+    /// Create a group owned by this device, bound to one of our shares.
+    GroupCreate {
+        name: String,
+        share_id: String,
+        share_name: String,
+    },
+    GroupList,
+    GroupMembers {
+        group: String,
+    },
+    /// This device's contributed workspaces for a group (for join checkboxes).
+    GroupShares {
+        group: String,
+    },
+    GroupInvite {
+        group: String,
+        valid_for_seconds: i64,
+        max_uses: Option<i64>,
+    },
+    /// Join a group (or adjust contributions): redeem the invite and register
+    /// the final contributed-workspace list. The daemon diffs against current
+    /// contributions — additions broadcast, withdrawals revoke grants.
+    GroupJoin {
+        invite: String,
+        shares: Vec<(String, String)>,
+    },
+    GroupLeave {
+        group: String,
+    },
+    /// Owner-only: remove a member (kicks them out of the group).
+    GroupRemoveMember {
+        group: String,
+        peer: String,
+    },
+    /// Force a roster pull from the group owner.
+    GroupSync {
+        group: String,
+    },
+    /// Fan out a query to every group member (or one, when `member` is set;
+    /// and one contributed share when `share` is set).
+    GroupQuery {
+        group: String,
+        member: Option<String>,
+        share: Option<String>,
+        source: String,
+        filter: Filter,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -199,6 +322,15 @@ pub enum LocalResponse {
         peer_name: String,
         share_name: String,
     },
+    Group(GroupInfo),
+    Groups(Vec<GroupInfo>),
+    Members(Vec<GroupMemberInfo>),
+    GroupShares(Vec<GroupShareInfo>),
+    GroupJoined {
+        group_name: String,
+        member_count: usize,
+    },
+    GroupQuery(GroupQueryResponse),
     Query(QueryResponse),
     Error {
         message: String,

--- a/src/remote/state.rs
+++ b/src/remote/state.rs
@@ -736,10 +736,21 @@ impl StateStore {
 
     pub fn remove_member(&self, group_name_or_id: &str, peer_id: &str) -> Result<()> {
         let group = self.group(group_name_or_id)?;
-        self.connect()?.execute(
+        let mut connection = self.connect()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        // The member's contribution rows describe access on its own device and
+        // are not covered by the `group_members` cascade; leaving them behind
+        // would resurrect stale shares if the peer ever rejoins with a
+        // different set, so removal is one operation over both tables.
+        transaction.execute(
+            "DELETE FROM group_shares WHERE group_id = ?1 AND peer_id = ?2",
+            params![group.id, peer_id],
+        )?;
+        transaction.execute(
             "DELETE FROM group_members WHERE group_id = ?1 AND peer_id = ?2",
             params![group.id, peer_id],
         )?;
+        transaction.commit()?;
         Ok(())
     }
 
@@ -852,8 +863,55 @@ impl StateStore {
         Ok(())
     }
 
+    /// Revoke a member's grant on a group share, keeping it while another
+    /// source still justifies the access (see [`Self::has_other_grant_source`]).
+    pub fn revoke_group_grant(
+        &self,
+        group_name_or_id: &str,
+        share_id: &str,
+        peer_id: &str,
+    ) -> Result<()> {
+        let group = self.group(group_name_or_id)?;
+        if self.has_other_grant_source(&group.id, share_id, peer_id)? {
+            return Ok(());
+        }
+        self.revoke(share_id, peer_id)?;
+        Ok(())
+    }
+
+    /// True when `peer` still holds access to `share` from a source other than
+    /// the group being revoked from: membership in another group that lists
+    /// the share, or a direct share mount. `grants` stores one row per
+    /// (peer, share) even when several sources issued it, so group revocation
+    /// must not tear down independently authorized access.
+    fn has_other_grant_source(
+        &self,
+        group_id: &str,
+        share_id: &str,
+        peer_id: &str,
+    ) -> Result<bool> {
+        let connection = self.connect()?;
+        let other_group: bool = connection.query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM group_members gm
+                JOIN group_shares gs ON gs.group_id = gm.group_id AND gs.share_id = ?1
+                WHERE gm.peer_id = ?2 AND gm.group_id != ?3
+            )",
+            params![share_id, peer_id, group_id],
+            |row| row.get(0),
+        )?;
+        let direct_mount: bool = connection.query_row(
+            "SELECT EXISTS(SELECT 1 FROM mounts WHERE peer_id = ?1 AND share_id = ?2)",
+            params![peer_id, share_id],
+            |row| row.get(0),
+        )?;
+        Ok(other_group || direct_mount)
+    }
+
     /// Revoke every other member's grant on `share` (the contributor withdrew
-    /// that workspace from the group).
+    /// that workspace from the group). A grant survives when the peer still
+    /// holds access from another source, because `grants` keeps one row per
+    /// (peer, share) regardless of how many sources issued it.
     pub fn revoke_group_share(
         &self,
         group_name_or_id: &str,
@@ -861,10 +919,14 @@ impl StateStore {
         except_peer_id: &str,
     ) -> Result<()> {
         let group = self.group(group_name_or_id)?;
-        self.connect()?.execute(
-            "UPDATE grants SET revoked_at = ?1 WHERE share_id = ?2 AND revoked_at IS NULL AND peer_id IN (SELECT peer_id FROM group_members WHERE group_id = ?3 AND peer_id != ?4)",
-            params![now(), share_id, group.id, except_peer_id],
-        )?;
+        let peers: Vec<String> = self
+            .connect()?
+            .prepare("SELECT peer_id FROM group_members WHERE group_id = ?1 AND peer_id != ?2")?
+            .query_map(params![group.id, except_peer_id], |row| row.get(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        for peer_id in peers {
+            self.revoke_group_grant(&group.id, share_id, &peer_id)?;
+        }
         Ok(())
     }
 
@@ -1647,6 +1709,93 @@ mod tests {
         // Re-adding the share re-grants.
         store.group_grant(&share.id, "peer-1").unwrap();
         assert!(store.authorize("peer-1", &share.id, "query").is_ok());
+    }
+
+    #[test]
+    fn group_revocation_preserves_access_from_other_groups() {
+        let (_temp, store, share) = group_store();
+        // Alice is a member of `team` and `team-b`; the owner contributes the
+        // same workspace to both groups.
+        store.add_group("team-b", "self-1", "self").unwrap();
+        store.save_remote_peer("peer-1", "alice", "{}").unwrap();
+        store.add_member("team", "peer-1", "member").unwrap();
+        store.add_member("team-b", "peer-1", "member").unwrap();
+        store
+            .add_group_share("team", "self-1", &share.id, &share.name)
+            .unwrap();
+        store
+            .add_group_share("team-b", "self-1", &share.id, &share.name)
+            .unwrap();
+        store.group_grant(&share.id, "peer-1").unwrap();
+        // Withdraw from `team` (contribution row first, as the daemon does):
+        // the grant survives because `team-b` still lists the share.
+        store
+            .remove_group_share("team", "self-1", &share.id)
+            .unwrap();
+        store
+            .revoke_group_share("team", &share.id, "self-1")
+            .unwrap();
+        assert!(
+            store.authorize("peer-1", &share.id, "query").is_ok(),
+            "the second group still justifies the grant"
+        );
+        // Withdrawing from the last group revokes it.
+        store
+            .remove_group_share("team-b", "self-1", &share.id)
+            .unwrap();
+        store
+            .revoke_group_share("team-b", &share.id, "self-1")
+            .unwrap();
+        assert!(store.authorize("peer-1", &share.id, "query").is_err());
+    }
+
+    #[test]
+    fn group_revocation_preserves_direct_mount_access() {
+        let (temp, store, share) = group_store();
+        let alice_share = real_share(&store, temp.path(), "alice", "alice-ws");
+        let invite = store.create_group_invite("team", 60, None).unwrap();
+        store
+            .redeem_group_invite(
+                &invite.id,
+                &invite.secret,
+                &joiner(
+                    "peer-1",
+                    "alice",
+                    &[(alice_share.id.clone(), alice_share.name.clone())],
+                ),
+            )
+            .unwrap();
+        // Alice also redeemed a direct share invite for the owner workspace.
+        store
+            .add_mount("workspace-key", "desk", "peer-1", &share.id, &share.name)
+            .unwrap();
+        store
+            .revoke_group_share("team", &share.id, "self-1")
+            .unwrap();
+        assert!(
+            store.authorize("peer-1", &share.id, "query").is_ok(),
+            "the direct mount still grants access"
+        );
+    }
+
+    #[test]
+    fn remove_member_cleans_contribution_rows() {
+        let (temp, store, _share) = group_store();
+        let alice_share = real_share(&store, temp.path(), "alice", "alice-ws");
+        let invite = store.create_group_invite("team", 60, None).unwrap();
+        store
+            .redeem_group_invite(
+                &invite.id,
+                &invite.secret,
+                &joiner("peer-1", "alice", &[(alice_share.id, alice_share.name)]),
+            )
+            .unwrap();
+        assert_eq!(store.group_shares("team", "peer-1").unwrap().len(), 1);
+        store.remove_member("team", "peer-1").unwrap();
+        assert!(
+            store.group_shares("team", "peer-1").unwrap().is_empty(),
+            "contributions are removed with the membership"
+        );
     }
 
     #[test]

--- a/src/remote/state.rs
+++ b/src/remote/state.rs
@@ -54,6 +54,34 @@ pub struct MountInfo {
     pub share_name: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GroupInfo {
+    pub id: String,
+    pub name: String,
+    pub member_count: i64,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GroupMemberInfo {
+    pub peer_id: String,
+    pub peer_name: String,
+    pub role: String,
+    pub joined_at: String,
+    pub last_seen_at: Option<String>,
+    /// Number of workspaces this member contributes to the group.
+    pub share_count: i64,
+    /// Stored endpoint JSON (iroh `EndpointAddr`); dialable members have one.
+    pub endpoint: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GroupShareInfo {
+    pub share_id: String,
+    pub share_name: String,
+    pub added_at: String,
+}
+
 #[derive(Debug, Clone)]
 pub struct InviteRecord {
     pub id: String,
@@ -67,6 +95,16 @@ pub struct InviteRecord {
 pub struct RedeemedShare {
     pub share_id: String,
     pub share_name: String,
+}
+
+/// A peer joining a group, as seen by the group owner. `shares` lists every
+/// workspace the joiner contributes (multi-select join).
+#[derive(Debug)]
+pub struct JoinerInfo<'a> {
+    pub peer_id: &'a str,
+    pub peer_name: &'a str,
+    pub shares: &'a [(String, String)],
+    pub endpoint_json: &'a str,
 }
 
 impl StateStore {
@@ -155,8 +193,103 @@ impl StateStore {
                 decision        TEXT NOT NULL,
                 reason          TEXT
             );
+
+            CREATE TABLE IF NOT EXISTS groups (
+                id              TEXT PRIMARY KEY,
+                name            TEXT NOT NULL UNIQUE,
+                last_synced_at  TEXT,
+                created_at      TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS group_members (
+                group_id    TEXT NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+                peer_id     TEXT NOT NULL REFERENCES peers(id) ON DELETE CASCADE,
+                role        TEXT NOT NULL DEFAULT 'member',
+                joined_at   TEXT NOT NULL,
+                PRIMARY KEY(group_id, peer_id)
+            );
+
+            -- One row per (member, contributed share); a member contributes
+            -- many workspaces. `share_id` intentionally has NO foreign key:
+            -- mirrored members' shares live on their own devices. Deleting a
+            -- local share cleans its contribution rows in `remove_share`.
+            CREATE TABLE IF NOT EXISTS group_shares (
+                group_id    TEXT NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+                peer_id     TEXT NOT NULL REFERENCES peers(id) ON DELETE CASCADE,
+                share_id    TEXT NOT NULL,
+                share_name  TEXT NOT NULL,
+                added_at    TEXT NOT NULL,
+                PRIMARY KEY(group_id, peer_id, share_id)
+            );
             "#,
         )?;
+        // Idempotent migration for installs that predate group invites.
+        // `CREATE TABLE IF NOT EXISTS` cannot add columns, so ALTER and ignore
+        // the "duplicate column name" error on already-migrated databases.
+        let connection = self.connect()?;
+        for statement in [
+            "ALTER TABLE invites ADD COLUMN kind TEXT NOT NULL DEFAULT 'share'",
+            "ALTER TABLE invites ADD COLUMN group_id TEXT",
+            "ALTER TABLE invites ADD COLUMN max_uses INTEGER",
+            "ALTER TABLE invites ADD COLUMN used_count INTEGER NOT NULL DEFAULT 0",
+        ] {
+            match connection.execute(statement, []) {
+                Ok(_) | Err(_) => {}
+            }
+        }
+        // Migrate the pre-split `group_members` (one share per member) into the
+        // member/share split: contributions move to `group_shares`, the member
+        // table keeps only membership + role.
+        let columns: Vec<String> = connection
+            .prepare("PRAGMA table_info(group_members)")?
+            .query_map([], |row| row.get::<_, String>(1))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        if columns.iter().any(|column| column == "share_id") {
+            connection.execute_batch(
+                r#"
+                INSERT INTO group_shares(group_id, peer_id, share_id, share_name, added_at)
+                    SELECT group_id, peer_id, share_id, share_name, joined_at
+                    FROM group_members WHERE share_id IS NOT NULL AND share_id != '';
+                ALTER TABLE group_members RENAME TO group_members_old;
+                CREATE TABLE group_members (
+                    group_id    TEXT NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+                    peer_id     TEXT NOT NULL REFERENCES peers(id) ON DELETE CASCADE,
+                    role        TEXT NOT NULL DEFAULT 'member',
+                    joined_at   TEXT NOT NULL,
+                    PRIMARY KEY(group_id, peer_id)
+                );
+                INSERT INTO group_members(group_id, peer_id, role, joined_at)
+                    SELECT group_id, peer_id, role, joined_at FROM group_members_old;
+                DROP TABLE group_members_old;
+                "#,
+            )?;
+        }
+        // Rebuild `group_shares` without the share_id foreign key: mirrored
+        // members' shares live on their own devices, so they never exist in
+        // the local shares table and a FK would reject them.
+        let share_fks: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM pragma_foreign_key_list('group_shares')",
+            [],
+            |row| row.get(0),
+        )?;
+        if share_fks > 0 {
+            connection.execute_batch(
+                r#"
+                ALTER TABLE group_shares RENAME TO group_shares_old;
+                CREATE TABLE group_shares (
+                    group_id    TEXT NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+                    peer_id     TEXT NOT NULL REFERENCES peers(id) ON DELETE CASCADE,
+                    share_id    TEXT NOT NULL,
+                    share_name  TEXT NOT NULL,
+                    added_at    TEXT NOT NULL,
+                    PRIMARY KEY(group_id, peer_id, share_id)
+                );
+                INSERT INTO group_shares(group_id, peer_id, share_id, share_name, added_at)
+                    SELECT group_id, peer_id, share_id, share_name, added_at FROM group_shares_old;
+                DROP TABLE group_shares_old;
+                "#,
+            )?;
+        }
         Ok(())
     }
 
@@ -216,8 +349,11 @@ impl StateStore {
 
     pub fn remove_share(&self, name_or_id: &str) -> Result<ShareInfo> {
         let share = self.share(name_or_id)?;
-        self.connect()?
-            .execute("DELETE FROM shares WHERE id = ?1", [&share.id])?;
+        let connection = self.connect()?;
+        // The share no longer exists, so it can no longer be contributed to
+        // any group (grants cascade via the shares FK).
+        connection.execute("DELETE FROM group_shares WHERE share_id = ?1", [&share.id])?;
+        connection.execute("DELETE FROM shares WHERE id = ?1", [&share.id])?;
         Ok(share)
     }
 
@@ -485,6 +621,366 @@ impl StateStore {
         Ok(grant)
     }
 
+    // ------------------------------------------------------------------
+    // Groups: a named set of devices that expose their memory to each other.
+    // Membership (`group_members`) and contributed workspaces (`group_shares`,
+    // many per member) are separate. Invariant: for every contribution a
+    // member adds, every other member holds a read-memory grant on that share.
+    // ------------------------------------------------------------------
+
+    pub fn add_group(
+        &self,
+        name: &str,
+        self_peer_id: &str,
+        self_peer_name: &str,
+    ) -> Result<GroupInfo> {
+        validate_identifier(name, "group name")?;
+        // The local device is a peer of itself; peers(id) is a FK target.
+        self.save_remote_peer(self_peer_id, self_peer_name, "{}")?;
+        let id = random_id("grp");
+        let info = self.register_group(&id, name)?;
+        self.connect()?.execute(
+            "INSERT INTO group_members(group_id, peer_id, role, joined_at) VALUES (?1, ?2, 'owner', ?3)",
+            params![id, self_peer_id, now()],
+        )?;
+        Ok(info)
+    }
+
+    /// Register a group row with an explicit id. Joiners use this to mirror the
+    /// owner's group identity; idempotent on re-join.
+    pub fn register_group(&self, id: &str, name: &str) -> Result<GroupInfo> {
+        validate_identifier(name, "group name")?;
+        self.connect()?.execute(
+            "INSERT INTO groups(id, name, created_at) VALUES (?1, ?2, ?3) ON CONFLICT(id) DO NOTHING",
+            params![id, name.to_ascii_lowercase(), now()],
+        )?;
+        self.group(name)
+    }
+
+    pub fn groups(&self) -> Result<Vec<GroupInfo>> {
+        let connection = self.connect()?;
+        let mut statement = connection.prepare(
+            "SELECT g.id, g.name, (SELECT COUNT(*) FROM group_members m WHERE m.group_id = g.id), g.created_at FROM groups g ORDER BY g.name",
+        )?;
+        let rows = statement.query_map([], group_from_row)?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
+    }
+
+    pub fn group(&self, name_or_id: &str) -> Result<GroupInfo> {
+        self.connect()?
+            .query_row(
+                "SELECT g.id, g.name, (SELECT COUNT(*) FROM group_members m WHERE m.group_id = g.id), g.created_at FROM groups g WHERE g.id = ?1 OR lower(g.name) = lower(?1)",
+                [name_or_id],
+                group_from_row,
+            )
+            .optional()?
+            .with_context(|| format!("Unknown group `{name_or_id}`"))
+    }
+
+    /// Insert or refresh one member row. Endpoint/name live in `peers`.
+    pub fn add_member(
+        &self,
+        group_name_or_id: &str,
+        peer_id: &str,
+        role: &str,
+    ) -> Result<GroupMemberInfo> {
+        let group = self.group(group_name_or_id)?;
+        self.connect()?.execute(
+            "INSERT INTO group_members(group_id, peer_id, role, joined_at) VALUES (?1, ?2, ?3, ?4) ON CONFLICT(group_id, peer_id) DO UPDATE SET role = excluded.role",
+            params![group.id, peer_id, role, now()],
+        )?;
+        self.member(&group.id, peer_id)
+    }
+
+    pub fn remove_member(&self, group_name_or_id: &str, peer_id: &str) -> Result<()> {
+        let group = self.group(group_name_or_id)?;
+        self.connect()?.execute(
+            "DELETE FROM group_members WHERE group_id = ?1 AND peer_id = ?2",
+            params![group.id, peer_id],
+        )?;
+        Ok(())
+    }
+
+    pub fn member(&self, group_name_or_id: &str, peer_id: &str) -> Result<GroupMemberInfo> {
+        let group = self.group(group_name_or_id)?;
+        self.connect()?
+            .query_row(
+                "SELECT gm.peer_id, p.name, gm.role, gm.joined_at, p.last_seen_at, p.endpoint_json, (SELECT COUNT(*) FROM group_shares gs WHERE gs.group_id = gm.group_id AND gs.peer_id = gm.peer_id) FROM group_members gm JOIN peers p ON p.id = gm.peer_id WHERE gm.group_id = ?1 AND gm.peer_id = ?2",
+                params![group.id, peer_id],
+                group_member_from_row,
+            )
+            .optional()?
+            .with_context(|| format!("Peer `{peer_id}` is not a member of `{}`", group.name))
+    }
+
+    pub fn members(&self, group_name_or_id: &str) -> Result<Vec<GroupMemberInfo>> {
+        let group = self.group(group_name_or_id)?;
+        let connection = self.connect()?;
+        let mut statement = connection.prepare(
+            "SELECT gm.peer_id, p.name, gm.role, gm.joined_at, p.last_seen_at, p.endpoint_json, (SELECT COUNT(*) FROM group_shares gs WHERE gs.group_id = gm.group_id AND gs.peer_id = gm.peer_id) FROM group_members gm JOIN peers p ON p.id = gm.peer_id WHERE gm.group_id = ?1 ORDER BY p.name",
+        )?;
+        let rows = statement.query_map([group.id], group_member_from_row)?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
+    }
+
+    /// Register one contributed workspace for a member (idempotent).
+    pub fn add_group_share(
+        &self,
+        group_name_or_id: &str,
+        peer_id: &str,
+        share_id: &str,
+        share_name: &str,
+    ) -> Result<()> {
+        let group = self.group(group_name_or_id)?;
+        self.connect()?.execute(
+            "INSERT INTO group_shares(group_id, peer_id, share_id, share_name, added_at) VALUES (?1, ?2, ?3, ?4, ?5) ON CONFLICT(group_id, peer_id, share_id) DO NOTHING",
+            params![group.id, peer_id, share_id, share_name, now()],
+        )?;
+        Ok(())
+    }
+
+    pub fn remove_group_share(
+        &self,
+        group_name_or_id: &str,
+        peer_id: &str,
+        share_id: &str,
+    ) -> Result<()> {
+        let group = self.group(group_name_or_id)?;
+        self.connect()?.execute(
+            "DELETE FROM group_shares WHERE group_id = ?1 AND peer_id = ?2 AND share_id = ?3",
+            params![group.id, peer_id, share_id],
+        )?;
+        Ok(())
+    }
+
+    pub fn group_shares(
+        &self,
+        group_name_or_id: &str,
+        peer_id: &str,
+    ) -> Result<Vec<GroupShareInfo>> {
+        let group = self.group(group_name_or_id)?;
+        let connection = self.connect()?;
+        let mut statement = connection.prepare(
+            "SELECT share_id, share_name, added_at FROM group_shares WHERE group_id = ?1 AND peer_id = ?2 ORDER BY share_name",
+        )?;
+        let rows = statement.query_map(params![group.id, peer_id], |row| {
+            Ok(GroupShareInfo {
+                share_id: row.get(0)?,
+                share_name: row.get(1)?,
+                added_at: row.get(2)?,
+            })
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
+    }
+
+    /// Resolve a member's contributed share by name (three-segment scope
+    /// `team/alice/proj-b` lands here).
+    pub fn group_share_by_name(
+        &self,
+        group_name_or_id: &str,
+        peer_id: &str,
+        share_name: &str,
+    ) -> Result<Option<GroupShareInfo>> {
+        let group = self.group(group_name_or_id)?;
+        self.connect()?
+            .query_row(
+                "SELECT share_id, share_name, added_at FROM group_shares WHERE group_id = ?1 AND peer_id = ?2 AND share_name = ?3",
+                params![group.id, peer_id, share_name],
+                |row| {
+                    Ok(GroupShareInfo {
+                        share_id: row.get(0)?,
+                        share_name: row.get(1)?,
+                        added_at: row.get(2)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(Into::into)
+    }
+
+    /// Grant `peer` read access to `share` (idempotent). Also clears a previous
+    /// revocation, so rejoining a group reactivates the grant.
+    pub fn group_grant(&self, share_id: &str, peer_id: &str) -> Result<()> {
+        self.connect()?.execute(
+            "INSERT INTO grants(peer_id, share_id, permission, created_at, revoked_at) VALUES (?1, ?2, ?3, ?4, NULL) ON CONFLICT(peer_id, share_id) DO UPDATE SET permission = excluded.permission, revoked_at = NULL",
+            params![peer_id, share_id, PERMISSION_READ_MEMORY, now()],
+        )?;
+        Ok(())
+    }
+
+    /// Revoke every other member's grant on `share` (the contributor withdrew
+    /// that workspace from the group).
+    pub fn revoke_group_share(
+        &self,
+        group_name_or_id: &str,
+        share_id: &str,
+        except_peer_id: &str,
+    ) -> Result<()> {
+        let group = self.group(group_name_or_id)?;
+        self.connect()?.execute(
+            "UPDATE grants SET revoked_at = ?1 WHERE share_id = ?2 AND revoked_at IS NULL AND peer_id IN (SELECT peer_id FROM group_members WHERE group_id = ?3 AND peer_id != ?4)",
+            params![now(), share_id, group.id, except_peer_id],
+        )?;
+        Ok(())
+    }
+
+    pub fn remove_group(&self, name_or_id: &str) -> Result<GroupInfo> {
+        let group = self.group(name_or_id)?;
+        self.connect()?
+            .execute("DELETE FROM groups WHERE id = ?1", [&group.id])?;
+        Ok(group)
+    }
+
+    pub fn create_group_invite(
+        &self,
+        group_name_or_id: &str,
+        valid_for_seconds: i64,
+        max_uses: Option<i64>,
+    ) -> Result<InviteRecord> {
+        if valid_for_seconds <= 0 {
+            bail!("Invite expiration must be positive");
+        }
+        let group = self.group(group_name_or_id)?;
+        // invites.share_id references shares(id); group invites point at the
+        // owner's first contributed share so the FK holds.
+        let owner_share: String = self
+            .connect()?
+            .query_row(
+                "SELECT gs.share_id FROM group_shares gs JOIN group_members gm ON gm.group_id = gs.group_id AND gm.peer_id = gs.peer_id WHERE gs.group_id = ?1 AND gm.role = 'owner' LIMIT 1",
+                [&group.id],
+                |row| row.get(0),
+            )
+            .optional()?
+            .context("Group has no shared workspace to invite with")?;
+        let id = random_id("iv");
+        let secret = random_secret();
+        let expires_at = Utc::now().timestamp() + valid_for_seconds;
+        self.connect()?.execute(
+            "INSERT INTO invites(id, share_id, secret_hash, permission, expires_at, used_at, created_at, kind, group_id, max_uses, used_count) VALUES (?1, ?2, ?3, ?4, ?5, NULL, ?6, 'group', ?7, ?8, 0)",
+            params![id, owner_share, hash_secret(&secret), PERMISSION_READ_MEMORY, expires_at, now(), group.id, max_uses],
+        )?;
+        Ok(InviteRecord {
+            id,
+            share_id: group.id,
+            share_name: group.name,
+            secret,
+            expires_at,
+        })
+    }
+
+    /// Redeem a group invite: validates the multi-use ticket, adds the joiner
+    /// to the roster with every contributed workspace, grants the joiner read
+    /// access to the owner's contributions, and returns the current roster for
+    /// the joiner to reconcile.
+    pub fn redeem_group_invite(
+        &self,
+        invite_id: &str,
+        secret: &str,
+        joiner: &JoinerInfo<'_>,
+    ) -> Result<Vec<GroupMemberInfo>> {
+        validate_identifier(joiner.peer_name, "peer name")?;
+        let mut connection = self.connect()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let invite = transaction
+            .query_row(
+                "SELECT i.group_id, i.secret_hash, i.expires_at, i.used_count, i.max_uses, i.used_at FROM invites i WHERE i.id = ?1 AND i.kind = 'group'",
+                [invite_id],
+                |row| {
+                    Ok((
+                        row.get::<_, Option<String>>(0)?,
+                        row.get::<_, Vec<u8>>(1)?,
+                        row.get::<_, i64>(2)?,
+                        row.get::<_, i64>(3)?,
+                        row.get::<_, Option<i64>>(4)?,
+                        row.get::<_, Option<String>>(5)?,
+                    ))
+                },
+            )
+            .optional()?
+            .context("Invitation is invalid or expired")?;
+        let (group_id, expected_hash, expires_at, used_count, max_uses, used_at) = invite;
+        let group_id = group_id.context("Invitation is invalid or expired")?;
+        if expires_at < Utc::now().timestamp() || used_at.is_some() {
+            bail!("Invitation is invalid or expired");
+        }
+        if let Some(max_uses) = max_uses {
+            if used_count >= max_uses {
+                bail!("Invitation has reached its usage limit");
+            }
+        }
+        if expected_hash != hash_secret(secret) {
+            bail!("Invitation is invalid or expired");
+        }
+        let timestamp = now();
+        transaction.execute(
+            "INSERT INTO peers(id, name, endpoint_json, created_at, last_seen_at) VALUES (?1, ?2, ?3, ?4, ?4) ON CONFLICT(id) DO UPDATE SET name = excluded.name, endpoint_json = excluded.endpoint_json, last_seen_at = excluded.last_seen_at",
+            params![joiner.peer_id, joiner.peer_name, joiner.endpoint_json, timestamp],
+        )?;
+        transaction.execute(
+            "INSERT INTO group_members(group_id, peer_id, role, joined_at) VALUES (?1, ?2, 'member', ?3) ON CONFLICT(group_id, peer_id) DO NOTHING",
+            params![group_id, joiner.peer_id, timestamp],
+        )?;
+        for (share_id, share_name) in joiner.shares {
+            transaction.execute(
+                "INSERT INTO group_shares(group_id, peer_id, share_id, share_name, added_at) VALUES (?1, ?2, ?3, ?4, ?5) ON CONFLICT(group_id, peer_id, share_id) DO NOTHING",
+                params![group_id, joiner.peer_id, share_id, share_name, timestamp],
+            )?;
+        }
+        // Owner grants the newcomer on every owner contribution.
+        let owner_shares: Vec<String> = {
+            let mut statement = transaction.prepare(
+                "SELECT gs.share_id FROM group_shares gs JOIN group_members gm ON gm.group_id = gs.group_id AND gm.peer_id = gs.peer_id WHERE gs.group_id = ?1 AND gm.role = 'owner'",
+            )?;
+            let rows = statement.query_map([&group_id], |row| row.get::<_, String>(0))?;
+            rows.collect::<rusqlite::Result<Vec<_>>>()?
+        };
+        for owner_share in &owner_shares {
+            transaction.execute(
+                "INSERT INTO grants(peer_id, share_id, permission, created_at, revoked_at) VALUES (?1, ?2, ?3, ?4, NULL) ON CONFLICT(peer_id, share_id) DO UPDATE SET permission = excluded.permission, revoked_at = NULL",
+                params![joiner.peer_id, owner_share, PERMISSION_READ_MEMORY, timestamp],
+            )?;
+        }
+        transaction.execute(
+            "UPDATE invites SET used_count = used_count + 1 WHERE id = ?1",
+            [invite_id],
+        )?;
+        transaction.commit()?;
+        self.members(&group_id)
+    }
+
+    pub fn touch_group_sync(&self, group_name_or_id: &str) -> Result<()> {
+        let group = self.group(group_name_or_id)?;
+        self.connect()?.execute(
+            "UPDATE groups SET last_synced_at = ?1 WHERE id = ?2",
+            params![now(), group.id],
+        )?;
+        Ok(())
+    }
+
+    pub fn sync_stale(&self, group_name_or_id: &str, ttl_secs: i64) -> Result<bool> {
+        let group = self.group(group_name_or_id)?;
+        let last: Option<String> = self
+            .connect()?
+            .query_row(
+                "SELECT last_synced_at FROM groups WHERE id = ?1",
+                [&group.id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        match last {
+            None => Ok(true),
+            Some(timestamp) => {
+                let last = chrono::DateTime::parse_from_rfc3339(&timestamp)
+                    .map_err(|_| anyhow::anyhow!("Invalid last_synced_at timestamp"))?
+                    .with_timezone(&Utc);
+                Ok(Utc::now() - last > chrono::Duration::seconds(ttl_secs))
+            }
+        }
+    }
+
     fn peer(&self, name_or_id: &str) -> Result<PeerInfo> {
         self.connect()?
             .query_row(
@@ -539,6 +1035,27 @@ fn mount_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<MountInfo> {
         peer_name: row.get(3)?,
         share_id: row.get(4)?,
         share_name: row.get(5)?,
+    })
+}
+
+fn group_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<GroupInfo> {
+    Ok(GroupInfo {
+        id: row.get(0)?,
+        name: row.get(1)?,
+        member_count: row.get(2)?,
+        created_at: row.get(3)?,
+    })
+}
+
+fn group_member_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<GroupMemberInfo> {
+    Ok(GroupMemberInfo {
+        peer_id: row.get(0)?,
+        peer_name: row.get(1)?,
+        role: row.get(2)?,
+        joined_at: row.get(3)?,
+        last_seen_at: row.get(4)?,
+        endpoint: row.get(5)?,
+        share_count: row.get(6)?,
     })
 }
 
@@ -677,5 +1194,335 @@ mod tests {
         assert!(store
             .add_mount("workspace-a", "local", "peer-1", "share-a", "project-a")
             .is_err());
+    }
+
+    fn group_store() -> (tempfile::TempDir, StateStore, ShareInfo) {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir(&workspace).unwrap();
+        let store = StateStore::open(temp.path().join("state.db")).unwrap();
+        let share = store
+            .add_share("workspace-key", &workspace, "project", true)
+            .unwrap();
+        store.add_group("team", "self-1", "self").unwrap();
+        store
+            .add_group_share("team", "self-1", &share.id, &share.name)
+            .unwrap();
+        (temp, store, share)
+    }
+
+    fn joiner<'a>(
+        peer_id: &'a str,
+        peer_name: &'a str,
+        shares: &'a [(String, String)],
+    ) -> JoinerInfo<'a> {
+        JoinerInfo {
+            peer_id,
+            peer_name,
+            shares,
+            endpoint_json: "{}",
+        }
+    }
+
+    /// Create a real share under `temp` (group_shares.share_id references shares.id).
+    fn real_share(store: &StateStore, temp: &Path, key: &str, name: &str) -> ShareInfo {
+        let root = temp.join(format!("ws-{key}"));
+        std::fs::create_dir(&root).unwrap();
+        store.add_share(key, &root, name, true).unwrap()
+    }
+
+    #[test]
+    fn group_invite_is_multi_use_until_expiry_or_max_uses() {
+        let (temp, store, _share) = group_store();
+        let alice_share = real_share(&store, temp.path(), "alice", "alice-ws");
+        let bob_share = real_share(&store, temp.path(), "bob", "bob-ws");
+        let dan_share = real_share(&store, temp.path(), "dan", "dan-ws");
+        let erin_share = real_share(&store, temp.path(), "erin", "erin-ws");
+
+        let invite = store.create_group_invite("team", 60, None).unwrap();
+        let roster = store
+            .redeem_group_invite(
+                &invite.id,
+                &invite.secret,
+                &joiner(
+                    "peer-1",
+                    "alice",
+                    &[(alice_share.id.clone(), alice_share.name.clone())],
+                ),
+            )
+            .unwrap();
+        assert_eq!(roster.len(), 2, "owner + alice");
+        // The same ticket admits another peer — group invites are multi-use.
+        let roster = store
+            .redeem_group_invite(
+                &invite.id,
+                &invite.secret,
+                &joiner(
+                    "peer-2",
+                    "bob",
+                    &[(bob_share.id.clone(), bob_share.name.clone())],
+                ),
+            )
+            .unwrap();
+        assert_eq!(roster.len(), 3);
+        assert!(store
+            .redeem_group_invite(
+                &invite.id,
+                "wrong-secret",
+                &joiner(
+                    "peer-3",
+                    "carol",
+                    &[(alice_share.id.clone(), alice_share.name.clone())],
+                ),
+            )
+            .is_err());
+
+        // max_uses caps redemption even before expiry.
+        let limited = store.create_group_invite("team", 60, Some(1)).unwrap();
+        store
+            .redeem_group_invite(
+                &limited.id,
+                &limited.secret,
+                &joiner(
+                    "peer-4",
+                    "dan",
+                    &[(dan_share.id.clone(), dan_share.name.clone())],
+                ),
+            )
+            .unwrap();
+        assert!(store
+            .redeem_group_invite(
+                &limited.id,
+                &limited.secret,
+                &joiner(
+                    "peer-5",
+                    "erin",
+                    &[(erin_share.id.clone(), erin_share.name.clone())],
+                ),
+            )
+            .is_err());
+    }
+
+    #[test]
+    fn join_grants_owner_and_roster_roundtrips() {
+        let (temp, store, share) = group_store();
+        let alice_share = real_share(&store, temp.path(), "alice", "alice-ws");
+        let invite = store.create_group_invite("team", 60, None).unwrap();
+        let roster = store
+            .redeem_group_invite(
+                &invite.id,
+                &invite.secret,
+                &JoinerInfo {
+                    peer_id: "peer-1",
+                    peer_name: "alice",
+                    shares: &[(alice_share.id.clone(), alice_share.name.clone())],
+                    endpoint_json: r#"{"id":"alice"}"#,
+                },
+            )
+            .unwrap();
+        // Owner's share is now authorized for the newcomer.
+        store.authorize("peer-1", &share.id, "query").unwrap();
+        // Roster carries the member's endpoint hint for dialing back.
+        let alice = roster
+            .iter()
+            .find(|member| member.peer_id == "peer-1")
+            .expect("alice in roster");
+        assert_eq!(alice.endpoint.as_deref(), Some(r#"{"id":"alice"}"#));
+        assert_eq!(alice.role, "member");
+        assert_eq!(alice.share_count, 1);
+    }
+
+    #[test]
+    fn member_add_reconciles_newcomer_grant() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir(&workspace).unwrap();
+        let store = StateStore::open(temp.path().join("state.db")).unwrap();
+        let owner_share = store
+            .add_share("workspace-key", &workspace, "project", true)
+            .unwrap();
+        let bob_share = store
+            .add_share("workspace-bob", &workspace, "bob-project", true)
+            .unwrap();
+        let carol_share = real_share(&store, temp.path(), "carol", "carol-ws");
+        store.add_group("team", "self-1", "self").unwrap();
+        store
+            .add_group_share("team", "self-1", &owner_share.id, &owner_share.name)
+            .unwrap();
+        store.save_remote_peer("peer-2", "bob", "{}").unwrap();
+        store.add_member("team", "peer-2", "member").unwrap();
+        store
+            .add_group_share("team", "peer-2", &bob_share.id, &bob_share.name)
+            .unwrap();
+        // Bob reconciles a GroupMemberAdded push: the newcomer gets read access
+        // to Bob's group share.
+        store.save_remote_peer("peer-3", "carol", "{}").unwrap();
+        store.group_grant(&bob_share.id, "peer-3").unwrap();
+        store.add_member("team", "peer-3", "member").unwrap();
+        store
+            .add_group_share("team", "peer-3", &carol_share.id, &carol_share.name)
+            .unwrap();
+        assert!(store.authorize("peer-3", &bob_share.id, "query").is_ok());
+    }
+
+    #[test]
+    fn remove_member_revokes_grants_and_roster() {
+        let (temp, store, share) = group_store();
+        let alice_share = real_share(&store, temp.path(), "alice", "alice-ws");
+        let invite = store.create_group_invite("team", 60, None).unwrap();
+        store
+            .redeem_group_invite(
+                &invite.id,
+                &invite.secret,
+                &joiner(
+                    "peer-1",
+                    "alice",
+                    &[(alice_share.id.clone(), alice_share.name.clone())],
+                ),
+            )
+            .unwrap();
+        store.remove_member("team", "peer-1").unwrap();
+        store.revoke(&share.name, "peer-1").unwrap();
+        assert!(store.authorize("peer-1", &share.id, "query").is_err());
+        assert!(!store
+            .members("team")
+            .unwrap()
+            .iter()
+            .any(|member| member.peer_id == "peer-1"));
+    }
+
+    #[test]
+    fn member_list_includes_last_seen_and_endpoint() {
+        let (temp, store, _share) = group_store();
+        let alice_share = real_share(&store, temp.path(), "alice", "alice-ws");
+        store
+            .save_remote_peer("peer-1", "alice", r#"{"id":"alice"}"#)
+            .unwrap();
+        store.add_member("team", "peer-1", "member").unwrap();
+        store
+            .add_group_share("team", "peer-1", &alice_share.id, &alice_share.name)
+            .unwrap();
+        let roster = store.members("team").unwrap();
+        assert_eq!(roster.len(), 2, "owner + alice");
+        let alice = roster
+            .iter()
+            .find(|member| member.peer_id == "peer-1")
+            .unwrap();
+        assert_eq!(alice.role, "member");
+        assert_eq!(alice.endpoint.as_deref(), Some(r#"{"id":"alice"}"#));
+        assert_eq!(alice.share_count, 1);
+        assert!(
+            alice.last_seen_at.is_some(),
+            "peer upsert sets last_seen_at"
+        );
+        let team = store.group("team").unwrap();
+        assert_eq!(team.member_count, 2);
+    }
+
+    #[test]
+    fn share_reused_across_groups() {
+        let (temp, store, share) = group_store();
+        let a_share = real_share(&store, temp.path(), "a", "a-ws");
+        let b_share = real_share(&store, temp.path(), "b", "b-ws");
+        store.add_group("team-b", "self-1", "self").unwrap();
+        store.save_remote_peer("peer-1", "alice", "{}").unwrap();
+        store.add_member("team", "peer-1", "member").unwrap();
+        store.add_member("team-b", "peer-1", "member").unwrap();
+        store
+            .add_group_share("team", "peer-1", &a_share.id, &a_share.name)
+            .unwrap();
+        store
+            .add_group_share("team-b", "peer-1", &b_share.id, &b_share.name)
+            .unwrap();
+        // Same share granted to the same peer twice is a no-op, not a conflict.
+        store.group_grant(&share.id, "peer-1").unwrap();
+        store.group_grant(&share.id, "peer-1").unwrap();
+        assert!(store.authorize("peer-1", &share.id, "query").is_ok());
+        assert_eq!(store.groups().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn member_contributes_multiple_workspaces() {
+        let temp = tempfile::tempdir().unwrap();
+        let root_a = temp.path().join("a");
+        let root_b = temp.path().join("b");
+        std::fs::create_dir(&root_a).unwrap();
+        std::fs::create_dir(&root_b).unwrap();
+        let store = StateStore::open(temp.path().join("state.db")).unwrap();
+        let first = store
+            .add_share("workspace-key-1", &root_a, "project-1", true)
+            .unwrap();
+        let second = store
+            .add_share("workspace-key-2", &root_b, "project-2", true)
+            .unwrap();
+        store.add_group("team", "self-1", "self").unwrap();
+        store
+            .add_group_share("team", "self-1", &first.id, &first.name)
+            .unwrap();
+        store
+            .add_group_share("team", "self-1", &second.id, &second.name)
+            .unwrap();
+        assert_eq!(store.group_shares("team", "self-1").unwrap().len(), 2);
+        let owner = store.members("team").unwrap().remove(0);
+        assert_eq!(owner.share_count, 2);
+        // Name-resolved lookup powers `team/self/project-2` three-segment refs.
+        let found = store
+            .group_share_by_name("team", "self-1", "project-2")
+            .unwrap()
+            .expect("share by name");
+        assert_eq!(found.share_id, second.id);
+        // Withdrawing one contribution keeps the rest.
+        store
+            .remove_group_share("team", "self-1", &second.id)
+            .unwrap();
+        assert_eq!(store.group_shares("team", "self-1").unwrap().len(), 1);
+        assert!(store
+            .group_share_by_name("team", "self-1", "project-2")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn revoke_group_share_withdraws_member_grants() {
+        let (temp, store, share) = group_store();
+        let alice_share = real_share(&store, temp.path(), "alice", "alice-ws");
+        let invite = store.create_group_invite("team", 60, None).unwrap();
+        store
+            .redeem_group_invite(
+                &invite.id,
+                &invite.secret,
+                &joiner(
+                    "peer-1",
+                    "alice",
+                    &[(alice_share.id.clone(), alice_share.name.clone())],
+                ),
+            )
+            .unwrap();
+        // The owner withdraws their contribution; alice loses access to it.
+        store
+            .revoke_group_share("team", &share.id, "self-1")
+            .unwrap();
+        assert!(store.authorize("peer-1", &share.id, "query").is_err());
+        // Re-adding the share re-grants.
+        store.group_grant(&share.id, "peer-1").unwrap();
+        assert!(store.authorize("peer-1", &share.id, "query").is_ok());
+    }
+
+    #[test]
+    fn removing_share_cascades_group_contribution() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir(&workspace).unwrap();
+        let store = StateStore::open(temp.path().join("state.db")).unwrap();
+        let share = store
+            .add_share("workspace-key", &workspace, "project", true)
+            .unwrap();
+        store.add_group("team", "self-1", "self").unwrap();
+        store
+            .add_group_share("team", "self-1", &share.id, &share.name)
+            .unwrap();
+        store.remove_share(&share.name).unwrap();
+        // Group state converges passively: the contribution row is gone.
+        assert!(store.group_shares("team", "self-1").unwrap().is_empty());
     }
 }

--- a/src/remote/state.rs
+++ b/src/remote/state.rs
@@ -97,6 +97,15 @@ pub struct RedeemedShare {
     pub share_name: String,
 }
 
+/// A redeemed group invite: the authoritative group id (read from the invite
+/// row, never from the joiner's request) plus the post-join roster for the
+/// joiner to mirror.
+#[derive(Debug)]
+pub struct RedeemedGroup {
+    pub group_id: String,
+    pub roster: Vec<GroupMemberInfo>,
+}
+
 /// A peer joining a group, as seen by the group owner. `shares` lists every
 /// workspace the joiner contributes (multi-select join).
 #[derive(Debug)]
@@ -899,14 +908,14 @@ impl StateStore {
 
     /// Redeem a group invite: validates the multi-use ticket, adds the joiner
     /// to the roster with every contributed workspace, grants the joiner read
-    /// access to the owner's contributions, and returns the current roster for
-    /// the joiner to reconcile.
+    /// access to the owner's contributions, and returns the authoritative
+    /// group id with the current roster for the joiner to reconcile.
     pub fn redeem_group_invite(
         &self,
         invite_id: &str,
         secret: &str,
         joiner: &JoinerInfo<'_>,
-    ) -> Result<Vec<GroupMemberInfo>> {
+    ) -> Result<RedeemedGroup> {
         validate_identifier(joiner.peer_name, "peer name")?;
         let mut connection = self.connect()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
@@ -974,7 +983,8 @@ impl StateStore {
             [invite_id],
         )?;
         transaction.commit()?;
-        self.members(&group_id)
+        let roster = self.members(&group_id)?;
+        Ok(RedeemedGroup { group_id, roster })
     }
 
     pub fn touch_group_sync(&self, group_name_or_id: &str) -> Result<()> {
@@ -1266,7 +1276,7 @@ mod tests {
         let erin_share = real_share(&store, temp.path(), "erin", "erin-ws");
 
         let invite = store.create_group_invite("team", 60, None).unwrap();
-        let roster = store
+        let redeemed = store
             .redeem_group_invite(
                 &invite.id,
                 &invite.secret,
@@ -1277,9 +1287,14 @@ mod tests {
                 ),
             )
             .unwrap();
-        assert_eq!(roster.len(), 2, "owner + alice");
+        assert_eq!(
+            redeemed.group_id,
+            store.group("team").unwrap().id,
+            "the group is derived from the invite row"
+        );
+        assert_eq!(redeemed.roster.len(), 2, "owner + alice");
         // The same ticket admits another peer — group invites are multi-use.
-        let roster = store
+        let redeemed = store
             .redeem_group_invite(
                 &invite.id,
                 &invite.secret,
@@ -1290,7 +1305,7 @@ mod tests {
                 ),
             )
             .unwrap();
-        assert_eq!(roster.len(), 3);
+        assert_eq!(redeemed.roster.len(), 3);
         assert!(store
             .redeem_group_invite(
                 &invite.id,
@@ -1334,7 +1349,7 @@ mod tests {
         let (temp, store, share) = group_store();
         let alice_share = real_share(&store, temp.path(), "alice", "alice-ws");
         let invite = store.create_group_invite("team", 60, None).unwrap();
-        let roster = store
+        let redeemed = store
             .redeem_group_invite(
                 &invite.id,
                 &invite.secret,
@@ -1349,7 +1364,8 @@ mod tests {
         // Owner's share is now authorized for the newcomer.
         store.authorize("peer-1", &share.id, "query").unwrap();
         // Roster carries the member's endpoint hint for dialing back.
-        let alice = roster
+        let alice = redeemed
+            .roster
             .iter()
             .find(|member| member.peer_id == "peer-1")
             .expect("alice in roster");

--- a/src/remote/state.rs
+++ b/src/remote/state.rs
@@ -233,8 +233,12 @@ impl StateStore {
             "ALTER TABLE invites ADD COLUMN max_uses INTEGER",
             "ALTER TABLE invites ADD COLUMN used_count INTEGER NOT NULL DEFAULT 0",
         ] {
+            // Only the expected "column already exists" failure is benign for
+            // an idempotent ALTER; anything else is a real migration error.
             match connection.execute(statement, []) {
-                Ok(_) | Err(_) => {}
+                Ok(_) => {}
+                Err(error) if Self::is_duplicate_column(&error) => {}
+                Err(error) => return Err(error.into()),
             }
         }
         // Migrate the pre-split `group_members` (one share per member) into the
@@ -291,6 +295,16 @@ impl StateStore {
             )?;
         }
         Ok(())
+    }
+
+    /// True for the only benign `ALTER TABLE ADD COLUMN` failure on an
+    /// already-migrated database: the column already exists.
+    fn is_duplicate_column(error: &rusqlite::Error) -> bool {
+        matches!(
+            error,
+            rusqlite::Error::SqliteFailure(_, Some(message))
+                if message.contains("duplicate column name")
+        )
     }
 
     pub fn add_share(
@@ -601,24 +615,31 @@ impl StateStore {
             .map_err(Into::into)
     }
 
-    pub fn revoke(&self, share_name_or_id: &str, peer_name_or_id: &str) -> Result<GrantInfo> {
+    /// Revoke a grant, returning it when one was active.
+    ///
+    /// Revoking a grant that does not exist is an idempotent no-op (`Ok(None)`):
+    /// the group paths rely on it, since kick/leave must not fail just because
+    /// a peer already lost access. Every other failure (missing share/peer,
+    /// database error) is propagated.
+    pub fn revoke(
+        &self,
+        share_name_or_id: &str,
+        peer_name_or_id: &str,
+    ) -> Result<Option<GrantInfo>> {
         let share = self.share(share_name_or_id)?;
         let peer = self.peer(peer_name_or_id)?;
         let grant = self
             .grants(&share.id)?
             .into_iter()
-            .find(|grant| grant.peer_id == peer.id)
-            .with_context(|| {
-                format!(
-                    "Peer `{}` has no active grant for `{}`",
-                    peer.name, share.name
-                )
-            })?;
+            .find(|grant| grant.peer_id == peer.id);
+        let Some(grant) = grant else {
+            return Ok(None);
+        };
         self.connect()?.execute(
             "UPDATE grants SET revoked_at = ?1 WHERE peer_id = ?2 AND share_id = ?3",
             params![now(), peer.id, share.id],
         )?;
-        Ok(grant)
+        Ok(Some(grant))
     }
 
     // ------------------------------------------------------------------
@@ -667,14 +688,19 @@ impl StateStore {
             .map_err(Into::into)
     }
 
-    pub fn group(&self, name_or_id: &str) -> Result<GroupInfo> {
+    pub fn group_opt(&self, name_or_id: &str) -> Result<Option<GroupInfo>> {
         self.connect()?
             .query_row(
                 "SELECT g.id, g.name, (SELECT COUNT(*) FROM group_members m WHERE m.group_id = g.id), g.created_at FROM groups g WHERE g.id = ?1 OR lower(g.name) = lower(?1)",
                 [name_or_id],
                 group_from_row,
             )
-            .optional()?
+            .optional()
+            .map_err(Into::into)
+    }
+
+    pub fn group(&self, name_or_id: &str) -> Result<GroupInfo> {
+        self.group_opt(name_or_id)?
             .with_context(|| format!("Unknown group `{name_or_id}`"))
     }
 
@@ -1382,13 +1408,36 @@ mod tests {
             )
             .unwrap();
         store.remove_member("team", "peer-1").unwrap();
-        store.revoke(&share.name, "peer-1").unwrap();
+        assert!(
+            store.revoke(&share.name, "peer-1").unwrap().is_some(),
+            "an active grant was revoked"
+        );
         assert!(store.authorize("peer-1", &share.id, "query").is_err());
         assert!(!store
             .members("team")
             .unwrap()
             .iter()
             .any(|member| member.peer_id == "peer-1"));
+    }
+
+    #[test]
+    fn revoke_without_grant_is_an_idempotent_noop() {
+        let (_temp, store, share) = group_store();
+        store.save_remote_peer("peer-1", "alice", "{}").unwrap();
+        assert!(store.revoke(&share.name, "peer-1").unwrap().is_none());
+        // Repeating the revoke stays a success: kick/leave must not fail just
+        // because a peer already lost access.
+        assert!(store.revoke(&share.name, "peer-1").unwrap().is_none());
+    }
+
+    #[test]
+    fn group_opt_is_none_for_unknown_group() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = StateStore::open(temp.path().join("state.db")).unwrap();
+        assert!(store.group_opt("missing").unwrap().is_none());
+        store.add_group("team", "self-1", "self").unwrap();
+        let group = store.group_opt("team").unwrap().expect("known group");
+        assert_eq!(group.name, "team");
     }
 
     #[test]

--- a/src/remote/state.rs
+++ b/src/remote/state.rs
@@ -279,9 +279,12 @@ impl StateStore {
         }
         // Rebuild `group_shares` without the share_id foreign key: mirrored
         // members' shares live on their own devices, so they never exist in
-        // the local shares table and a FK would reject them.
+        // the local shares table and a FK would reject them. Only the obsolete
+        // `share_id` FK triggers the rebuild — the `group_id`/`peer_id` FKs are
+        // intentional, so counting every FK would re-run this migration on
+        // every startup.
         let share_fks: i64 = connection.query_row(
-            "SELECT COUNT(*) FROM pragma_foreign_key_list('group_shares')",
+            "SELECT COUNT(*) FROM pragma_foreign_key_list('group_shares') WHERE \"from\" = 'share_id'",
             [],
             |row| row.get(0),
         )?;
@@ -414,9 +417,12 @@ impl StateStore {
         validate_identifier(peer_name, "peer name")?;
         let mut connection = self.connect()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        // Only share tickets are redeemable here; a group ticket carries an
+        // owner share id and must go through `redeem_group_invite`, which
+        // joins the roster and grants the whole mesh instead of a direct grant.
         let invite = transaction
             .query_row(
-                "SELECT i.share_id, s.name, i.secret_hash, i.expires_at, i.used_at, s.enabled FROM invites i JOIN shares s ON s.id = i.share_id WHERE i.id = ?1",
+                "SELECT i.share_id, s.name, i.secret_hash, i.expires_at, i.used_at, s.enabled FROM invites i JOIN shares s ON s.id = i.share_id WHERE i.id = ?1 AND i.kind = 'share'",
                 [invite_id],
                 |row| {
                     Ok((
@@ -917,6 +923,12 @@ impl StateStore {
         joiner: &JoinerInfo<'_>,
     ) -> Result<RedeemedGroup> {
         validate_identifier(joiner.peer_name, "peer name")?;
+        // Group mode promises every member publishes memory to the mesh; a
+        // joiner with no contribution would consume the roster and owner
+        // shares without contributing anything back.
+        if joiner.shares.is_empty() {
+            bail!("A group member must contribute at least one workspace");
+        }
         let mut connection = self.connect()?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let invite = transaction
@@ -1372,6 +1384,70 @@ mod tests {
         assert_eq!(alice.endpoint.as_deref(), Some(r#"{"id":"alice"}"#));
         assert_eq!(alice.role, "member");
         assert_eq!(alice.share_count, 1);
+    }
+
+    #[test]
+    fn redeem_invite_rejects_group_tickets() {
+        let (temp, store, _share) = group_store();
+        let invite = store.create_group_invite("team", 60, None).unwrap();
+        let error = store
+            .redeem_invite(&invite.id, &invite.secret, "peer-1", "alice")
+            .expect_err("a group ticket must not grant a direct share");
+        assert!(error.to_string().contains("invalid or expired"));
+        // The failed attempt grants nothing and leaves the multi-use ticket
+        // valid, so legitimate joiners are unaffected.
+        assert!(store
+            .authorize("peer-1", &invite.share_id, "query")
+            .is_err());
+        let alice_share = real_share(&store, temp.path(), "alice", "alice-ws");
+        store
+            .redeem_group_invite(
+                &invite.id,
+                &invite.secret,
+                &joiner("peer-1", "alice", &[(alice_share.id, alice_share.name)]),
+            )
+            .expect("group ticket still redeemable");
+    }
+
+    #[test]
+    fn group_join_requires_a_contributed_workspace() {
+        let (_temp, store, _share) = group_store();
+        let invite = store.create_group_invite("team", 60, None).unwrap();
+        let error = store
+            .redeem_group_invite(&invite.id, &invite.secret, &joiner("peer-1", "alice", &[]))
+            .expect_err("an empty contribution set must be rejected");
+        assert!(error.to_string().contains("contribute at least one"));
+        // The peer was not admitted and holds no grant.
+        assert!(store
+            .members("team")
+            .unwrap()
+            .iter()
+            .all(|member| member.peer_id != "peer-1"));
+        assert!(store
+            .authorize("peer-1", &invite.share_id, "query")
+            .is_err());
+    }
+
+    #[test]
+    fn group_shares_keeps_only_intentional_foreign_keys() {
+        let temp = tempfile::tempdir().unwrap();
+        let db = temp.path().join("state.db");
+        StateStore::open(db.clone()).unwrap();
+        let store = StateStore::open(db).unwrap();
+        let connection = store.connect().unwrap();
+        let mut fks: Vec<String> = connection
+            .prepare("SELECT \"from\" FROM pragma_foreign_key_list('group_shares')")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        fks.sort();
+        assert_eq!(
+            fks,
+            vec!["group_id".to_string(), "peer_id".to_string()],
+            "the obsolete share_id FK stays gone across reopens"
+        );
     }
 
     #[test]

--- a/src/remote/state.rs
+++ b/src/remote/state.rs
@@ -172,6 +172,19 @@ impl StateStore {
                 PRIMARY KEY(peer_id, share_id)
             );
 
+            -- One row per (peer, share) authorization source. `grants` keeps a
+            -- single row regardless of how many sources issued it, so each
+            -- group grant and each direct redeem records its own source here;
+            -- a grant row survives until its last source is removed.
+            CREATE TABLE IF NOT EXISTS grant_sources (
+                share_id    TEXT NOT NULL,
+                peer_id     TEXT NOT NULL,
+                via         TEXT NOT NULL CHECK (via IN ('group', 'direct')),
+                group_id    TEXT,
+                created_at  TEXT NOT NULL,
+                PRIMARY KEY(share_id, peer_id, via, group_id)
+            );
+
             CREATE TABLE IF NOT EXISTS invites (
                 id              TEXT PRIMARY KEY,
                 share_id        TEXT NOT NULL REFERENCES shares(id) ON DELETE CASCADE,
@@ -375,9 +388,24 @@ impl StateStore {
 
     pub fn remove_share(&self, name_or_id: &str) -> Result<ShareInfo> {
         let share = self.share(name_or_id)?;
+        // A share that is still contributed to a group cannot be deleted: the
+        // group's roster elsewhere keeps dialing it and a later sync would
+        // resurrect the stale contribution. Withdraw it from the group first.
+        let groups: Vec<String> = self
+            .connect()?
+            .prepare(
+                "SELECT g.name FROM group_shares gs JOIN groups g ON g.id = gs.group_id WHERE gs.share_id = ?1 ORDER BY g.name",
+            )?
+            .query_map([&share.id], |row| row.get(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        if !groups.is_empty() {
+            bail!(
+                "Share `{}` is contributed to group(s) {}; withdraw it from the group(s) first",
+                share.name,
+                groups.join(", ")
+            );
+        }
         let connection = self.connect()?;
-        // The share no longer exists, so it can no longer be contributed to
-        // any group (grants cascade via the shares FK).
         connection.execute("DELETE FROM group_shares WHERE share_id = ?1", [&share.id])?;
         connection.execute("DELETE FROM shares WHERE id = ?1", [&share.id])?;
         Ok(share)
@@ -448,6 +476,12 @@ impl StateStore {
         transaction.execute(
             "INSERT INTO peers(id, name, created_at, last_seen_at) VALUES (?1, ?2, ?3, ?3) ON CONFLICT(id) DO UPDATE SET name = excluded.name, last_seen_at = excluded.last_seen_at",
             params![peer_id, peer_name, timestamp],
+        )?;
+        // A direct redeem is its own grant source, independent of any group:
+        // withdrawing the same share from a group later must keep this grant.
+        transaction.execute(
+            "INSERT INTO grant_sources(share_id, peer_id, via, group_id, created_at) VALUES (?1, ?2, 'direct', NULL, ?3) ON CONFLICT DO NOTHING",
+            params![share_id, peer_id, timestamp],
         )?;
         transaction.execute(
             "INSERT INTO grants(peer_id, share_id, permission, created_at, revoked_at) VALUES (?1, ?2, ?3, ?4, NULL) ON CONFLICT(peer_id, share_id) DO UPDATE SET permission = excluded.permission, revoked_at = NULL",
@@ -539,6 +573,23 @@ impl StateStore {
 
     pub fn forget_peer(&self, name_or_id: &str) -> Result<PeerInfo> {
         let peer = self.peer(name_or_id)?;
+        // group_members cascades on peers(id): forgetting a peer that still
+        // participates in a group would silently delete the membership and
+        // leave the group without an owner, unreachable by roster sync.
+        let groups: Vec<String> = self
+            .connect()?
+            .prepare(
+                "SELECT g.name FROM group_members gm JOIN groups g ON g.id = gm.group_id WHERE gm.peer_id = ?1 ORDER BY g.name",
+            )?
+            .query_map([&peer.id], |row| row.get(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        if !groups.is_empty() {
+            bail!(
+                "Peer `{}` participates in group(s) {}; remove it from the group(s) before forgetting it",
+                peer.name,
+                groups.join(", ")
+            );
+        }
         self.connect()?
             .execute("DELETE FROM peers WHERE id = ?1", [&peer.id])?;
         Ok(peer)
@@ -650,9 +701,16 @@ impl StateStore {
         let Some(grant) = grant else {
             return Ok(None);
         };
-        self.connect()?.execute(
+        let connection = self.connect()?;
+        connection.execute(
             "UPDATE grants SET revoked_at = ?1 WHERE peer_id = ?2 AND share_id = ?3",
             params![now(), peer.id, share.id],
+        )?;
+        // An explicit revoke removes the grant for good, so its sources no
+        // longer justify anything.
+        connection.execute(
+            "DELETE FROM grant_sources WHERE peer_id = ?1 AND share_id = ?2",
+            params![peer.id, share.id],
         )?;
         Ok(Some(grant))
     }
@@ -670,7 +728,7 @@ impl StateStore {
         self_peer_id: &str,
         self_peer_name: &str,
     ) -> Result<GroupInfo> {
-        validate_identifier(name, "group name")?;
+        validate_alias(name, "group name")?;
         // The local device is a peer of itself; peers(id) is a FK target.
         self.save_remote_peer(self_peer_id, self_peer_name, "{}")?;
         let id = random_id("grp");
@@ -685,7 +743,7 @@ impl StateStore {
     /// Register a group row with an explicit id. Joiners use this to mirror the
     /// owner's group identity; idempotent on re-join.
     pub fn register_group(&self, id: &str, name: &str) -> Result<GroupInfo> {
-        validate_identifier(name, "group name")?;
+        validate_alias(name, "group name")?;
         self.connect()?.execute(
             "INSERT INTO groups(id, name, created_at) VALUES (?1, ?2, ?3) ON CONFLICT(id) DO NOTHING",
             params![id, name.to_ascii_lowercase(), now()],
@@ -853,18 +911,29 @@ impl StateStore {
             .map_err(Into::into)
     }
 
-    /// Grant `peer` read access to `share` (idempotent). Also clears a previous
-    /// revocation, so rejoining a group reactivates the grant.
-    pub fn group_grant(&self, share_id: &str, peer_id: &str) -> Result<()> {
-        self.connect()?.execute(
+    /// Grant `peer` read access to `share` on behalf of `group` (idempotent).
+    /// Also clears a previous revocation, so rejoining a group reactivates
+    /// the grant. The group source is recorded in `grant_sources` under the
+    /// group's real id (the argument may be a name), so a later withdrawal
+    /// from this group alone does not revoke access still justified by
+    /// another source.
+    pub fn group_grant(&self, group_name_or_id: &str, share_id: &str, peer_id: &str) -> Result<()> {
+        let group = self.group(group_name_or_id)?;
+        let connection = self.connect()?;
+        connection.execute(
+            "INSERT INTO grant_sources(share_id, peer_id, via, group_id, created_at) VALUES (?1, ?2, 'group', ?3, ?4) ON CONFLICT DO NOTHING",
+            params![share_id, peer_id, group.id, now()],
+        )?;
+        connection.execute(
             "INSERT INTO grants(peer_id, share_id, permission, created_at, revoked_at) VALUES (?1, ?2, ?3, ?4, NULL) ON CONFLICT(peer_id, share_id) DO UPDATE SET permission = excluded.permission, revoked_at = NULL",
             params![peer_id, share_id, PERMISSION_READ_MEMORY, now()],
         )?;
         Ok(())
     }
 
-    /// Revoke a member's grant on a group share, keeping it while another
-    /// source still justifies the access (see [`Self::has_other_grant_source`]).
+    /// Revoke a member's grant on a group share. The group's source row is
+    /// removed first; the grant itself survives while another source still
+    /// justifies it (see [`Self::has_other_grant_source`]).
     pub fn revoke_group_grant(
         &self,
         group_name_or_id: &str,
@@ -872,6 +941,10 @@ impl StateStore {
         peer_id: &str,
     ) -> Result<()> {
         let group = self.group(group_name_or_id)?;
+        self.connect()?.execute(
+            "DELETE FROM grant_sources WHERE share_id = ?1 AND peer_id = ?2 AND via = 'group' AND group_id = ?3",
+            params![share_id, peer_id, group.id],
+        )?;
         if self.has_other_grant_source(&group.id, share_id, peer_id)? {
             return Ok(());
         }
@@ -880,32 +953,27 @@ impl StateStore {
     }
 
     /// True when `peer` still holds access to `share` from a source other than
-    /// the group being revoked from: membership in another group that lists
-    /// the share, or a direct share mount. `grants` stores one row per
-    /// (peer, share) even when several sources issued it, so group revocation
-    /// must not tear down independently authorized access.
+    /// the group being revoked from. `grants` stores one row per (peer, share)
+    /// even when several sources issued it, so each group grant and direct
+    /// redeem records a row in `grant_sources`; revocation must not tear down
+    /// independently authorized access.
     fn has_other_grant_source(
         &self,
         group_id: &str,
         share_id: &str,
         peer_id: &str,
     ) -> Result<bool> {
-        let connection = self.connect()?;
-        let other_group: bool = connection.query_row(
-            "SELECT EXISTS(
-                SELECT 1 FROM group_members gm
-                JOIN group_shares gs ON gs.group_id = gm.group_id AND gs.share_id = ?1
-                WHERE gm.peer_id = ?2 AND gm.group_id != ?3
-            )",
-            params![share_id, peer_id, group_id],
-            |row| row.get(0),
-        )?;
-        let direct_mount: bool = connection.query_row(
-            "SELECT EXISTS(SELECT 1 FROM mounts WHERE peer_id = ?1 AND share_id = ?2)",
-            params![peer_id, share_id],
-            |row| row.get(0),
-        )?;
-        Ok(other_group || direct_mount)
+        self.connect()?
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM grant_sources
+                    WHERE share_id = ?1 AND peer_id = ?2
+                      AND NOT (via = 'group' AND group_id = ?3)
+                )",
+                params![share_id, peer_id, group_id],
+                |row| row.get(0),
+            )
+            .map_err(Into::into)
     }
 
     /// Revoke every other member's grant on `share` (the contributor withdrew
@@ -1047,6 +1115,10 @@ impl StateStore {
             rows.collect::<rusqlite::Result<Vec<_>>>()?
         };
         for owner_share in &owner_shares {
+            transaction.execute(
+                "INSERT INTO grant_sources(share_id, peer_id, via, group_id, created_at) VALUES (?1, ?2, 'group', ?3, ?4) ON CONFLICT DO NOTHING",
+                params![owner_share, joiner.peer_id, group_id, timestamp],
+            )?;
             transaction.execute(
                 "INSERT INTO grants(peer_id, share_id, permission, created_at, revoked_at) VALUES (?1, ?2, ?3, ?4, NULL) ON CONFLICT(peer_id, share_id) DO UPDATE SET permission = excluded.permission, revoked_at = NULL",
                 params![joiner.peer_id, owner_share, PERMISSION_READ_MEMORY, timestamp],
@@ -1537,7 +1609,7 @@ mod tests {
         // Bob reconciles a GroupMemberAdded push: the newcomer gets read access
         // to Bob's group share.
         store.save_remote_peer("peer-3", "carol", "{}").unwrap();
-        store.group_grant(&bob_share.id, "peer-3").unwrap();
+        store.group_grant("team", &bob_share.id, "peer-3").unwrap();
         store.add_member("team", "peer-3", "member").unwrap();
         store
             .add_group_share("team", "peer-3", &carol_share.id, &carol_share.name)
@@ -1638,8 +1710,8 @@ mod tests {
             .add_group_share("team-b", "peer-1", &b_share.id, &b_share.name)
             .unwrap();
         // Same share granted to the same peer twice is a no-op, not a conflict.
-        store.group_grant(&share.id, "peer-1").unwrap();
-        store.group_grant(&share.id, "peer-1").unwrap();
+        store.group_grant("team", &share.id, "peer-1").unwrap();
+        store.group_grant("team", &share.id, "peer-1").unwrap();
         assert!(store.authorize("peer-1", &share.id, "query").is_ok());
         assert_eq!(store.groups().unwrap().len(), 2);
     }
@@ -1707,7 +1779,7 @@ mod tests {
             .unwrap();
         assert!(store.authorize("peer-1", &share.id, "query").is_err());
         // Re-adding the share re-grants.
-        store.group_grant(&share.id, "peer-1").unwrap();
+        store.group_grant("team", &share.id, "peer-1").unwrap();
         assert!(store.authorize("peer-1", &share.id, "query").is_ok());
     }
 
@@ -1726,7 +1798,9 @@ mod tests {
         store
             .add_group_share("team-b", "self-1", &share.id, &share.name)
             .unwrap();
-        store.group_grant(&share.id, "peer-1").unwrap();
+        // Both groups granted access; each records its own source.
+        store.group_grant("team", &share.id, "peer-1").unwrap();
+        store.group_grant("team-b", &share.id, "peer-1").unwrap();
         // Withdraw from `team` (contribution row first, as the daemon does):
         // the grant survives because `team-b` still lists the share.
         store
@@ -1750,9 +1824,16 @@ mod tests {
     }
 
     #[test]
-    fn group_revocation_preserves_direct_mount_access() {
+    fn group_revocation_preserves_direct_redeem_access() {
         let (temp, store, share) = group_store();
         let alice_share = real_share(&store, temp.path(), "alice", "alice-ws");
+        // Alice first redeems a direct share invite for the owner workspace
+        // (the owner's store records the 'direct' source), then joins the
+        // group too.
+        let direct = store.create_invite("project", 60).unwrap();
+        store
+            .redeem_invite(&direct.id, &direct.secret, "peer-1", "alice")
+            .unwrap();
         let invite = store.create_group_invite("team", 60, None).unwrap();
         store
             .redeem_group_invite(
@@ -1765,17 +1846,17 @@ mod tests {
                 ),
             )
             .unwrap();
-        // Alice also redeemed a direct share invite for the owner workspace.
-        store
-            .add_mount("workspace-key", "desk", "peer-1", &share.id, &share.name)
-            .unwrap();
+        // Withdrawing the workspace from the group must keep the direct grant.
         store
             .revoke_group_share("team", &share.id, "self-1")
             .unwrap();
         assert!(
             store.authorize("peer-1", &share.id, "query").is_ok(),
-            "the direct mount still grants access"
+            "the direct redeem still grants access"
         );
+        // An explicit revoke removes it for good.
+        store.revoke(&share.name, "peer-1").unwrap();
+        assert!(store.authorize("peer-1", &share.id, "query").is_err());
     }
 
     #[test]
@@ -1799,7 +1880,7 @@ mod tests {
     }
 
     #[test]
-    fn removing_share_cascades_group_contribution() {
+    fn removing_a_contributed_share_is_rejected() {
         let temp = tempfile::tempdir().unwrap();
         let workspace = temp.path().join("workspace");
         std::fs::create_dir(&workspace).unwrap();
@@ -1811,8 +1892,41 @@ mod tests {
         store
             .add_group_share("team", "self-1", &share.id, &share.name)
             .unwrap();
+        let error = store.remove_share(&share.name).expect_err("contributed");
+        assert!(error.to_string().contains("contributed to group"));
+        // Once the contribution is withdrawn, removal succeeds.
+        store
+            .remove_group_share("team", "self-1", &share.id)
+            .unwrap();
         store.remove_share(&share.name).unwrap();
-        // Group state converges passively: the contribution row is gone.
-        assert!(store.group_shares("team", "self-1").unwrap().is_empty());
+        assert!(store.share(&share.id).is_err());
+    }
+
+    #[test]
+    fn forgetting_a_group_member_is_rejected() {
+        let (_temp, store, _share) = group_store();
+        // self-1 is the group owner; forgetting it would orphan the group.
+        let error = store.forget_peer("self-1").expect_err("group member");
+        assert!(error.to_string().contains("participates in group"));
+        // A peer that is not in any group is forgettable.
+        store.save_remote_peer("peer-9", "zoe", "{}").unwrap();
+        store.forget_peer("peer-9").unwrap();
+        assert!(store.peer("peer-9").is_err());
+    }
+
+    #[test]
+    fn group_names_reject_reserved_schemes() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = StateStore::open(temp.path().join("state.db")).unwrap();
+        let error = store
+            .add_group("local", "self-1", "self")
+            .expect_err("reserved");
+        assert!(error.to_string().contains("reserved"));
+        let error = store
+            .add_group("sivtr", "self-1", "self")
+            .expect_err("reserved");
+        assert!(error.to_string().contains("reserved"));
+        // Ordinary names still work.
+        store.add_group("team", "self-1", "self").unwrap();
     }
 }


### PR DESCRIPTION
## Summary

Adds **group mode**: a named set of devices that publish their workspace memory to each other. Groups are a mesh overlay on the existing share/grant/mount model - no new transport, crypto, or central storage. Join = redeem one multi-use invite with the owner, mirror the roster locally, and grant every member read access to every share you contribute.

## How group mode works

**Mental model.** A group is a roster overlay on the existing share/grant/mount model. There is no central server: every device stores a full local mirror of the roster, its own contributions, and the grants it issued. The owner is the roster's source of truth for membership; members pull-sync on a 5-minute TTL. Queries fan out peer-to-peer (each member is dialed directly, never through the owner).

**Invariant.** For every contribution a member adds, every other member holds a read-memory grant on that share.

**Data model.** `groups` (the group), `group_members` (who is in, owner/member role), `group_shares` (each member's contributions; one device can contribute several workspaces), `invites(kind='group')` (multi-use join tickets), plus the existing `grants` table (one row per (peer, share), possibly issued by several sources).

**Lifecycle.**

1. **Create** - `sivtr group create <GROUP>`: local group row, self is owner, the current workspace becomes the first contribution.
2. **Invite** - `sivtr group invite <GROUP>`: a multi-use ticket (secret, expiry, optional `--max-uses`) encoded as a join link.
3. **Join** - `sivtr group join <INVITE>`: the joiner sends `RedeemGroupInvite` (ticket + own peer identity + chosen contributions + endpoint) to the owner. The owner validates the ticket, inserts the member and its contributions, grants the newcomer read access to every owner contribution, broadcasts `GroupMemberAdded` to the other members, and returns the authoritative group id + full roster. The joiner mirrors the roster locally and grants every member read access to its own contributions - the mesh closes.
4. **Adjust contributions** - re-running join diffs current vs. wanted contributions: new ones register + grant + broadcast `GroupShareAdded`; unchecked ones are removed + revoked + broadcast `GroupShareRemoved`.
5. **Sync** - when the 5-min TTL is stale, the member pulls the authoritative roster from the owner (bounded 5s dial; on failure the cached roster is used). Reconciliation upserts members/contributions, prunes contributions the owner no longer lists, re-grants, and drops members the owner no longer lists (revoking their access). A `member: false` response (kicked, or group gone) drops the group locally.
6. **Query** - `sivtr s <GROUP>:terminal "q"` fans out to every (member, share); `sivtr s <GROUP>/<PEER>:terminal` pins one member, `sivtr s <GROUP>/<PEER>/<SHARE>:terminal` pins one share. Shares only bound the set; ordering, `--latest`, and `--limit` are applied once over the merged corpus, so results are the group's global top results, not a per-share top-k. Members that answered nothing are reported as skipped. Results are scoped `<GROUP>/<peer-id>/<SHARE>/...` so refs round-trip through show/zoom/nav even when two devices share a hostname.
7. **Leave** - revoke the grants you issued, drop the local group (membership + contributions cascade), notify the owner; the owner removes the member and broadcasts `GroupMemberRemoved`. Leaving is clean even while the owner is offline.
8. **Kick** - owner-only `sivtr group remove <GROUP> <PEER>`: revoke the owner's grants to the member, remove the member (with its contribution rows), broadcast `GroupMemberRemoved`. An online kicked device drops the group on receipt; an offline one self-heals on the next sync.
9. **Disband** - the owner leaving revokes all grants, drops the local group, and notifies every member to drop it too.

**Offline behavior.** Queries and listings always use the cached roster when the owner is unreachable (sync is best-effort). Members that miss a broadcast catch up on the next sync: additions are granted, removals pruned, kicks drop the group.

**Security model.** The iroh transport authenticates the sender's peer id, and every group operation is bound to it: only the owner may change membership, only a contributor may register/withdraw its own share, and only members may read the roster. Group tickets are rejected by the single-share redemption path (`kind` check), and joining requires at least one contributed workspace. Grant revocation is source-aware: a grant survives while another group or a direct share mount still justifies it.

## Usage

`<GROUP>` is any name you pick (used in refs, e.g. `team:terminal/...`); `<PEER>` is a member name or id; `<SHARE>` is a contributed workspace name.

```bash
sivtr group create <GROUP>         # create group + contribute current workspace
sivtr group invite <GROUP>         # reusable join link (expires, optional --max-uses)
sivtr group join <INVITE>          # interactive multi-select of workspaces to contribute
sivtr group join <INVITE> --workspace <PATH>   # append another workspace (re-run anywhere)
sivtr group members <GROUP>        # roster with per-member workspace count
sivtr group remove <GROUP> <PEER>  # owner kicks (kicked device self-heals on next sync)
sivtr group leave <GROUP>          # leave; owner leaving disbands the group

sivtr s <GROUP>:terminal "docker pull failed"   # fan out to every member, merged
sivtr s <GROUP>/<PEER>:terminal "x"             # one member (all their contributions)
sivtr s <GROUP>/<PEER>/<SHARE>:terminal "x"     # one member, one specific share
```

## Design

- **Membership - grants**: a member's contribution is visible to the group iff every member holds a read-memory grant on that share (existing grants table, share-scoped).
- **Member/share split**: group_members (who's in) + group_shares (many contributions per member) - one device can contribute several workspaces, reusing the existing sivtr share primitive as the contribution unit.
- **Owner as roster source of truth**: members pull-sync on a 5-min TTL (GroupSync); offline members catch up, kicked devices drop the group locally.
- **Three-segment scopes** (`<GROUP>/<PEER>/<SHARE>`) reuse the existing WorkRef hierarchy: parse_scope_name accepts up to three segments, targeting accepts a member by name or peer id, and result refs use the stable peer id as the member segment so show/zoom/nav round-trip group refs unchanged even across same-named devices.
- **Fan-out**: the daemon dials every (member, share) in parallel under a per-peer timeout; offline members are skipped and reported, never fatal. Only bound predicates are pushed down; `latest`/`sort`/`limit` are applied once over the merged corpus.

## Also in this PR

- Remote queries against an empty workspace now return empty results instead of erroring (previously misreported as "offline").
- sivtr share helpers (find_share_for_workspace, default_share_name, workspace picker) extracted for reuse by group join.
- Review hardening: group tickets cannot redeem as direct shares, joining requires a contribution, owners cannot remove themselves, stale-roster sync is time-bounded, the migration no longer rebuilds group_shares on every startup, group query ordering/limits are global, and grant revocation is source-aware.

## Tests

- cargo test --workspace - 319 lib + 197 bin pass.
- cargo clippy --workspace --all-targets -- -D warnings clean.
- Manual two-device e2e (dual SIVTR_DATA_DIR): create - invite - join - append a second workspace - fan-out query - kick self-heal - rejoin.

## Compatibility

Groups add new wire messages and database tables to the remote daemon. Existing daemons (without group support) simply do not recognize the new messages and continue serving share-scoped requests unchanged; there is no change to existing CLI, wire, or storage contracts, so no breaking change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added group collaboration with group creation, invitations, joining, member management, leaving, and roster synchronization.
  - Added the `group` command, with `g` as an alias.
  - Groups support multiple workspace contributions, configurable invite expiration and usage limits, and permission-aware membership changes.
  - Added group-scoped queries for members and shared workspaces, including support for offline-member reporting.
- **Documentation**
  - Added guidance and examples for using remote groups, membership, permissions, synchronization, and qualified member references.
- **Bug Fixes**
  - Improved invitation handling, share revocation, authorization, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->