### PR TITLE
build: optimize release profile for TUI startup and size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,3 +124,13 @@ dhat = "0.3"
 perf-benches = []
 # Heap profiling: `cargo bench -p sivtr --bench browse_dhat --features "perf-benches,dhat-heap"`
 dhat-heap = []
+
+# Release binary optimization. This is a TUI-heavy CLI where binary size and
+# startup latency are user-visible: cross-crate LTO inlines across the heavy
+# dependency chain (iroh/tokio/rusqlite), a single codegen unit maximizes that,
+# and stripping debug symbols halves the shipped artifact. `panic` stays
+# `unwind` — anyhow backtraces rely on it.
+[profile.release]
+lto = "thin"
+codegen-units = 1
+strip = "symbols"


### PR DESCRIPTION
## Summary

Adds a `[profile.release]` section — previously release builds used Rust defaults (no LTO, 16 codegen units, unstripped symbols).

- `lto = "thin"`: cross-crate inlining across the heavy dependency chain (iroh/tokio/rusqlite)
- `codegen-units = 1`: maximizes optimization (thin LTO keeps compile time sane)
- `strip = "symbols"`: roughly halves the shipped binary — this is a TUI-heavy CLI where startup latency and download size are user-visible
- `panic` stays `unwind`: terminal restore relies on `Drop` and the panic hook's unwind semantics, and the daemon catches faults. Not related to anyhow backtraces (those are captured at error creation, independent of panic strategy)

## Why

Sivtr is a TUI + CLI: the binary should start fast and be small to install. Current release binaries ship unstripped with no LTO. No functional change — build output only.

## Trade-offs (measured)

Measured against `main` on a clean release build (Linux, debug toolchain host):

| Measurement | `main` | this PR | Change |
| --- | ---: | ---: | ---: |
| Raw binary | 40,059,328 B | 26,766,400 B | −33.2% |
| `tar.gz` binary | 13,196,094 B | 10,985,812 B | −16.7% |
| Clean release build | 47.5 s | 114.5 s | +2.4x |

The clean-build cost is accepted: release builds are low-frequency (tag/release workflow), and the debug profile used for day-to-day development is untouched. `strip = "symbols"` also removes the symbol table, so `RUST_BACKTRACE=1` on a release artifact shows addresses rather than symbol names; `strip = "debuginfo"` can be swapped in if symbolized backtraces become a support requirement.

## Notes

Based directly on `main` — no dependency on any other open PR. No breaking change: the profile affects build output only, all supported targets (Linux GNU/musl, Windows MSVC, macOS) build through the existing release workflow.
