### PR TITLE
feat(tui): restore terminal state before panics are reported

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ use std::process::ExitCode;
 
 /// Binary entry — keeps `main.rs` a one-liner so benches can depend on the lib.
 pub fn cli_main() -> ExitCode {
+    tui::panic::install();
     match run() {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) if commands::browse::is_pick_cancelled(&error) => ExitCode::SUCCESS,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod content;
 pub mod pane;
+pub mod panic;
 pub mod search;
 pub mod terminal;
 pub mod theme;

--- a/src/tui/panic.rs
+++ b/src/tui/panic.rs
@@ -1,0 +1,68 @@
+//! Restore the terminal before reporting a panic.
+//!
+//! The panic hook runs on whatever thread panicked. A TUI can only be torn down safely from the
+//! thread that owns it (the main thread), so the restore closure is stored in a thread-local and
+//! only invoked when the panicking thread is the one that registered it. Background-thread panics
+//! still get the default report without tearing down a live interface.
+
+use std::cell::RefCell;
+use std::panic::AssertUnwindSafe;
+use std::sync::Once;
+
+thread_local! {
+    /// Closure that restores the terminal, registered by the TUI on the thread that owns it.
+    static TERMINAL_RESTORE: RefCell<Option<Box<dyn FnOnce()>>> = const { RefCell::new(None) };
+}
+
+static INSTALL: Once = Once::new();
+
+/// Register the closure the panic hook runs to restore the terminal.
+///
+/// The closure is stored on the calling thread and only runs when that thread panics, so a panic
+/// on a background thread cannot tear down a TUI that is still drawing on the main thread.
+pub fn register_restore(restore: Box<dyn FnOnce()>) {
+    TERMINAL_RESTORE.with(|slot| slot.replace(Some(restore)));
+}
+
+/// Install a panic hook that restores the terminal before reporting the panic.
+///
+/// The previously installed hook is kept and invoked afterward, so panic output formatting and
+/// backtrace hints are unchanged. Installing more than once is a no-op.
+pub fn install() {
+    INSTALL.call_once(|| {
+        let default_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            let restore = TERMINAL_RESTORE
+                .with(|slot| slot.try_borrow_mut().ok().and_then(|mut slot| slot.take()));
+            if let Some(restore) = restore {
+                // A restore that panics (e.g. I/O against a dying console) must not abort the
+                // process before the panic is reported.
+                let _ = std::panic::catch_unwind(AssertUnwindSafe(restore));
+            }
+            default_hook(info);
+        }));
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{install, register_restore};
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+
+    #[test]
+    fn restore_closure_runs_on_same_thread_panic() {
+        install();
+        let restored = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&restored);
+        register_restore(Box::new(move || {
+            flag.store(true, Ordering::Relaxed);
+        }));
+
+        let result = std::panic::catch_unwind(|| panic!("deliberate panic"));
+        assert!(result.is_err());
+        assert!(restored.load(Ordering::Relaxed));
+    }
+}

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -12,12 +12,16 @@ use crossterm::{
 use ratatui::{buffer::CellDiffOption, prelude::*};
 use std::io::IsTerminal;
 use std::{
+    cell::RefCell,
     fmt::Display,
     io::{self, Stdout},
     mem,
     ops::{Deref, DerefMut},
+    rc::Rc,
 };
 use unicode_width::UnicodeWidthStr;
+
+use super::panic;
 
 type InnerTui = Terminal<CrosstermBackend<Stdout>>;
 
@@ -28,7 +32,9 @@ type InnerTui = Terminal<CrosstermBackend<Stdout>>;
 pub struct Tui {
     terminal: InnerTui,
     drawing_active: bool,
-    state: TerminalState,
+    /// Shared with the panic hook so a crash restores the terminal exactly as `Drop` would.
+    /// The TUI and its panic restore live on the same thread, so the state never leaves it.
+    state: Rc<RefCell<TerminalState>>,
     #[cfg(windows)]
     previous_frame_had_wide_cells: bool,
     #[cfg(windows)]
@@ -49,10 +55,28 @@ impl DerefMut for Tui {
     }
 }
 
+impl Tui {
+    /// Register the terminal restore with the panic hook, replacing any previous registration.
+    ///
+    /// Called by [`init`] for every new terminal session. The previous session's state was
+    /// already restored (or its `Tui` is still alive and owns its own registration path), so
+    /// replacing the closure is safe.
+    fn register_panic_restore(&self) {
+        let state = Rc::clone(&self.state);
+        panic::register_restore(Box::new(move || {
+            // Restore in place: successful cleanup steps are disarmed, so an unwinding `Drop`
+            // afterwards retries only the steps that failed here.
+            let mut state = state.borrow_mut();
+            let _ = restore_terminal_state(&mut state);
+        }));
+    }
+}
+
 impl Drop for Tui {
     fn drop(&mut self) {
-        if self.state.has_pending_cleanup() {
-            let _ = restore_terminal_state(&mut self.state);
+        let mut state = self.state.borrow_mut();
+        if state.has_pending_cleanup() {
+            let _ = restore_terminal_state(&mut state);
         }
         self.drawing_active = false;
     }
@@ -116,15 +140,17 @@ pub fn init() -> Result<Tui> {
         Err(error) => return setup.fail(error),
     };
 
-    Ok(Tui {
+    let tui = Tui {
         terminal,
         drawing_active: true,
-        state: setup.commit(),
+        state: Rc::new(RefCell::new(setup.commit())),
         #[cfg(windows)]
         previous_frame_had_wide_cells: false,
         #[cfg(windows)]
         synchronized_updates_supported,
-    })
+    };
+    tui.register_panic_restore();
+    Ok(tui)
 }
 
 /// Draw one TUI frame.
@@ -245,7 +271,8 @@ fn apply_full_redraw_policy(buffer: &mut Buffer) {
 /// cleanup is pending because crossterm can write its cached raw mode during a retry.
 pub fn restore(terminal: &mut Tui) -> Result<()> {
     terminal.drawing_active = false;
-    restore_terminal_state(&mut terminal.state)
+    let mut state = terminal.state.borrow_mut();
+    restore_terminal_state(&mut state)
 }
 
 /// Restore a terminal and preserve both the operation error and a cleanup error, if both occur.


### PR DESCRIPTION
## What

Installs a panic hook that restores the terminal before the default panic report prints, so a crash never leaves the user's shell in raw mode / alternate screen / mouse capture — and on Windows, with the exact console input/output modes, code page, and temporary CONIN$ handle still swapped in.

## How

- `src/tui/panic.rs` (new): a thread-local restore slot + `install()`. The hook runs on whatever thread panicked, but the restore closure is only invoked when that thread is the one that owns the TUI — a background-thread panic still gets the default report without tearing down a live interface. The previously installed hook is kept and invoked after restore, so panic output format and backtrace hints are unchanged.
- `Tui::init` registers a restore closure that reuses the existing `restore_terminal_state`, so a crash gets the same precise Windows cleanup as a normal exit (console modes, code page, CONIN$ handle), not just the usual alt-screen/raw-mode four commands.
- `Tui.state` becomes `Rc<RefCell<TerminalState>>` shared with the hook. The hook restores **in place**, disarming successful steps; an unwinding `Drop` afterwards retries only the steps that failed in the hook — preserving the existing Windows retry semantics exactly.
- `cli_main` installs the hook once (idempotent), covering browse, copy, hotkey, and everything else that opens a TUI.

Test: registers a restore closure on the current thread, panics inside `catch_unwind`, asserts the closure ran. Gate: fmt + clippy `-D warnings` + full workspace tests all green (197 passed).

## Why now

Panic hooks are the one substantive gap vs. standard TUI-app practice (ratatui templates, color-eyre, human-panic all do this); everything else was already in place — Drop-based restore, Ctrl+C handling, `event::poll(100ms)` loop. Note `panic=abort` stays off: terminal restore relies on `Drop`, which the panic hook needs to complete first.
