### PR TITLE
feat(tui): restore terminal state before panics are reported

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ use std::process::ExitCode;
 
 /// Binary entry — keeps `main.rs` a one-liner so benches can depend on the lib.
 pub fn cli_main() -> ExitCode {
+    tui::panic::install();
     match run() {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) if commands::browse::is_pick_cancelled(&error) => ExitCode::SUCCESS,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod content;
 pub mod pane;
+pub mod panic;
 pub mod search;
 pub mod terminal;
 pub mod theme;

--- a/src/tui/panic.rs
+++ b/src/tui/panic.rs
@@ -45,11 +45,15 @@ pub fn register_restore(restore: Box<dyn FnOnce()>) -> RestoreRegistration {
 
 impl Drop for RestoreRegistration {
     fn drop(&mut self) {
-        TERMINAL_RESTORE.with(|slot| {
-            if let Some(entry) = slot.borrow_mut().get_mut(self.index) {
-                *entry = None;
-            }
-        });
+        // Teardown-safe: the thread-local may be destroyed when this runs at
+        // process exit; a panic here would abort the process.
+        TERMINAL_RESTORE
+            .try_with(|slot| {
+                if let Some(entry) = slot.borrow_mut().get_mut(self.index) {
+                    *entry = None;
+                }
+            })
+            .ok();
     }
 }
 
@@ -61,11 +65,17 @@ pub fn install() {
     INSTALL.call_once(|| {
         let default_hook = std::panic::take_hook();
         std::panic::set_hook(Box::new(move |info| {
-            let restore = TERMINAL_RESTORE.with(|slot| {
-                slot.try_borrow_mut()
-                    .ok()
-                    .and_then(|mut slot| slot.iter_mut().rev().find_map(|entry| entry.take()))
-            });
+            // Teardown-safe: the thread-local may already be destroyed when
+            // the hook runs at process exit; a panic here would abort the
+            // report of the original panic.
+            let restore = TERMINAL_RESTORE
+                .try_with(|slot| {
+                    slot.try_borrow_mut()
+                        .ok()
+                        .and_then(|mut slot| slot.iter_mut().rev().find_map(|entry| entry.take()))
+                })
+                .ok()
+                .flatten();
             if let Some(restore) = restore {
                 // A restore that panics (e.g. I/O against a dying console) must not abort the
                 // process before the panic is reported.

--- a/src/tui/panic.rs
+++ b/src/tui/panic.rs
@@ -1,0 +1,68 @@
+//! Restore the terminal before reporting a panic.
+//!
+//! The panic hook runs on whatever thread panicked. A TUI can only be torn down safely from the
+//! thread that owns it (the main thread), so the restore closure is stored in a thread-local and
+//! only invoked when the panicking thread is the one that registered it. Background-thread panics
+//! still get the default report without tearing down a live interface.
+
+use std::cell::RefCell;
+use std::panic::AssertUnwindSafe;
+use std::sync::Once;
+
+thread_local! {
+    /// Closure that restores the terminal, registered by the TUI on the thread that owns it.
+    static TERMINAL_RESTORE: RefCell<Option<Box<dyn FnOnce()>>> = const { RefCell::new(None) };
+}
+
+static INSTALL: Once = Once::new();
+
+/// Register the closure the panic hook runs to restore the terminal.
+///
+/// The closure is stored on the calling thread and only runs when that thread panics, so a panic
+/// on a background thread cannot tear down a TUI that is still drawing on the main thread.
+pub fn register_restore(restore: Box<dyn FnOnce()>) {
+    TERMINAL_RESTORE.with(|slot| slot.replace(Some(restore)));
+}
+
+/// Install a panic hook that restores the terminal before reporting the panic.
+///
+/// The previously installed hook is kept and invoked afterward, so panic output formatting and
+/// backtrace hints are unchanged. Installing more than once is a no-op.
+pub fn install() {
+    INSTALL.call_once(|| {
+        let default_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            let restore = TERMINAL_RESTORE
+                .with(|slot| slot.try_borrow_mut().ok().and_then(|mut slot| slot.take()));
+            if let Some(restore) = restore {
+                // A restore that panics (e.g. I/O against a dying console) must not abort the
+                // process before the panic is reported.
+                let _ = std::panic::catch_unwind(AssertUnwindSafe(restore));
+            }
+            default_hook(info);
+        }));
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{install, register_restore};
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+
+    #[test]
+    fn restore_closure_runs_on_same_thread_panic() {
+        install();
+        let restored = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&restored);
+        register_restore(Box::new(move || {
+            flag.store(true, Ordering::Relaxed);
+        }));
+
+        let result = std::panic::catch_unwind(|| panic!("deliberate panic"));
+        assert!(result.is_err());
+        assert!(restored.load(Ordering::Relaxed));
+    }
+}

--- a/src/tui/panic.rs
+++ b/src/tui/panic.rs
@@ -10,18 +10,47 @@ use std::panic::AssertUnwindSafe;
 use std::sync::Once;
 
 thread_local! {
-    /// Closure that restores the terminal, registered by the TUI on the thread that owns it.
-    static TERMINAL_RESTORE: RefCell<Option<Box<dyn FnOnce()>>> = const { RefCell::new(None) };
+    /// Stack of panic-time restore closures, innermost (most recent) session
+    /// last. A session's entry is cleared when that session restores or drops,
+    /// so a later panic in a still-live outer session pops the outer closure.
+    static TERMINAL_RESTORE: RestoreSlots = const { RefCell::new(Vec::new()) };
 }
 
+/// Registered restore closures; see [`TERMINAL_RESTORE`].
+type RestoreSlots = RefCell<Vec<Option<Box<dyn FnOnce()>>>>;
+
 static INSTALL: Once = Once::new();
+
+/// A session's panic-restore registration. Dropping it (TUI finish/drop)
+/// clears this session's slot without shifting later indices; the panic hook
+/// takes the innermost live closure.
+pub struct RestoreRegistration {
+    index: usize,
+}
 
 /// Register the closure the panic hook runs to restore the terminal.
 ///
 /// The closure is stored on the calling thread and only runs when that thread panics, so a panic
-/// on a background thread cannot tear down a TUI that is still drawing on the main thread.
-pub fn register_restore(restore: Box<dyn FnOnce()>) {
-    TERMINAL_RESTORE.with(|slot| slot.replace(Some(restore)));
+/// on a background thread cannot tear down a TUI that is still drawing on the main thread. Nested
+/// TUI sessions stack on their owning thread; drop the returned registration when the session
+/// ends so a later panic in an outer session still restores the outer state.
+pub fn register_restore(restore: Box<dyn FnOnce()>) -> RestoreRegistration {
+    let index = TERMINAL_RESTORE.with(|slot| {
+        let mut slot = slot.borrow_mut();
+        slot.push(Some(restore));
+        slot.len() - 1
+    });
+    RestoreRegistration { index }
+}
+
+impl Drop for RestoreRegistration {
+    fn drop(&mut self) {
+        TERMINAL_RESTORE.with(|slot| {
+            if let Some(entry) = slot.borrow_mut().get_mut(self.index) {
+                *entry = None;
+            }
+        });
+    }
 }
 
 /// Install a panic hook that restores the terminal before reporting the panic.
@@ -32,8 +61,11 @@ pub fn install() {
     INSTALL.call_once(|| {
         let default_hook = std::panic::take_hook();
         std::panic::set_hook(Box::new(move |info| {
-            let restore = TERMINAL_RESTORE
-                .with(|slot| slot.try_borrow_mut().ok().and_then(|mut slot| slot.take()));
+            let restore = TERMINAL_RESTORE.with(|slot| {
+                slot.try_borrow_mut()
+                    .ok()
+                    .and_then(|mut slot| slot.iter_mut().rev().find_map(|entry| entry.take()))
+            });
             if let Some(restore) = restore {
                 // A restore that panics (e.g. I/O against a dying console) must not abort the
                 // process before the panic is reported.
@@ -57,12 +89,42 @@ mod tests {
         install();
         let restored = Arc::new(AtomicBool::new(false));
         let flag = Arc::clone(&restored);
-        register_restore(Box::new(move || {
+        let _registration = register_restore(Box::new(move || {
             flag.store(true, Ordering::Relaxed);
         }));
 
         let result = std::panic::catch_unwind(|| panic!("deliberate panic"));
         assert!(result.is_err());
         assert!(restored.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn ended_session_clears_its_restore_and_keeps_the_outer_one() {
+        install();
+        let inner = Arc::new(AtomicBool::new(false));
+        let outer = Arc::new(AtomicBool::new(false));
+        // An inner session registers and ends normally: its slot must clear,
+        // so a later panic in the still-live outer session pops the outer
+        // closure instead of the stale inner one.
+        let inner_flag = Arc::clone(&inner);
+        let registration = register_restore(Box::new(move || {
+            inner_flag.store(true, Ordering::Relaxed);
+        }));
+        let outer_flag = Arc::clone(&outer);
+        let _outer_registration = register_restore(Box::new(move || {
+            outer_flag.store(true, Ordering::Relaxed);
+        }));
+        drop(registration);
+
+        let result = std::panic::catch_unwind(|| panic!("deliberate panic"));
+        assert!(result.is_err());
+        assert!(
+            !inner.load(Ordering::Relaxed),
+            "inner restore must be cleared"
+        );
+        assert!(
+            outer.load(Ordering::Relaxed),
+            "outer restore must still run"
+        );
     }
 }

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -35,6 +35,9 @@ pub struct Tui {
     /// Shared with the panic hook so a crash restores the terminal exactly as `Drop` would.
     /// The TUI and its panic restore live on the same thread, so the state never leaves it.
     state: Rc<RefCell<TerminalState>>,
+    /// Clears this session's panic-restore slot when the `Tui` ends, so a later
+    /// panic in an outer session still pops the outer closure.
+    _panic_restore: panic::RestoreRegistration,
     #[cfg(windows)]
     previous_frame_had_wide_cells: bool,
     #[cfg(windows)]
@@ -52,31 +55,6 @@ impl Deref for Tui {
 impl DerefMut for Tui {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.terminal
-    }
-}
-
-impl Tui {
-    /// Register the terminal restore with the panic hook, replacing any previous registration.
-    ///
-    /// Called by [`init`] for every new terminal session. The previous session's state was
-    /// already restored (or its `Tui` is still alive and owns its own registration path), so
-    /// replacing the closure is safe.
-    fn register_panic_restore(&self) {
-        let state = Rc::clone(&self.state);
-        panic::register_restore(Box::new(move || {
-            // Restore in place: successful cleanup steps are disarmed, so an
-            // unwinding `Drop` afterwards retries only the steps that failed here.
-            // The state may be mutably borrowed by the frame that is unwinding,
-            // so borrow non-panicking: the `Drop` path is the safety net.
-            let Ok(mut state) = state.try_borrow_mut() else {
-                return;
-            };
-            // A library caller may catch the panic itself and keep using this
-            // `Tui`; mark it so a later `draw` cannot paint onto the restored
-            // normal screen, and a later panic knows cleanup already ran.
-            state.panic_restored = true;
-            let _ = restore_terminal_state(&mut state);
-        }));
     }
 }
 
@@ -152,19 +130,37 @@ pub fn init() -> Result<Tui> {
         Err(error) => return setup.fail(error),
     };
 
+    let state = Rc::new(RefCell::new(setup.commit()));
+    let panic_restore = panic::register_restore(Box::new({
+        let state = Rc::clone(&state);
+        move || {
+            // Restore in place: successful cleanup steps are disarmed, so an
+            // unwinding `Drop` afterwards retries only the steps that failed
+            // here. The state may be mutably borrowed by the frame that is
+            // unwinding, so borrow non-panicking: the `Drop` path is the
+            // safety net.
+            let Ok(mut state) = state.try_borrow_mut() else {
+                return;
+            };
+            // A library caller may catch the panic itself and keep using this
+            // `Tui`; mark it so a later `draw` cannot paint onto the restored
+            // normal screen, and a later panic knows cleanup already ran.
+            state.panic_restored = true;
+            let _ = restore_terminal_state(&mut state);
+        }
+    }));
     let tui = Tui {
         terminal,
         drawing_active: true,
-        state: Rc::new(RefCell::new(setup.commit())),
+        state,
+        _panic_restore: panic_restore,
         #[cfg(windows)]
         previous_frame_had_wide_cells: false,
         #[cfg(windows)]
         synchronized_updates_supported,
     };
-    tui.register_panic_restore();
     Ok(tui)
 }
-
 /// Draw one TUI frame.
 ///
 /// Windows terminals can leave stale trailing cells when an incremental diff replaces CJK or
@@ -190,7 +186,7 @@ where
         let force_full_redraw = resized || terminal.previous_frame_had_wide_cells;
 
         let draw_result = if terminal.synchronized_updates_supported {
-            let update = SynchronizedUpdateGuard::begin()?;
+            let update = SynchronizedUpdateGuard::begin(&terminal.state)?;
             let result = draw_terminal_frame(&mut terminal.terminal, force_full_redraw, render)
                 .context("Failed to draw a Windows terminal frame");
             combine_results(
@@ -368,6 +364,14 @@ fn restore_owned_state(failures: &mut CleanupFailures, state: &mut TerminalState
         // Windows. Keep virtual-terminal output enabled until every such sequence succeeds, so a
         // later Drop retry can still take effect instead of merely writing inert escape bytes.
         if display_commands_restored {
+            // A panic can leave the synchronized-update guard armed; end the update while VT
+            // output is still enabled, before restoring the original mode (which may disable the
+            // processing the end sequence needs).
+            #[cfg(windows)]
+            if state.synchronized_update_active {
+                let _ = execute!(io::stdout(), EndSynchronizedUpdate);
+                state.synchronized_update_active = false;
+            }
             let output_result = modes.restore_output();
             failures.record("restore console output mode", output_result);
         }
@@ -412,6 +416,11 @@ struct TerminalState {
     /// Set when the panic hook already restored the terminal for a `Tui` that
     /// survived the unwind (library callers may catch the panic themselves).
     panic_restored: bool,
+    /// A synchronized update is open on the output; the panic restore ends it
+    /// before restoring the original console mode (which may disable the
+    /// virtual-terminal processing the end sequence needs).
+    #[cfg(windows)]
+    synchronized_update_active: bool,
 }
 
 impl TerminalState {
@@ -881,16 +890,21 @@ fn win32_console_call(operation: &str, succeeded: i32) -> Result<()> {
 #[cfg(windows)]
 struct SynchronizedUpdateGuard {
     active: bool,
+    state: Rc<RefCell<TerminalState>>,
 }
 
 #[cfg(windows)]
 impl SynchronizedUpdateGuard {
-    fn begin() -> Result<Self> {
+    fn begin(state: &Rc<RefCell<TerminalState>>) -> Result<Self> {
         // Arm before writing Begin: an I/O error can occur after bytes have partially reached the
         // terminal, so Drop must still attempt End.
-        let guard = Self { active: true };
+        let guard = Self {
+            active: true,
+            state: Rc::clone(state),
+        };
         execute!(io::stdout(), BeginSynchronizedUpdate)
             .context("Failed to begin synchronized terminal update")?;
+        state.borrow_mut().synchronized_update_active = true;
         Ok(guard)
     }
 
@@ -898,6 +912,7 @@ impl SynchronizedUpdateGuard {
         let result = execute!(io::stdout(), EndSynchronizedUpdate)
             .context("Failed to end synchronized terminal update");
         if result.is_ok() {
+            self.state.borrow_mut().synchronized_update_active = false;
             self.active = false;
         }
         result
@@ -907,10 +922,14 @@ impl SynchronizedUpdateGuard {
 #[cfg(windows)]
 impl Drop for SynchronizedUpdateGuard {
     fn drop(&mut self) {
-        if self.active {
+        // The panic restore ends the update itself and clears the shared flag;
+        // end here only while the update is still open, so the restore's End
+        // is not echoed a second time after VT output has been restored.
+        if self.active && self.state.borrow().synchronized_update_active {
             let _ = execute!(io::stdout(), EndSynchronizedUpdate);
-            self.active = false;
+            self.state.borrow_mut().synchronized_update_active = false;
         }
+        self.active = false;
     }
 }
 

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -12,7 +12,7 @@ use crossterm::{
 use ratatui::{buffer::CellDiffOption, prelude::*};
 use std::io::IsTerminal;
 use std::{
-    cell::RefCell,
+    cell::{Cell, RefCell},
     fmt::Display,
     io::{self, Stdout},
     mem,
@@ -35,6 +35,12 @@ pub struct Tui {
     /// Shared with the panic hook so a crash restores the terminal exactly as `Drop` would.
     /// The TUI and its panic restore live on the same thread, so the state never leaves it.
     state: Rc<RefCell<TerminalState>>,
+    /// Whether a synchronized update is open, shared with the guard and the
+    /// panic restore. A `Cell` (not a field behind the `RefCell`) so cleanup
+    /// paths can read and clear it without a borrow that could panic during
+    /// unwinding.
+    #[cfg(windows)]
+    update_active: Rc<Cell<bool>>,
     /// Clears this session's panic-restore slot when the `Tui` ends, so a later
     /// panic in an outer session still pops the outer closure.
     _panic_restore: panic::RestoreRegistration,
@@ -102,6 +108,10 @@ pub fn init() -> Result<Tui> {
         .modes
         .as_ref()
         .is_some_and(TerminalModes::enable_virtual_terminal_processing);
+    // Shared with the synchronized-update guard and the panic restore so they
+    // can read and clear the open-update flag without borrowing the RefCell.
+    #[cfg(windows)]
+    let update_active = Rc::clone(&setup.state.update_active);
     if let Err(error) = enable_raw_mode().context("Failed to enable terminal raw mode") {
         return setup.fail(error);
     }
@@ -153,6 +163,8 @@ pub fn init() -> Result<Tui> {
         terminal,
         drawing_active: true,
         state,
+        #[cfg(windows)]
+        update_active,
         _panic_restore: panic_restore,
         #[cfg(windows)]
         previous_frame_had_wide_cells: false,
@@ -186,7 +198,7 @@ where
         let force_full_redraw = resized || terminal.previous_frame_had_wide_cells;
 
         let draw_result = if terminal.synchronized_updates_supported {
-            let update = SynchronizedUpdateGuard::begin(&terminal.state)?;
+            let update = SynchronizedUpdateGuard::begin(&terminal.update_active)?;
             let result = draw_terminal_frame(&mut terminal.terminal, force_full_redraw, render)
                 .context("Failed to draw a Windows terminal frame");
             combine_results(
@@ -366,11 +378,11 @@ fn restore_owned_state(failures: &mut CleanupFailures, state: &mut TerminalState
         if display_commands_restored {
             // A panic can leave the synchronized-update guard armed; end the update while VT
             // output is still enabled, before restoring the original mode (which may disable the
-            // processing the end sequence needs).
+            // processing the end sequence needs). The flag is a Cell shared with the guard, so
+            // reading and clearing it cannot borrow the state.
             #[cfg(windows)]
-            if state.synchronized_update_active {
+            if state.update_active.replace(false) {
                 let _ = execute!(io::stdout(), EndSynchronizedUpdate);
-                state.synchronized_update_active = false;
             }
             let output_result = modes.restore_output();
             failures.record("restore console output mode", output_result);
@@ -416,11 +428,11 @@ struct TerminalState {
     /// Set when the panic hook already restored the terminal for a `Tui` that
     /// survived the unwind (library callers may catch the panic themselves).
     panic_restored: bool,
-    /// A synchronized update is open on the output; the panic restore ends it
-    /// before restoring the original console mode (which may disable the
-    /// virtual-terminal processing the end sequence needs).
+    /// Whether a synchronized update is open on the output. Shared with the
+    /// guard behind an `Rc<Cell<bool>>` so cleanup paths can read and clear it
+    /// without a `RefCell` borrow that could panic during unwinding.
     #[cfg(windows)]
-    synchronized_update_active: bool,
+    update_active: Rc<Cell<bool>>,
 }
 
 impl TerminalState {
@@ -890,21 +902,21 @@ fn win32_console_call(operation: &str, succeeded: i32) -> Result<()> {
 #[cfg(windows)]
 struct SynchronizedUpdateGuard {
     active: bool,
-    state: Rc<RefCell<TerminalState>>,
+    update_active: Rc<Cell<bool>>,
 }
 
 #[cfg(windows)]
 impl SynchronizedUpdateGuard {
-    fn begin(state: &Rc<RefCell<TerminalState>>) -> Result<Self> {
+    fn begin(update_active: &Rc<Cell<bool>>) -> Result<Self> {
         // Arm before writing Begin: an I/O error can occur after bytes have partially reached the
         // terminal, so Drop must still attempt End.
         let guard = Self {
             active: true,
-            state: Rc::clone(state),
+            update_active: Rc::clone(update_active),
         };
+        update_active.set(true);
         execute!(io::stdout(), BeginSynchronizedUpdate)
             .context("Failed to begin synchronized terminal update")?;
-        state.borrow_mut().synchronized_update_active = true;
         Ok(guard)
     }
 
@@ -912,7 +924,7 @@ impl SynchronizedUpdateGuard {
         let result = execute!(io::stdout(), EndSynchronizedUpdate)
             .context("Failed to end synchronized terminal update");
         if result.is_ok() {
-            self.state.borrow_mut().synchronized_update_active = false;
+            self.update_active.set(false);
             self.active = false;
         }
         result
@@ -922,12 +934,13 @@ impl SynchronizedUpdateGuard {
 #[cfg(windows)]
 impl Drop for SynchronizedUpdateGuard {
     fn drop(&mut self) {
-        // The panic restore ends the update itself and clears the shared flag;
-        // end here only while the update is still open, so the restore's End
-        // is not echoed a second time after VT output has been restored.
-        if self.active && self.state.borrow().synchronized_update_active {
+        // The panic restore ends the update itself and clears the flag; end
+        // here only while the update is still open so the restore's End is
+        // not echoed a second time after VT output has been restored. The
+        // flag is a Cell, so this cannot borrow or panic during unwinding.
+        if self.active && self.update_active.get() {
             let _ = execute!(io::stdout(), EndSynchronizedUpdate);
-            self.state.borrow_mut().synchronized_update_active = false;
+            self.update_active.set(false);
         }
         self.active = false;
     }

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -12,12 +12,16 @@ use crossterm::{
 use ratatui::{buffer::CellDiffOption, prelude::*};
 use std::io::IsTerminal;
 use std::{
+    cell::RefCell,
     fmt::Display,
     io::{self, Stdout},
     mem,
     ops::{Deref, DerefMut},
+    rc::Rc,
 };
 use unicode_width::UnicodeWidthStr;
+
+use super::panic;
 
 type InnerTui = Terminal<CrosstermBackend<Stdout>>;
 
@@ -28,7 +32,9 @@ type InnerTui = Terminal<CrosstermBackend<Stdout>>;
 pub struct Tui {
     terminal: InnerTui,
     drawing_active: bool,
-    state: TerminalState,
+    /// Shared with the panic hook so a crash restores the terminal exactly as `Drop` would.
+    /// The TUI and its panic restore live on the same thread, so the state never leaves it.
+    state: Rc<RefCell<TerminalState>>,
     #[cfg(windows)]
     previous_frame_had_wide_cells: bool,
     #[cfg(windows)]
@@ -49,10 +55,28 @@ impl DerefMut for Tui {
     }
 }
 
+impl Tui {
+    /// Register the terminal restore with the panic hook, replacing any previous registration.
+    ///
+    /// Called by [`init`] for every new terminal session. The previous session's state was
+    /// already restored (or its `Tui` is still alive and owns its own registration path), so
+    /// replacing the closure is safe.
+    fn register_panic_restore(&self) {
+        let state = Rc::clone(&self.state);
+        panic::register_restore(Box::new(move || {
+            // Restore in place: successful cleanup steps are disarmed, so an unwinding `Drop`
+            // afterwards retries only the steps that failed here.
+            let mut state = state.borrow_mut();
+            let _ = restore_terminal_state(&mut state);
+        }));
+    }
+}
+
 impl Drop for Tui {
     fn drop(&mut self) {
-        if self.state.has_pending_cleanup() {
-            let _ = restore_terminal_state(&mut self.state);
+        let mut state = self.state.borrow_mut();
+        if state.has_pending_cleanup() {
+            let _ = restore_terminal_state(&mut state);
         }
         self.drawing_active = false;
     }
@@ -116,15 +140,17 @@ pub fn init() -> Result<Tui> {
         Err(error) => return setup.fail(error),
     };
 
-    Ok(Tui {
+    let tui = Tui {
         terminal,
         drawing_active: true,
-        state: setup.commit(),
+        state: Rc::new(RefCell::new(setup.commit())),
         #[cfg(windows)]
         previous_frame_had_wide_cells: false,
         #[cfg(windows)]
         synchronized_updates_supported,
-    })
+    };
+    tui.register_panic_restore();
+    Ok(tui)
 }
 
 /// Draw one TUI frame.
@@ -245,7 +271,8 @@ fn apply_full_redraw_policy(buffer: &mut Buffer) {
 /// cleanup is pending because crossterm can write its cached raw mode during a retry.
 pub fn restore(terminal: &mut Tui) -> Result<()> {
     terminal.drawing_active = false;
-    restore_terminal_state(&mut terminal.state)
+    let mut state = terminal.state.borrow_mut();
+    restore_terminal_state(&mut state)
 }
 
 /// Restore a terminal and preserve both the operation error and a cleanup error, if both occur.

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -10,9 +10,11 @@ use crossterm::{
     terminal::{enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ratatui::{buffer::CellDiffOption, prelude::*};
+#[cfg(windows)]
+use std::cell::Cell;
 use std::io::IsTerminal;
 use std::{
-    cell::{Cell, RefCell},
+    cell::RefCell,
     fmt::Display,
     io::{self, Stdout},
     mem,

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -378,16 +378,25 @@ fn restore_owned_state(failures: &mut CleanupFailures, state: &mut TerminalState
         // Windows. Keep virtual-terminal output enabled until every such sequence succeeds, so a
         // later Drop retry can still take effect instead of merely writing inert escape bytes.
         if display_commands_restored {
-            // A panic can leave the synchronized-update guard armed; end the update while VT
-            // output is still enabled, before restoring the original mode (which may disable the
-            // processing the end sequence needs). The flag is a Cell shared with the guard, so
-            // reading and clearing it cannot borrow the state.
             #[cfg(windows)]
-            if state.update_active.replace(false) {
-                let _ = execute!(io::stdout(), EndSynchronizedUpdate);
+            let update_ended = if state.update_active.get() {
+                let result = execute!(io::stdout(), EndSynchronizedUpdate);
+                let succeeded = result.is_ok();
+                failures.record("end synchronized terminal update", result);
+                if succeeded {
+                    state.update_active.set(false);
+                }
+                succeeded
+            } else {
+                true
+            };
+            #[cfg(not(windows))]
+            let update_ended = true;
+
+            if update_ended {
+                let output_result = modes.restore_output();
+                failures.record("restore console output mode", output_result);
             }
-            let output_result = modes.restore_output();
-            failures.record("restore console output mode", output_result);
         }
 
         if modes.is_restored() {
@@ -439,12 +448,18 @@ struct TerminalState {
 
 impl TerminalState {
     fn has_pending_cleanup(&self) -> bool {
+        #[cfg(windows)]
+        let update_pending = self.update_active.get();
+        #[cfg(not(windows))]
+        let update_pending = false;
+
         self.mouse_capture
             || self.alternate_screen
             || self.cursor_restore_pending
             || self.modes.is_some()
             || self.code_pages.is_some()
             || self.console_input.is_some()
+            || update_pending
     }
 }
 
@@ -940,8 +955,10 @@ impl Drop for SynchronizedUpdateGuard {
         // here only while the update is still open so the restore's End is
         // not echoed a second time after VT output has been restored. The
         // flag is a Cell, so this cannot borrow or panic during unwinding.
-        if self.active && self.update_active.get() {
-            let _ = execute!(io::stdout(), EndSynchronizedUpdate);
+        if self.active
+            && self.update_active.get()
+            && execute!(io::stdout(), EndSynchronizedUpdate).is_ok()
+        {
             self.update_active.set(false);
         }
         self.active = false;

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -64,9 +64,17 @@ impl Tui {
     fn register_panic_restore(&self) {
         let state = Rc::clone(&self.state);
         panic::register_restore(Box::new(move || {
-            // Restore in place: successful cleanup steps are disarmed, so an unwinding `Drop`
-            // afterwards retries only the steps that failed here.
-            let mut state = state.borrow_mut();
+            // Restore in place: successful cleanup steps are disarmed, so an
+            // unwinding `Drop` afterwards retries only the steps that failed here.
+            // The state may be mutably borrowed by the frame that is unwinding,
+            // so borrow non-panicking: the `Drop` path is the safety net.
+            let Ok(mut state) = state.try_borrow_mut() else {
+                return;
+            };
+            // A library caller may catch the panic itself and keep using this
+            // `Tui`; mark it so a later `draw` cannot paint onto the restored
+            // normal screen, and a later panic knows cleanup already ran.
+            state.panic_restored = true;
             let _ = restore_terminal_state(&mut state);
         }));
     }
@@ -168,6 +176,9 @@ where
 {
     if !terminal.drawing_active {
         bail!("Cannot draw while the terminal session is suspended");
+    }
+    if terminal.state.borrow().panic_restored {
+        bail!("Cannot draw after the terminal was restored by a panic");
     }
 
     #[cfg(windows)]
@@ -398,6 +409,9 @@ struct TerminalState {
     modes: Option<TerminalModes>,
     code_pages: Option<ConsoleCodePages>,
     console_input: Option<ConsoleInputHandle>,
+    /// Set when the panic hook already restored the terminal for a `Tui` that
+    /// survived the unwind (library callers may catch the panic themselves).
+    panic_restored: bool,
 }
 
 impl TerminalState {

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -84,6 +84,10 @@ impl Drop for Tui {
 
 /// Initialize the terminal for TUI rendering.
 pub fn init() -> Result<Tui> {
+    // The panic hook that restores the terminal is normally installed by `cli_main`; library
+    // callers (e.g. `commands::browse::run_with_sessions`) never pass through it, so install
+    // here too. `install` is idempotent, and `register_panic_restore` below arms the closure.
+    panic::install();
     ensure_tui_stdout()?;
 
     let mut setup = TerminalSetup::default();


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal recovery when the application encounters a panic or unexpected failure.
  * Ensured active terminal updates are properly closed and console settings are restored.
  * Prevented further screen updates after terminal state has been restored.
  * Improved cleanup for nested terminal sessions and repeated restoration attempts.
  * Reduced the risk of leaving the terminal in an unusable state after unexpected interruptions.
  * Preserved existing panic handling while safely completing terminal cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->