### PR TITLE
perf(tui): skip redraw when idle and block on input

### DIFF
--- a/src/commands/browse/help.rs
+++ b/src/commands/browse/help.rs
@@ -253,8 +253,7 @@ pub(super) fn apply_workspace_help_action(
                 *content_mode,
                 content_at,
             );
-            let frame =
-                ContentIoFrame::build(layout.content, &io, *content_mode, *content_io_focus);
+            let frame = ContentIoFrame::build(layout.content, io, *content_mode, *content_io_focus);
             let active = frame.active(*content_io_focus, content_scrolls);
             enter_visual_select_mode(
                 visual_select_mode,

--- a/src/commands/browse/load.rs
+++ b/src/commands/browse/load.rs
@@ -292,6 +292,15 @@ impl SourceLoadPump {
         }
     }
 
+    /// True while at least one body-hydration job is still running.
+    ///
+    /// `SessionColumn::is_fetching` uses this to keep the event loop on its short poll while
+    /// bodies stream in: metadata may already be `Ready`, but a copy action against a not-yet
+    /// hydrated body would return stale or empty content.
+    pub fn has_inflight_bodies(&self) -> bool {
+        !self.body_inflight.is_empty()
+    }
+
     fn spawn_meta(&mut self, idx: usize, source: &WorkspaceSource, gen: u64, budget: usize) {
         let budget = budget.clamp(FETCH_FLOOR, FETCH_CEILING);
         let selector = source.selector();
@@ -560,7 +569,7 @@ impl Pane for SessionColumn {
     }
 
     fn is_fetching(&self) -> bool {
-        self.states.iter().any(SourceLoadState::is_fetching)
+        self.states.iter().any(SourceLoadState::is_fetching) || self.pump.has_inflight_bodies()
     }
 }
 

--- a/src/commands/browse/panes.rs
+++ b/src/commands/browse/panes.rs
@@ -412,10 +412,10 @@ impl ContentPane {
             ctx.mode,
             ctx.target,
         );
-        let frame = ContentIoFrame::build(ctx.area, &texts, ctx.mode, ctx.io_focus);
+        let frame = ContentIoFrame::build(ctx.area, texts, ctx.mode, ctx.io_focus);
         self.input_lines = frame.input_lines;
         self.output_lines = frame.output_lines;
-        texts
+        frame.texts
     }
 }
 

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -13,8 +13,8 @@ use crate::tui::terminal::read_interaction;
 use crate::tui::workspace::{
     help_action_for_key, panel_inner_rows, render_workspace, search_match_half, selected_index,
     workspace_help_entries, workspace_hit_test, workspace_layout, ContentIoFocus, ContentIoFrame,
-    ContentScrolls, WorkspaceFocus, WorkspacePickedContent, WorkspaceSearchView, WorkspaceSession,
-    WorkspaceSource, WorkspaceView,
+    ContentScrolls, WorkspaceDialogue, WorkspaceFocus, WorkspacePickedContent, WorkspaceSearchView,
+    WorkspaceSession, WorkspaceSource, WorkspaceView,
 };
 
 use super::content::{
@@ -93,6 +93,14 @@ pub(crate) fn run(
     let mut fullscreen = None;
     let mut visual_select_mode = None;
     let mut loading_tick = 0u8;
+    // Redraw when an event changed state, a background load landed, or the
+    // loading spinner ticked. When idle with no load in flight, block on
+    // input instead of redrawing the whole frame at a fixed rate.
+    let mut redraw = true;
+    // Last-rendered content values, reused by event handlers on iterations
+    // that skip redrawing (idle with no state change).
+    let mut dialogues: Vec<WorkspaceDialogue> = Vec::new();
+    let mut content_frame = ContentIoFrame::default();
 
     loop {
         // ── Unified pane poll/ensure ───────────────────────────────────────
@@ -100,6 +108,7 @@ pub(crate) fn run(
         if sessions_pane.poll() {
             sessions_dirty = true;
             search_dirty = true;
+            redraw = true;
         }
         if sessions_dirty {
             all_sessions = sessions_pane.collect(&selected_sources);
@@ -267,11 +276,6 @@ pub(crate) fn run(
         if pending_match.is_some() {
             range_anchor = None;
         }
-
-        // List: title borrows. Content/copy: materialize (body only for focus∪select).
-        let dialogue_titles: Vec<&str> = dialogue_pane.titles().collect();
-        let dialogues = dialogue_pane.materialize(&selected_dialogues, dialogue_idx);
-
         let active_content_at = active_workspace_content_at(
             search_has_query,
             &search_output,
@@ -280,94 +284,115 @@ pub(crate) fn run(
             &selected_dialogues,
             dialogue_idx,
         );
-        let io_texts = content_pane.ensure(ContentCtx {
-            dialogues: &dialogues,
-            selected_dialogues: &selected_dialogues,
-            highlighted_idx: dialogue_idx,
-            mode: content_mode,
-            target: active_content_at,
-            area: layout.content,
-            io_focus: content_io_focus,
-        });
-        // One frame geometry/metrics for handlers below (same texts/layout as ensure).
-        let content_frame =
-            ContentIoFrame::build(layout.content, &io_texts, content_mode, content_io_focus);
-        content_scrolls.clamp_to(content_frame.input_lines, content_frame.output_lines);
-        if let Some(matched) = pending_match {
-            let input = dialogues
-                .get(dialogue_idx)
-                .and_then(|dialogue| dialogue.record.as_ref())
-                .and_then(|record| record.part_for_at(matched.at))
-                .is_none_or(|part| part.kind().is_input());
-            let (half, scroll) = search_match_half(input, matched.matched_line);
-            content_io_focus = half;
-            let total = content_frame.line_count(half);
-            content_scrolls.set(half, scroll.min(total.saturating_sub(1)));
-            search_apply_pending = false;
-        }
 
-        let source_markers = sessions_pane.markers();
-        terminal.draw(|frame| {
-            render_workspace(
-                frame,
-                WorkspaceView {
-                    sources: &sources,
-                    selected_sources: &selected_sources,
-                    source_markers: &source_markers,
-                    loading_tick,
-                    source_state: &source_state,
-                    sessions: &sessions,
-                    selected_sessions: &selected_sessions,
-                    session_state: &session_state,
-                    dialogue_titles: &dialogue_titles,
+        if redraw {
+            redraw = false;
+            // List: title borrows. Content/copy: materialize (body only for focus∪select).
+            let dialogue_titles: Vec<&str> = dialogue_pane.titles().collect();
+            dialogues = dialogue_pane.materialize(&selected_dialogues, dialogue_idx);
+
+            content_frame = ContentIoFrame::build(
+                layout.content,
+                content_pane.ensure(ContentCtx {
                     dialogues: &dialogues,
-                    dialogue_state: &dialogue_state,
                     selected_dialogues: &selected_dialogues,
-                    range_anchor,
-                    focus,
-                    content_scrolls,
-                    content_io_focus,
-                    content_mode,
-                    content_at: active_content_at,
-                    show_help,
-                    help_state: &help_state,
-                    search: (show_search || search_has_query).then_some(WorkspaceSearchView {
-                        query: &search_query,
-                        scope: workspace_search_scope(&search_query),
-                        result_count: sessions.len(),
-                        current_match: (!search_output.matches.is_empty()).then_some(search_cursor),
-                        match_count: search_output.matches.len(),
-                        current_target: search_output
-                            .matches
-                            .get(search_cursor)
-                            .and_then(|matched| {
-                                workspace_search_target_ref(&sessions, matched, &|s| {
-                                    sessions_pane.body_for(s)
+                    highlighted_idx: dialogue_idx,
+                    mode: content_mode,
+                    target: active_content_at,
+                    area: layout.content,
+                    io_focus: content_io_focus,
+                }),
+                content_mode,
+                content_io_focus,
+            );
+            content_scrolls.clamp_to(content_frame.input_lines, content_frame.output_lines);
+            if let Some(matched) = pending_match {
+                let input = dialogues
+                    .get(dialogue_idx)
+                    .and_then(|dialogue| dialogue.record.as_ref())
+                    .and_then(|record| record.part_for_at(matched.at))
+                    .is_none_or(|part| part.kind().is_input());
+                let (half, scroll) = search_match_half(input, matched.matched_line);
+                content_io_focus = half;
+                let total = content_frame.line_count(half);
+                content_scrolls.set(half, scroll.min(total.saturating_sub(1)));
+                search_apply_pending = false;
+            }
+
+            let source_markers = sessions_pane.markers();
+            terminal.draw(|frame| {
+                render_workspace(
+                    frame,
+                    WorkspaceView {
+                        sources: &sources,
+                        selected_sources: &selected_sources,
+                        source_markers: &source_markers,
+                        loading_tick,
+                        source_state: &source_state,
+                        sessions: &sessions,
+                        selected_sessions: &selected_sessions,
+                        session_state: &session_state,
+                        dialogue_titles: &dialogue_titles,
+                        dialogues: &dialogues,
+                        dialogue_state: &dialogue_state,
+                        selected_dialogues: &selected_dialogues,
+                        range_anchor,
+                        focus,
+                        content_scrolls,
+                        content_io_focus,
+                        content_mode,
+                        content_at: active_content_at,
+                        show_help,
+                        help_state: &help_state,
+                        search: (show_search || search_has_query).then_some(WorkspaceSearchView {
+                            query: &search_query,
+                            scope: workspace_search_scope(&search_query),
+                            result_count: sessions.len(),
+                            current_match: (!search_output.matches.is_empty())
+                                .then_some(search_cursor),
+                            match_count: search_output.matches.len(),
+                            current_target: search_output
+                                .matches
+                                .get(search_cursor)
+                                .and_then(|matched| {
+                                    workspace_search_target_ref(&sessions, matched, &|s| {
+                                        sessions_pane.body_for(s)
+                                    })
                                 })
-                            })
-                            .map(|work_ref| work_ref.to_string()),
-                        input_open: show_search,
-                    }),
-                    line_filter_input_open,
-                    line_filter: (!line_filter.is_empty()).then_some(line_filter.as_str()),
-                    line_filter_error: line_filter_error.as_deref(),
-                    fullscreen,
-                    content_selection: visual_select_mode
-                        .map(|mode: VisualSelectMode| mode.selection),
-                },
-            )
-        })?;
-        if visual_select_mode.is_some() {
-            terminal.show_cursor()?;
+                                .map(|work_ref| work_ref.to_string()),
+                            input_open: show_search,
+                        }),
+                        line_filter_input_open,
+                        line_filter: (!line_filter.is_empty()).then_some(line_filter.as_str()),
+                        line_filter_error: line_filter_error.as_deref(),
+                        fullscreen,
+                        content_selection: visual_select_mode
+                            .map(|mode: VisualSelectMode| mode.selection),
+                    },
+                )
+            })?;
+            if visual_select_mode.is_some() {
+                terminal.show_cursor()?;
+            }
         }
 
-        // Poll so background loads can repaint without waiting for a key.
-        if !event::poll(std::time::Duration::from_millis(100))? {
+        // Wait for input. While a load is in flight, keep a short poll so the
+        // spinner animates and results repaint without a keypress. When
+        // nothing is loading, block until an event arrives instead of
+        // redrawing the whole frame at a fixed rate.
+        let poll_timeout = if sessions_pane.is_fetching() {
+            std::time::Duration::from_millis(100)
+        } else {
+            std::time::Duration::from_secs(3600)
+        };
+        if !event::poll(poll_timeout)? {
             if sessions_pane.is_fetching() {
                 loading_tick = loading_tick.wrapping_add(1);
+                redraw = true;
             }
             continue;
         }
+        redraw = true;
         match read_interaction()? {
             Event::Key(key) => {
                 if key.kind != KeyEventKind::Press {

--- a/src/tui/content/io.rs
+++ b/src/tui/content/io.rs
@@ -154,22 +154,23 @@ pub(crate) struct ActiveHalf<'a> {
     pub(crate) scroll: &'a mut usize,
 }
 
-/// Borrowed view of both halves for one frame (texts computed once).
-pub(crate) struct ContentIoFrame<'a> {
-    pub(crate) texts: &'a ContentIoTexts,
+/// Owned view of both halves for one frame (texts computed once).
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ContentIoFrame {
+    pub(crate) texts: ContentIoTexts,
     pub(crate) areas: ContentIoAreas,
     pub(crate) input_lines: usize,
     pub(crate) output_lines: usize,
 }
 
-impl<'a> ContentIoFrame<'a> {
+impl ContentIoFrame {
     pub(crate) fn build(
         area: Rect,
-        texts: &'a ContentIoTexts,
+        texts: ContentIoTexts,
         mode: ContentViewMode,
         focus: ContentIoFocus,
     ) -> Self {
-        let areas = content_io_layout(area, texts, mode, focus);
+        let areas = content_io_layout(area, &texts, mode, focus);
         let input_lines =
             content_view_line_count(areas.input, texts.display(ContentIoFocus::Input), mode).max(1);
         let output_lines =
@@ -190,7 +191,7 @@ impl<'a> ContentIoFrame<'a> {
         }
     }
 
-    pub(crate) fn active(
+    pub(crate) fn active<'a>(
         &'a self,
         half: ContentIoFocus,
         scrolls: &'a mut ContentScrolls,

--- a/src/tui/workspace/render.rs
+++ b/src/tui/workspace/render.rs
@@ -92,7 +92,7 @@ pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
     );
     let frame_io = ContentIoFrame::build(
         layout.content,
-        &io_texts,
+        io_texts,
         view.content_mode,
         view.content_io_focus,
     );
@@ -121,7 +121,7 @@ pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
                 ),
                 content_active && view.content_io_focus == half,
             ),
-            io_texts.display_owned(half),
+            frame_io.texts.display_owned(half),
             view.content_scrolls.get(half),
             view.content_mode,
             content_selection_for_half(view.content_selection, view.content_io_focus, half),


### PR DESCRIPTION
The picker redrew the whole frame at a fixed 10 Hz even when nothing
changed: every event::poll(100ms) timeout re-ran pane ensures, content
layout, and terminal.draw. A redraw flag now gates the expensive render
path (materialize, IO texts, layout, draw), so an idle picker with no
load in flight blocks on input instead of burning CPU.

ContentIoFrame now owns its texts, so the last-rendered frame and
dialogue bodies stay available to event handlers on skipped-redraw
iterations. The 100ms poll is kept only while a background load is in
flight, to drive the spinner and repaint results.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>