### PR TITLE
perf(tui): dedupe per-frame content layout work

### DIFF
--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -291,6 +291,21 @@ pub(crate) fn run(
             let dialogue_titles: Vec<&str> = dialogue_pane.titles().collect();
             dialogues = dialogue_pane.materialize(&selected_dialogues, dialogue_idx);
 
+            // Resolve where the pending search match lands *before* building the
+            // frame: the frame weights geometry toward the focused half, so a
+            // focus switch must be visible to the build or the newly active pane
+            // keeps the smaller height until the next redraw.
+            let pending_half = pending_match.as_ref().map(|matched| {
+                let input = dialogues
+                    .get(dialogue_idx)
+                    .and_then(|dialogue| dialogue.record.as_ref())
+                    .and_then(|record| record.part_for_at(matched.at))
+                    .is_none_or(|part| part.kind().is_input());
+                search_match_half(input, matched.matched_line)
+            });
+            if let Some((half, _)) = pending_half {
+                content_io_focus = half;
+            }
             content_frame = ContentIoFrame::build(
                 layout.content,
                 content_pane.ensure(ContentCtx {
@@ -306,14 +321,7 @@ pub(crate) fn run(
                 content_io_focus,
             );
             content_scrolls.clamp_to(content_frame.input_lines, content_frame.output_lines);
-            if let Some(matched) = pending_match {
-                let input = dialogues
-                    .get(dialogue_idx)
-                    .and_then(|dialogue| dialogue.record.as_ref())
-                    .and_then(|record| record.part_for_at(matched.at))
-                    .is_none_or(|part| part.kind().is_input());
-                let (half, scroll) = search_match_half(input, matched.matched_line);
-                content_io_focus = half;
+            if let Some((half, scroll)) = pending_half {
                 let total = content_frame.line_count(half);
                 content_scrolls.set(half, scroll.min(total.saturating_sub(1)));
                 search_apply_pending = false;

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -368,6 +368,7 @@ pub(crate) fn run(
                         fullscreen,
                         content_selection: visual_select_mode
                             .map(|mode: VisualSelectMode| mode.selection),
+                        content_frame: &content_frame,
                     },
                 )
             })?;

--- a/src/tui/content/io.rs
+++ b/src/tui/content/io.rs
@@ -48,10 +48,6 @@ impl ContentIoTexts {
             raw
         }
     }
-
-    pub(crate) fn display_owned(&self, half: ContentIoFocus) -> String {
-        self.display(half).to_string()
-    }
 }
 
 /// Which content half keyboard / selection targets.

--- a/src/tui/content/view.rs
+++ b/src/tui/content/view.rs
@@ -86,17 +86,19 @@ pub(crate) fn render_content_view(
         return;
     }
 
-    let (total_lines, chunks) = content_layout(area, view.text, view.mode);
+    // Lay out the whole document once; the line count drives the gutter and
+    // the visible window is a slice of the same layout.
+    let (lines, chunks) = content_layout(area, view.text, view.mode);
 
     let visible_height = inner.height as usize;
+    let total_lines = lines.len().max(1);
     let scroll = view.scroll.min(total_lines.saturating_sub(1));
-    let visible = visible_content_lines(
-        view.text,
-        scroll,
-        visible_height,
-        chunks[2].width as usize,
-        view.mode,
-    );
+    let visible: Vec<ContentLine> = lines
+        .iter()
+        .skip(scroll)
+        .take(visible_height)
+        .cloned()
+        .collect();
     frame.render_widget(
         Paragraph::new(line_number_lines(total_lines, scroll, &visible))
             .alignment(Alignment::Right),
@@ -146,7 +148,7 @@ pub(crate) fn content_link_at(
         return None;
     }
 
-    let (total_lines, chunks) = content_layout(area, text, mode);
+    let (lines, chunks) = content_layout(area, text, mode);
     let content_area = chunks[2];
     if column < content_area.x
         || column >= content_area.x.saturating_add(content_area.width)
@@ -156,15 +158,8 @@ pub(crate) fn content_link_at(
         return None;
     }
 
-    let scroll = scroll.min(total_lines.saturating_sub(1));
-    let visible = visible_content_lines(
-        text,
-        scroll,
-        content_area.height as usize,
-        content_area.width as usize,
-        mode,
-    );
-    let line = visible.get((row - content_area.y) as usize)?;
+    let scroll = scroll.min(lines.len().saturating_sub(1));
+    let line = lines.get(scroll.saturating_add((row - content_area.y) as usize))?;
     let hit_col = (column - content_area.x) as usize;
     line.links
         .iter()
@@ -344,12 +339,15 @@ pub(crate) fn content_view_line_count(area: Rect, text: &str, mode: ContentViewM
     if inner.width == 0 || inner.height == 0 {
         return 1;
     }
-    content_layout_metrics(inner.width, text, mode).0
+    content_layout_lines_metrics(inner.width, text, mode)
+        .0
+        .len()
+        .max(1)
 }
 
-fn content_layout(area: Rect, text: &str, mode: ContentViewMode) -> (usize, Rc<[Rect]>) {
+fn content_layout(area: Rect, text: &str, mode: ContentViewMode) -> (Vec<ContentLine>, Rc<[Rect]>) {
     let inner = panel_block(&Panel::new("", "", false)).inner(area);
-    let (total_lines, gutter_width) = content_layout_metrics(inner.width, text, mode);
+    let (lines, gutter_width) = content_layout_lines_metrics(inner.width, text, mode);
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
@@ -358,9 +356,10 @@ fn content_layout(area: Rect, text: &str, mode: ContentViewMode) -> (usize, Rc<[
             Constraint::Min(1),
         ])
         .split(inner);
-    (total_lines, chunks)
+    (lines, chunks)
 }
 
+#[cfg(test)]
 fn visible_content_lines(
     text: &str,
     scroll: usize,
@@ -411,17 +410,22 @@ fn all_content_lines(text: &str, width: usize, mode: ContentViewMode) -> Vec<Con
         .collect()
 }
 
-fn display_line_count(text: &str, mode: ContentViewMode, width: usize) -> usize {
-    all_content_lines(text, width, mode).len().max(1)
-}
-
-fn content_layout_metrics(inner_width: u16, text: &str, mode: ContentViewMode) -> (usize, u16) {
+/// Lay out the document and converge the gutter width (digit count of the
+/// line count) against the wrap width. The final layout is returned so the
+/// caller's metrics and its visible window share one markdown + wrap pass.
+fn content_layout_lines_metrics(
+    inner_width: u16,
+    text: &str,
+    mode: ContentViewMode,
+) -> (Vec<ContentLine>, u16) {
     let mut total_lines = line_count(text);
     let mut gutter_width = line_number_width(total_lines).saturating_add(1);
+    let mut lines = Vec::new();
 
     for _ in 0..4 {
         let content_width = inner_width.saturating_sub(gutter_width.saturating_add(1)) as usize;
-        let next_total_lines = display_line_count(text, mode, content_width);
+        lines = all_content_lines(text, content_width, mode);
+        let next_total_lines = lines.len().max(1);
         let next_gutter_width = line_number_width(next_total_lines).saturating_add(1);
         if next_total_lines == total_lines && next_gutter_width == gutter_width {
             break;
@@ -430,7 +434,7 @@ fn content_layout_metrics(inner_width: u16, text: &str, mode: ContentViewMode) -
         gutter_width = next_gutter_width;
     }
 
-    (total_lines, gutter_width)
+    (lines, gutter_width)
 }
 
 fn content_lines(
@@ -1481,5 +1485,39 @@ mod tests {
         let backend = terminal.backend();
         assert!(backend_row(backend, 1).contains("1|alpha"));
         assert!(backend_row(backend, 2).contains("2|beta"));
+    }
+
+    #[test]
+    fn content_layout_single_pass_matches_metrics_and_fits_width() {
+        let text = "line one\nline two\n| a | b |\n| --- | --- |\n| 1 | 2 |\n\n```rust\nfn main() {}\n```\n";
+        let area = Rect::new(0, 0, 60, 20);
+
+        let (lines, chunks) = super::content_layout(area, text, ContentViewMode::Reading);
+        assert_eq!(chunks.len(), 3);
+        let inner_width = area.width.saturating_sub(2) as usize; // panel borders
+        let column_widths = chunks.iter().map(|c| c.width as usize).sum::<usize>();
+        assert_eq!(column_widths, inner_width);
+
+        // Metrics (used by ContentIoFrame) and the layout used for painting
+        // agree on the total line count — one markdown + wrap pass.
+        let metrics = super::content_view_line_count(area, text, ContentViewMode::Reading);
+        assert_eq!(metrics, lines.len().max(1));
+        assert!(!lines.is_empty());
+
+        // Every wrapped line fits the content column.
+        for line in &lines {
+            let joined: String = line
+                .line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect();
+            let width = UnicodeWidthStr::width(joined.as_str());
+            assert!(
+                width <= chunks[2].width as usize,
+                "line {width} exceeds content width {}",
+                chunks[2].width
+            );
+        }
     }
 }

--- a/src/tui/content/view.rs
+++ b/src/tui/content/view.rs
@@ -420,21 +420,25 @@ fn content_layout_lines_metrics(
 ) -> (Vec<ContentLine>, u16) {
     let mut total_lines = line_count(text);
     let mut gutter_width = line_number_width(total_lines).saturating_add(1);
-    let mut lines = Vec::new();
 
     for _ in 0..4 {
         let content_width = inner_width.saturating_sub(gutter_width.saturating_add(1)) as usize;
-        lines = all_content_lines(text, content_width, mode);
+        let lines = all_content_lines(text, content_width, mode);
         let next_total_lines = lines.len().max(1);
         let next_gutter_width = line_number_width(next_total_lines).saturating_add(1);
         if next_total_lines == total_lines && next_gutter_width == gutter_width {
-            break;
+            return (lines, gutter_width);
         }
         total_lines = next_total_lines;
         gutter_width = next_gutter_width;
     }
 
-    (lines, gutter_width)
+    // Non-convergent narrow panes (the gutter width oscillates against the
+    // wrap width): recompute the lines for the final gutter so content and
+    // gutter stay consistent — otherwise the last pass may have run at a
+    // different width and the layout can drop the content entirely.
+    let content_width = inner_width.saturating_sub(gutter_width.saturating_add(1)) as usize;
+    (all_content_lines(text, content_width, mode), gutter_width)
 }
 
 fn content_lines(
@@ -1338,6 +1342,19 @@ mod tests {
             ),
             2
         );
+    }
+
+    #[test]
+    fn oscillating_gutter_recomputes_lines_for_the_final_width() {
+        // inner_width == 4 makes the gutter width oscillate between 2 and 3
+        // for a ten-character unbroken line (content widths 1 and 0). The
+        // layout must return lines generated at the final gutter width
+        // instead of the single blank line produced at width 0.
+        let (lines, gutter_width) =
+            super::content_layout_lines_metrics(4, "0123456789", ContentViewMode::Reading);
+        assert_eq!(gutter_width, 2);
+        assert_eq!(lines.len(), 10, "one character per wrapped row");
+        assert!(!lines[0].line.spans.is_empty(), "content must not vanish");
     }
 
     #[test]

--- a/src/tui/workspace/model.rs
+++ b/src/tui/workspace/model.rs
@@ -7,7 +7,7 @@ use sivtr_core::record::{WorkAt, WorkRecord, WorkRef};
 use std::time::SystemTime;
 
 use crate::commands::select::CommandSelection;
-use crate::tui::content::io::{ContentIoFocus, ContentIoTexts, ContentScrolls};
+use crate::tui::content::io::{ContentIoFocus, ContentIoFrame, ContentIoTexts, ContentScrolls};
 use crate::tui::content::text::{content_io_from_record, structured_part_text};
 use crate::tui::content::view::{ContentSelection, ContentViewMode};
 use crate::tui::search::WorkspaceSearchScope;
@@ -392,6 +392,9 @@ pub(crate) struct WorkspaceView<'a> {
     pub(crate) line_filter_error: Option<&'a str>,
     pub(crate) fullscreen: Option<WorkspaceFocus>,
     pub(crate) content_selection: Option<ContentSelection>,
+    /// Dual IO layout + display texts, computed once per redraw by the picker
+    /// and shared with the renderer (no per-frame duplicate layout).
+    pub(crate) content_frame: &'a ContentIoFrame,
 }
 
 pub(crate) struct WorkspaceSearchView<'a> {

--- a/src/tui/workspace/render.rs
+++ b/src/tui/workspace/render.rs
@@ -6,8 +6,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Clear, ListItem, ListState, Paragraph};
 use regex::Regex;
 
-use crate::tui::content::io::{ContentIoFocus, ContentIoFrame};
-use crate::tui::content::text::workspace_content_io_texts;
+use crate::tui::content::io::ContentIoFocus;
 use crate::tui::content::view::{
     content_cursor_position, highlight_spans, render_content_view, ContentSelection, ContentView,
     ContentViewMode,
@@ -83,19 +82,9 @@ pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
         view.focus == WorkspaceFocus::Dialogues,
     );
 
-    let io_texts = workspace_content_io_texts(
-        view.dialogues,
-        view.selected_dialogues,
-        dialogue_idx,
-        view.content_mode,
-        view.content_at,
-    );
-    let frame_io = ContentIoFrame::build(
-        layout.content,
-        io_texts,
-        view.content_mode,
-        view.content_io_focus,
-    );
+    // Dual IO layout + display texts were computed once by the picker for
+    // this redraw; reuse them instead of laying the content out a second time.
+    let frame_io = view.content_frame;
     let content_active = view.focus == WorkspaceFocus::Content;
     let content_search = view
         .search
@@ -121,7 +110,7 @@ pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
                 ),
                 content_active && view.content_io_focus == half,
             ),
-            frame_io.texts.display_owned(half),
+            frame_io.texts.display(half),
             view.content_scrolls.get(half),
             view.content_mode,
             content_selection_for_half(view.content_selection, view.content_io_focus, half),
@@ -816,7 +805,7 @@ fn render_content_panel(
     frame: &mut Frame,
     area: Rect,
     panel: Panel,
-    text: String,
+    text: &str,
     scroll: usize,
     mode: ContentViewMode,
     selection: Option<ContentSelection>,
@@ -827,7 +816,7 @@ fn render_content_panel(
         area,
         panel,
         ContentView {
-            text: &text,
+            text,
             scroll,
             search_regex,
             mode,


### PR DESCRIPTION
The renderer recomputed the dual IO texts and full content layout a
second time inside terminal.draw, and each content pane laid the whole
document out once for metrics and again for the visible window.

Now ContentIoFrame is built once per redraw by the picker and passed to
the renderer via WorkspaceView, and content_layout returns the wrapped
lines so metrics, the gutter, and the visible slice share a single
markdown + wrap pass. Hit-testing slices the same layout instead of
re-parsing the document.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>