### PR TITLE
feat(tui): enable bracketed paste for text inputs

### DIFF
--- a/src/commands/browse/content.rs
+++ b/src/commands/browse/content.rs
@@ -181,6 +181,26 @@ pub(super) fn handle_line_filter_key(
     }
 }
 
+/// Apply a bracketed paste to the line filter with the same character policy
+/// as typed input (digits, `:`, `,`). Clipboard content is often copied with a
+/// trailing newline or other stray characters; appending it verbatim would make
+/// the later `filter_lines_by_spec` parse fail and exit the picker. Matching the
+/// typed path, the error is cleared once usable characters land.
+pub(super) fn handle_line_filter_paste(
+    text: &str,
+    line_filter: &mut String,
+    line_filter_error: &mut Option<String>,
+) {
+    let filtered: String = text
+        .chars()
+        .filter(|ch| matches!(ch, '0'..='9' | ':' | ','))
+        .collect();
+    if !filtered.is_empty() {
+        line_filter.push_str(&filtered);
+        *line_filter_error = None;
+    }
+}
+
 pub(super) fn apply_dialogue_range_selection(
     range_anchor: &mut Option<usize>,
     selected_dialogues: &mut [bool],

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -18,7 +18,7 @@ use crate::tui::workspace::{
 };
 
 use super::content::{
-    active_workspace_content_at, handle_line_filter_key, line_filter_spec,
+    active_workspace_content_at, handle_line_filter_key, handle_line_filter_paste, line_filter_spec,
     workspace_search_target_ref,
 };
 use super::help::{apply_workspace_help_action, set_focus, HelpDispatch};
@@ -437,7 +437,7 @@ pub(crate) fn run(
                         &mut content_scrolls,
                     );
                 } else if line_filter_input_open {
-                    line_filter.push_str(&text);
+                    handle_line_filter_paste(&text, &mut line_filter, &mut line_filter_error);
                 }
             }
             Event::Key(key) => {
@@ -1039,10 +1039,10 @@ mod tests {
     }
 
     use super::super::content::{
-        handle_line_filter_key, workspace_dialogue_vim_view, workspace_picked_content,
-        workspace_picked_content_for_copy, workspace_picked_content_for_copy_with_line_filter,
-        workspace_picked_content_with_line_filter, workspace_search_target_ref,
-        WorkspaceCopyShortcut,
+        handle_line_filter_key, handle_line_filter_paste, workspace_dialogue_vim_view,
+        workspace_picked_content, workspace_picked_content_for_copy,
+        workspace_picked_content_for_copy_with_line_filter, workspace_picked_content_with_line_filter,
+        workspace_search_target_ref, WorkspaceCopyShortcut,
     };
     use super::super::nav::{clamp_list_state, move_workspace_cursor_up};
     use super::super::panes::{DialogueCtx, DialoguePane};
@@ -1775,6 +1775,23 @@ mod tests {
 
         assert_eq!(filter, "2:3");
         assert!(open);
+    }
+
+    #[test]
+    fn line_filter_paste_strips_disallowed_characters() {
+        let mut filter = String::new();
+        let mut error = Some("previous error".into());
+
+        // Clipboard trailing newline and stray text must not leak into the spec.
+        handle_line_filter_paste("1,3:5\n", &mut filter, &mut error);
+        assert_eq!(filter, "1,3:5");
+        assert!(error.is_none());
+
+        // Fully invalid paste is dropped and the previous error is kept.
+        let mut error = Some("previous error".into());
+        handle_line_filter_paste("alpha beta\n", &mut filter, &mut error);
+        assert_eq!(filter, "1,3:5");
+        assert!(error.is_some());
     }
 
     #[test]

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -423,8 +423,13 @@ pub(crate) fn run(
                 // Bracketed paste delivers the whole clipboard as one event;
                 // route it to the open text input (search or line filter).
                 if show_search {
+                    // A copied line usually carries a trailing newline; the
+                    // per-line search regex cannot match one, so pasting
+                    // "target\n" would yield zero results. Normalize trailing
+                    // line breaks before applying the edit.
+                    let pasted = text.trim_end_matches(['\r', '\n']);
                     search_query_edited(
-                        |query| query.push_str(&text),
+                        |query| query.push_str(pasted),
                         &mut search_query,
                         &mut search_dirty,
                         &mut search_cursor,

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -419,6 +419,27 @@ pub(crate) fn run(
         }
         redraw = true;
         match read_interaction()? {
+            Event::Paste(text) => {
+                // Bracketed paste delivers the whole clipboard as one event;
+                // route it to the open text input (search or line filter).
+                if show_search {
+                    search_query_edited(
+                        |query| query.push_str(&text),
+                        &mut search_query,
+                        &mut search_dirty,
+                        &mut search_cursor,
+                        &mut search_apply_pending,
+                        &mut session_state,
+                        &mut selected_sessions,
+                        &mut dialogue_state,
+                        &mut selected_dialogues,
+                        &mut range_anchor,
+                        &mut content_scrolls,
+                    );
+                } else if line_filter_input_open {
+                    line_filter.push_str(&text);
+                }
+            }
             Event::Key(key) => {
                 if key.kind == KeyEventKind::Release {
                     continue;
@@ -518,26 +539,28 @@ pub(crate) fn run(
                                 content_io_focus,
                             );
                         }
-                        KeyCode::Backspace => {
-                            search_query.pop();
-                            search_dirty = true;
-                            search_cursor = 0;
-                            search_apply_pending = true;
-                            reset_workspace_search_state(
-                                &mut session_state,
-                                &mut selected_sessions,
-                                &mut dialogue_state,
-                                &mut selected_dialogues,
-                                &mut range_anchor,
-                                &mut content_scrolls,
-                            );
-                        }
+                        KeyCode::Backspace => search_query_edited(
+                            |query| {
+                                query.pop();
+                            },
+                            &mut search_query,
+                            &mut search_dirty,
+                            &mut search_cursor,
+                            &mut search_apply_pending,
+                            &mut session_state,
+                            &mut selected_sessions,
+                            &mut dialogue_state,
+                            &mut selected_dialogues,
+                            &mut range_anchor,
+                            &mut content_scrolls,
+                        ),
                         KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            search_query.clear();
-                            search_dirty = true;
-                            search_cursor = 0;
-                            search_apply_pending = true;
-                            reset_workspace_search_state(
+                            search_query_edited(
+                                |query| query.clear(),
+                                &mut search_query,
+                                &mut search_dirty,
+                                &mut search_cursor,
+                                &mut search_apply_pending,
                                 &mut session_state,
                                 &mut selected_sessions,
                                 &mut dialogue_state,
@@ -546,20 +569,19 @@ pub(crate) fn run(
                                 &mut content_scrolls,
                             );
                         }
-                        KeyCode::Char(ch) => {
-                            search_query.push(ch);
-                            search_dirty = true;
-                            search_cursor = 0;
-                            search_apply_pending = true;
-                            reset_workspace_search_state(
-                                &mut session_state,
-                                &mut selected_sessions,
-                                &mut dialogue_state,
-                                &mut selected_dialogues,
-                                &mut range_anchor,
-                                &mut content_scrolls,
-                            );
-                        }
+                        KeyCode::Char(ch) => search_query_edited(
+                            |query| query.push(ch),
+                            &mut search_query,
+                            &mut search_dirty,
+                            &mut search_cursor,
+                            &mut search_apply_pending,
+                            &mut session_state,
+                            &mut selected_sessions,
+                            &mut dialogue_state,
+                            &mut selected_dialogues,
+                            &mut range_anchor,
+                            &mut content_scrolls,
+                        ),
                         _ => {}
                     }
                     continue;
@@ -922,6 +944,38 @@ pub(crate) fn run(
             _ => {}
         }
     }
+}
+
+/// A search input edit (typed character, backspace, or paste) changed the
+/// query: mark the corpus dirty, restart at the first match, and drop the
+/// previous result's selection so a shrinking match set cannot leave
+/// dangling highlights.
+#[allow(clippy::too_many_arguments)]
+fn search_query_edited(
+    edit: impl FnOnce(&mut String),
+    search_query: &mut String,
+    search_dirty: &mut bool,
+    search_cursor: &mut usize,
+    search_apply_pending: &mut bool,
+    session_state: &mut ListState,
+    selected_sessions: &mut Vec<bool>,
+    dialogue_state: &mut ListState,
+    selected_dialogues: &mut Vec<bool>,
+    range_anchor: &mut Option<usize>,
+    content_scrolls: &mut ContentScrolls,
+) {
+    edit(search_query);
+    *search_dirty = true;
+    *search_cursor = 0;
+    *search_apply_pending = true;
+    reset_workspace_search_state(
+        session_state,
+        selected_sessions,
+        dialogue_state,
+        selected_dialogues,
+        range_anchor,
+        content_scrolls,
+    );
 }
 
 /// Keys that safely auto-repeat when held. Navigation and scrolling repeat

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -423,11 +423,12 @@ pub(crate) fn run(
                 // Bracketed paste delivers the whole clipboard as one event;
                 // route it to the open text input (search or line filter).
                 if show_search {
-                    // A copied line usually carries a trailing newline; the
-                    // per-line search regex cannot match one, so pasting
-                    // "target\n" would yield zero results. Normalize trailing
-                    // line breaks before applying the edit.
-                    let pasted = text.trim_end_matches(['\r', '\n']);
+                    // Search terms match single lines: fold every line break
+                    // into a space so a trailing newline (common when copying
+                    // a line) or a multi-line clipboard searches as one query
+                    // instead of silently matching nothing.
+                    let pasted = text.replace(['\r', '\n'], " ");
+                    let pasted = pasted.trim_end();
                     search_query_edited(
                         |query| query.push_str(pasted),
                         &mut search_query,

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -18,8 +18,8 @@ use crate::tui::workspace::{
 };
 
 use super::content::{
-    active_workspace_content_at, handle_line_filter_key, handle_line_filter_paste, line_filter_spec,
-    workspace_search_target_ref,
+    active_workspace_content_at, handle_line_filter_key, handle_line_filter_paste,
+    line_filter_spec, workspace_search_target_ref,
 };
 use super::help::{apply_workspace_help_action, set_focus, HelpDispatch};
 use super::load::{SessionColumn, SessionCtx, SourceLoadState};
@@ -1041,8 +1041,9 @@ mod tests {
     use super::super::content::{
         handle_line_filter_key, handle_line_filter_paste, workspace_dialogue_vim_view,
         workspace_picked_content, workspace_picked_content_for_copy,
-        workspace_picked_content_for_copy_with_line_filter, workspace_picked_content_with_line_filter,
-        workspace_search_target_ref, WorkspaceCopyShortcut,
+        workspace_picked_content_for_copy_with_line_filter,
+        workspace_picked_content_with_line_filter, workspace_search_target_ref,
+        WorkspaceCopyShortcut,
     };
     use super::super::nav::{clamp_list_state, move_workspace_cursor_up};
     use super::super::panes::{DialogueCtx, DialoguePane};

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -427,7 +427,7 @@ pub(crate) fn run(
                     // into a space so a trailing newline (common when copying
                     // a line) or a multi-line clipboard searches as one query
                     // instead of silently matching nothing.
-                    let pasted = text.replace(['\r', '\n'], " ");
+                    let pasted = normalize_search_paste(&text);
                     let pasted = pasted.trim_end();
                     search_query_edited(
                         |query| query.push_str(pasted),
@@ -950,6 +950,10 @@ pub(crate) fn run(
             _ => {}
         }
     }
+}
+
+fn normalize_search_paste(text: &str) -> String {
+    text.replace("\r\n", " ").replace(['\r', '\n'], " ")
 }
 
 /// A search input edit (typed character, backspace, or paste) changed the
@@ -1799,6 +1803,11 @@ mod tests {
         handle_line_filter_paste("alpha beta\n", &mut filter, &mut error);
         assert_eq!(filter, "1,3:5");
         assert!(error.is_some());
+    }
+
+    #[test]
+    fn search_paste_normalizes_crlf_as_one_space() {
+        assert_eq!(super::normalize_search_paste("foo\r\nbar"), "foo bar");
     }
 
     #[test]

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -5,7 +5,10 @@ use crossterm::terminal::disable_raw_mode;
 use crossterm::terminal::{BeginSynchronizedUpdate, EndSynchronizedUpdate};
 use crossterm::{
     cursor::Show,
-    event::{DisableMouseCapture, EnableMouseCapture, Event, MouseEvent, MouseEventKind},
+    event::{
+        DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+        Event, MouseEvent, MouseEventKind,
+    },
     execute,
     terminal::{enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -131,6 +134,15 @@ pub fn init() -> Result<Tui> {
     setup.state.mouse_capture = true;
     if let Err(error) =
         execute!(stdout, EnableMouseCapture).context("Failed to enable terminal mouse capture")
+    {
+        return setup.fail(error);
+    }
+
+    // Bracketed paste keeps pasted text intact (newlines, tab, UTF-8) and
+    // arrives as a single Event::Paste instead of a stream of key events.
+    setup.state.bracketed_paste = true;
+    if let Err(error) =
+        execute!(stdout, EnableBracketedPaste).context("Failed to enable terminal bracketed paste")
     {
         return setup.fail(error);
     }
@@ -345,6 +357,13 @@ fn restore_terminal_state(state: &mut TerminalState) -> Result<()> {
             execute!(stdout, DisableMouseCapture),
         );
     }
+    if state.bracketed_paste {
+        failures.record_flag(
+            "disable bracketed paste",
+            &mut state.bracketed_paste,
+            execute!(stdout, DisableBracketedPaste),
+        );
+    }
     if state.alternate_screen {
         failures.record_flag(
             "leave alternate screen",
@@ -365,8 +384,10 @@ fn restore_terminal_state(state: &mut TerminalState) -> Result<()> {
 }
 
 fn restore_owned_state(failures: &mut CleanupFailures, state: &mut TerminalState) {
-    let display_commands_restored =
-        !state.mouse_capture && !state.alternate_screen && !state.cursor_restore_pending;
+    let display_commands_restored = !state.mouse_capture
+        && !state.alternate_screen
+        && !state.cursor_restore_pending
+        && !state.bracketed_paste;
     let mut input_mode_restored = true;
 
     if let Some(modes) = state.modes.as_mut() {
@@ -433,6 +454,7 @@ struct TerminalState {
     mouse_capture: bool,
     alternate_screen: bool,
     cursor_restore_pending: bool,
+    bracketed_paste: bool,
     modes: Option<TerminalModes>,
     code_pages: Option<ConsoleCodePages>,
     console_input: Option<ConsoleInputHandle>,
@@ -456,6 +478,7 @@ impl TerminalState {
         self.mouse_capture
             || self.alternate_screen
             || self.cursor_restore_pending
+            || self.bracketed_paste
             || self.modes.is_some()
             || self.code_pages.is_some()
             || self.console_input.is_some()


### PR DESCRIPTION
Without EnableBracketedPaste, raw mode splits pasted text into a stream
of key events and multi-line clipboard content can be mangled into
accidental Enter presses. The terminal now arms bracketed paste on init
(and disarms it during cleanup), and Event::Paste routes the whole
clipboard into the open search query or line filter.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for pasting content directly into search and line-filter fields.
  * Multiline search text is normalized for easier searching.

* **Bug Fixes**
  * Line-filter pastes now keep only valid digits, commas, and colons.
  * Invalid pasted characters are discarded, and existing input errors clear when valid content is added.
  * Search results, selection, and scrolling now update consistently after edits.

* **Improvements**
  * Terminal paste mode is properly enabled and restored when browsing ends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->