### PR TITLE
fix(tui): catch panics, restore the terminal, and report

### DIFF
--- a/src/commands/browse/mod.rs
+++ b/src/commands/browse/mod.rs
@@ -23,10 +23,15 @@ pub(crate) use load::{workspace_source_catalog, SourceLoadState};
 pub(crate) use picker::run as run_picker;
 pub(crate) use text::{filter_lines_by_spec, record_text_to_pair, select_lines};
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use sivtr_core::ai::AgentProvider;
+use std::io::{self, IsTerminal};
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
-use crate::tui::terminal::{finish as finish_tui, init as init_tui};
+use crate::tui::terminal::{
+    finish as finish_tui, init as init_tui, panic_payload_message, restore as restore_tui,
+    wait_for_enter,
+};
 use crate::tui::workspace::{WorkspaceFocus, WorkspacePickedContent, WorkspaceSource};
 
 /// Run the workspace browser.
@@ -52,7 +57,7 @@ pub fn run(
         sources.iter().map(|_| SourceLoadState::idle()).collect();
 
     let mut terminal = init_tui()?;
-    let result = run_picker(
+    let result = run_picker_guarded(
         &mut terminal,
         sources,
         source_states,
@@ -72,7 +77,7 @@ pub fn run_with_sessions(
     let cwd = std::env::current_dir().context("Failed to resolve current directory")?;
     let loaded = sessions.len().max(1);
     let mut terminal = init_tui()?;
-    let result = run_picker(
+    let result = run_picker_guarded(
         &mut terminal,
         vec![source],
         vec![SourceLoadState::ready_from_sessions(sessions, loaded)],
@@ -81,6 +86,44 @@ pub fn run_with_sessions(
         initial_focus,
     );
     finish_tui(&mut terminal, result)
+}
+
+/// Run the picker and convert any panic into a reported error.
+///
+/// A panic inside the TUI must not leave the terminal in raw mode with the
+/// alternate screen active. The unwind is caught and the terminal is restored
+/// first; panics that skip this path are caught by the global panic hook
+/// ([`crate::tui::panic`]) and by the `Tui` drop. The panic message is
+/// printed before the error propagates.
+fn run_picker_guarded(
+    terminal: &mut crate::tui::terminal::Tui,
+    sources: Vec<WorkspaceSource>,
+    source_states: Vec<SourceLoadState>,
+    selected_sources: Vec<bool>,
+    cwd: std::path::PathBuf,
+    initial_focus: WorkspaceFocus,
+) -> Result<WorkspacePickedContent> {
+    match catch_unwind(AssertUnwindSafe(|| {
+        run_picker(
+            terminal,
+            sources,
+            source_states,
+            selected_sources,
+            cwd,
+            initial_focus,
+        )
+    })) {
+        Ok(result) => result,
+        Err(payload) => {
+            let message = panic_payload_message(&payload);
+            let _ = restore_tui(terminal);
+            eprintln!("sivtr: TUI panicked: {message}");
+            if io::stdin().is_terminal() {
+                wait_for_enter("press Enter to continue");
+            }
+            Err(anyhow!("TUI panicked: {message}"))
+        }
+    }
 }
 
 /// Shared cancel sentinel for picker Esc/q.

--- a/src/commands/browse/mod.rs
+++ b/src/commands/browse/mod.rs
@@ -132,6 +132,9 @@ fn run_picker_guarded(
     initial_focus: WorkspaceFocus,
     wait_after_panic: bool,
 ) -> Result<WorkspacePickedContent> {
+    // This guard recovers the panic and reports it itself, so the terminal-
+    // restoring hook must not also emit the default "uncaught panic" report.
+    let _suppress = crate::tui::panic::SuppressDefaultReport::enter();
     match catch_unwind(AssertUnwindSafe(|| {
         run_picker(
             terminal,
@@ -145,9 +148,13 @@ fn run_picker_guarded(
         Ok(result) => result,
         Err(payload) => {
             let message = panic_payload_message(&payload);
-            let _ = restore_tui(terminal);
+            let restored = restore_tui(terminal).is_ok();
             eprintln!("sivtr: TUI panicked: {message}");
-            if wait_after_panic && io::stdin().is_terminal() {
+            // Only prompt after a successful restore: while raw mode is still
+            // active a blocking read may never see a newline, and the later
+            // finish_tui retry must get a chance to run and report the
+            // cleanup failure.
+            if restored && wait_after_panic && io::stdin().is_terminal() {
                 wait_for_enter("press Enter to continue");
             }
             Err(anyhow!("TUI panicked: {message}"))

--- a/src/commands/browse/mod.rs
+++ b/src/commands/browse/mod.rs
@@ -43,6 +43,28 @@ pub fn run(
     select_remotes: bool,
     initial_focus: WorkspaceFocus,
 ) -> Result<WorkspacePickedContent> {
+    run_catalog(providers, select_remotes, initial_focus, true)
+}
+
+/// Like [`run`], but does not prompt for Enter after a recovered panic.
+///
+/// The Windows hotkey picker runs in its own console and already waits when it
+/// reports errors (`show_pick_error_and_wait`); waiting here as well would make
+/// the first keypress appear to be ignored by the panic prompt.
+pub fn run_without_panic_wait(
+    providers: &[AgentProvider],
+    select_remotes: bool,
+    initial_focus: WorkspaceFocus,
+) -> Result<WorkspacePickedContent> {
+    run_catalog(providers, select_remotes, initial_focus, false)
+}
+
+fn run_catalog(
+    providers: &[AgentProvider],
+    select_remotes: bool,
+    initial_focus: WorkspaceFocus,
+    wait_after_panic: bool,
+) -> Result<WorkspacePickedContent> {
     let cwd = std::env::current_dir().context("Failed to resolve current directory")?;
     let sources = workspace_source_catalog(providers, &cwd)?;
     if sources.is_empty() {
@@ -64,6 +86,7 @@ pub fn run(
         selected_sources,
         cwd,
         initial_focus,
+        wait_after_panic,
     );
     finish_tui(&mut terminal, result)
 }
@@ -84,6 +107,7 @@ pub fn run_with_sessions(
         vec![true],
         cwd,
         initial_focus,
+        true,
     );
     finish_tui(&mut terminal, result)
 }
@@ -95,6 +119,10 @@ pub fn run_with_sessions(
 /// first; panics that skip this path are caught by the global panic hook
 /// ([`crate::tui::panic`]) and by the `Tui` drop. The panic message is
 /// printed before the error propagates.
+///
+/// `wait_after_panic` controls whether a recovered panic prompts for Enter: the
+/// hotkey picker reports errors itself, so it passes `false` to avoid consuming
+/// a keypress the outer handler is about to wait on.
 fn run_picker_guarded(
     terminal: &mut crate::tui::terminal::Tui,
     sources: Vec<WorkspaceSource>,
@@ -102,6 +130,7 @@ fn run_picker_guarded(
     selected_sources: Vec<bool>,
     cwd: std::path::PathBuf,
     initial_focus: WorkspaceFocus,
+    wait_after_panic: bool,
 ) -> Result<WorkspacePickedContent> {
     match catch_unwind(AssertUnwindSafe(|| {
         run_picker(
@@ -118,7 +147,7 @@ fn run_picker_guarded(
             let message = panic_payload_message(&payload);
             let _ = restore_tui(terminal);
             eprintln!("sivtr: TUI panicked: {message}");
-            if io::stdin().is_terminal() {
+            if wait_after_panic && io::stdin().is_terminal() {
                 wait_for_enter("press Enter to continue");
             }
             Err(anyhow!("TUI panicked: {message}"))

--- a/src/commands/browse/mod.rs
+++ b/src/commands/browse/mod.rs
@@ -25,7 +25,6 @@ pub(crate) use text::{filter_lines_by_spec, record_text_to_pair, select_lines};
 
 use anyhow::{anyhow, Context, Result};
 use sivtr_core::ai::AgentProvider;
-use std::io::{self, IsTerminal};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use crate::tui::terminal::{
@@ -149,12 +148,11 @@ fn run_picker_guarded(
         Err(payload) => {
             let message = panic_payload_message(&payload);
             let restored = restore_tui(terminal).is_ok();
-            eprintln!("sivtr: TUI panicked: {message}");
-            // Only prompt after a successful restore: while raw mode is still
-            // active a blocking read may never see a newline, and the later
-            // finish_tui retry must get a chance to run and report the
-            // cleanup failure.
-            if restored && wait_after_panic && io::stdin().is_terminal() {
+            // The caller (cli_main / show_pick_error_and_wait) reports the
+            // error once; just pause so the user can see the restored screen
+            // before the report scrolls past. `wait_for_enter` reads from the
+            // console itself, so a redirected stdin cannot skip the prompt.
+            if restored && wait_after_panic {
                 wait_for_enter("press Enter to continue");
             }
             Err(anyhow!("TUI panicked: {message}"))

--- a/src/commands/system/hotkey.rs
+++ b/src/commands/system/hotkey.rs
@@ -64,7 +64,8 @@ pub fn pick_agent(args: &HotkeyPickAgentArgs) -> Result<()> {
         // The no-wait variant: this handler reports errors (and waits) itself,
         // so a panic recovered inside the picker must not consume an Enter
         // before show_pick_error_and_wait prompts.
-        let picked = browse::run_without_panic_wait(&providers, args.all, WorkspaceFocus::Sessions)?;
+        let picked =
+            browse::run_without_panic_wait(&providers, args.all, WorkspaceFocus::Sessions)?;
         copy::export_picked(&picked, false, None, None, false)
     });
 

--- a/src/commands/system/hotkey.rs
+++ b/src/commands/system/hotkey.rs
@@ -11,6 +11,7 @@ use crate::cli::{
 };
 use crate::commands::browse;
 use crate::commands::memory::copy;
+use crate::tui::terminal::{panic_payload_message, wait_for_enter};
 use crate::tui::workspace::WorkspaceFocus;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -72,10 +73,10 @@ pub fn pick_agent(args: &HotkeyPickAgentArgs) -> Result<()> {
             }
         }
         Err(panic) => {
-            let message = panic_message(&panic);
+            let message = panic_payload_message(&panic);
             eprintln!("sivtr: AI session picker panicked");
             eprintln!("{message}");
-            wait_for_enter();
+            wait_for_enter("Press Enter to close this window.");
         }
     }
 
@@ -178,24 +179,7 @@ fn state_path() -> Result<PathBuf> {
 fn show_pick_error_and_wait(error: &anyhow::Error) {
     eprintln!("sivtr: AI session picker failed");
     eprintln!("{error:#}");
-    wait_for_enter();
-}
-
-fn wait_for_enter() {
-    eprintln!();
-    eprintln!("Press Enter to close this window.");
-    let mut input = String::new();
-    let _ = std::io::stdin().read_line(&mut input);
-}
-
-fn panic_message(panic: &Box<dyn std::any::Any + Send>) -> String {
-    if let Some(message) = panic.downcast_ref::<&str>() {
-        (*message).to_string()
-    } else if let Some(message) = panic.downcast_ref::<String>() {
-        message.clone()
-    } else {
-        "unknown panic payload".to_string()
-    }
+    wait_for_enter("Press Enter to close this window.");
 }
 
 #[cfg(windows)]

--- a/src/commands/system/hotkey.rs
+++ b/src/commands/system/hotkey.rs
@@ -61,7 +61,10 @@ pub fn pick_agent(args: &HotkeyPickAgentArgs) -> Result<()> {
         let providers = args.provider.providers();
         // Hotkey owns the browse product surface; copy only exports the pick.
         let _ = args.current_session;
-        let picked = browse::run(&providers, args.all, WorkspaceFocus::Sessions)?;
+        // The no-wait variant: this handler reports errors (and waits) itself,
+        // so a panic recovered inside the picker must not consume an Enter
+        // before show_pick_error_and_wait prompts.
+        let picked = browse::run_without_panic_wait(&providers, args.all, WorkspaceFocus::Sessions)?;
         copy::export_picked(&picked, false, None, None, false)
     });
 

--- a/src/tui/panic.rs
+++ b/src/tui/panic.rs
@@ -5,7 +5,7 @@
 //! only invoked when the panicking thread is the one that registered it. Background-thread panics
 //! still get the default report without tearing down a live interface.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::panic::AssertUnwindSafe;
 use std::sync::Once;
 
@@ -14,6 +14,11 @@ thread_local! {
     /// last. A session's entry is cleared when that session restores or drops,
     /// so a later panic in a still-live outer session pops the outer closure.
     static TERMINAL_RESTORE: RestoreSlots = const { RefCell::new(Vec::new()) };
+    /// Set while a guard intends to catch and report a TUI panic itself; the
+    /// hook then restores the terminal without invoking the default reporter,
+    /// so the user does not see an uncaught-panic report followed by the
+    /// guard's own message.
+    static SUPPRESS_DEFAULT_REPORT: Cell<bool> = const { Cell::new(false) };
 }
 
 /// Registered restore closures; see [`TERMINAL_RESTORE`].
@@ -26,6 +31,28 @@ static INSTALL: Once = Once::new();
 /// takes the innermost live closure.
 pub struct RestoreRegistration {
     index: usize,
+}
+
+/// Scope guard that suppresses the default panic report for a recovered TUI
+/// panic on the thread that owns the terminal.
+///
+/// The terminal-restoring hook still runs; only the default reporter is
+/// skipped, because the caller reports the recovered panic itself. Background
+/// thread panics are unaffected — they never own a restore closure, so their
+/// default report is kept.
+pub struct SuppressDefaultReport;
+
+impl SuppressDefaultReport {
+    pub fn enter() -> Self {
+        SUPPRESS_DEFAULT_REPORT.with(|flag| flag.set(true));
+        SuppressDefaultReport
+    }
+}
+
+impl Drop for SuppressDefaultReport {
+    fn drop(&mut self) {
+        SUPPRESS_DEFAULT_REPORT.with(|flag| flag.set(false));
+    }
 }
 
 /// Register the closure the panic hook runs to restore the terminal.
@@ -60,7 +87,9 @@ impl Drop for RestoreRegistration {
 /// Install a panic hook that restores the terminal before reporting the panic.
 ///
 /// The previously installed hook is kept and invoked afterward, so panic output formatting and
-/// backtrace hints are unchanged. Installing more than once is a no-op.
+/// backtrace hints are unchanged — unless a [`SuppressDefaultReport`] guard is active and the
+/// panic is on the terminal-owning thread, in which case the guard reports it. Installing more
+/// than once is a no-op.
 pub fn install() {
     INSTALL.call_once(|| {
         let default_hook = std::panic::take_hook();
@@ -76,19 +105,24 @@ pub fn install() {
                 })
                 .ok()
                 .flatten();
+            // Only the terminal-owning thread holds a restore closure, so a
+            // restored panic is exactly the one a guard may be recovering.
+            let suppressed = restore.is_some() && SUPPRESS_DEFAULT_REPORT.with(Cell::get);
             if let Some(restore) = restore {
                 // A restore that panics (e.g. I/O against a dying console) must not abort the
                 // process before the panic is reported.
                 let _ = std::panic::catch_unwind(AssertUnwindSafe(restore));
             }
-            default_hook(info);
+            if !suppressed {
+                default_hook(info);
+            }
         }));
     });
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{install, register_restore};
+    use super::{install, register_restore, SuppressDefaultReport};
     use std::sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -136,5 +170,20 @@ mod tests {
             outer.load(Ordering::Relaxed),
             "outer restore must still run"
         );
+    }
+
+    #[test]
+    fn suppressed_default_report_still_restores_the_terminal() {
+        install();
+        let restored = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&restored);
+        let _registration = register_restore(Box::new(move || {
+            flag.store(true, Ordering::Relaxed);
+        }));
+
+        let _guard = SuppressDefaultReport::enter();
+        let result = std::panic::catch_unwind(|| panic!("recovered panic"));
+        assert!(result.is_err());
+        assert!(restored.load(Ordering::Relaxed));
     }
 }

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -333,10 +333,20 @@ pub(crate) fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> Str
 }
 
 /// Print a prompt and block until the user presses Enter.
+///
+/// On Windows the TUI binds a redirected stdin to `CONIN$` and restores the
+/// original handle during cleanup; rebind the console here so the prompt still
+/// reads from the console the user is looking at instead of a redirect.
 pub(crate) fn wait_for_enter(prompt: &str) {
     eprintln!("{prompt}");
+    #[cfg(windows)]
+    let _console = if io::stdin().is_terminal() {
+        None
+    } else {
+        ConsoleInputHandle::ensure_console().ok().flatten()
+    };
     let mut input = String::new();
-    let _ = std::io::stdin().read_line(&mut input);
+    let _ = io::stdin().read_line(&mut input);
 }
 
 /// Temporarily exit the TUI while an external program runs, then re-enter it.

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -321,6 +321,24 @@ pub fn finish<T>(terminal: &mut Tui, operation: Result<T>) -> Result<T> {
     )
 }
 
+/// Extract a panic payload's message for user-facing reporting.
+pub(crate) fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "unknown panic".to_string()
+    }
+}
+
+/// Print a prompt and block until the user presses Enter.
+pub(crate) fn wait_for_enter(prompt: &str) {
+    eprintln!("{prompt}");
+    let mut input = String::new();
+    let _ = std::io::stdin().read_line(&mut input);
+}
+
 /// Temporarily exit the TUI while an external program runs, then re-enter it.
 ///
 /// The outer result reports suspend/resume failures. The inner result is the external operation's


### PR DESCRIPTION
A panic inside the picker used to leave the terminal in raw mode with
the alternate screen active whenever the unwind escaped the Tui's Drop
guard. The picker call is now wrapped in catch_unwind: on a panic the
terminal is restored first, the message is printed, and an interactive
session waits for Enter before the error propagates — mirroring the
hotkey picker path.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace browser and hotkey picker recovery when an unexpected error or panic occurs.
  * Ensures the terminal interface is restored before displaying error details.
  * Added clearer panic messages, including a fallback for unknown errors.
  * Added an optional prompt to pause and review errors before continuing.
  * Improved handling of redirected input on Windows when waiting for confirmation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->