### PR TITLE
fix(tui): hide the cursor outside typing and selection modes

### DIFF
--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -396,8 +396,14 @@ pub(crate) fn run(
                     },
                 )
             })?;
-            if visual_select_mode.is_some() {
+            // Ratatui reveals the cursor after every frame. Keep it visible
+            // only while typing in an overlay or selecting text; hide it
+            // otherwise so it does not blink at a stale position during
+            // normal browsing.
+            if show_search || line_filter_input_open || visual_select_mode.is_some() {
                 terminal.show_cursor()?;
+            } else {
+                terminal.hide_cursor()?;
             }
         }
 

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -4,7 +4,7 @@ use crossterm::terminal::disable_raw_mode;
 #[cfg(windows)]
 use crossterm::terminal::{BeginSynchronizedUpdate, EndSynchronizedUpdate};
 use crossterm::{
-    cursor::Show,
+    cursor::{Hide, Show},
     event::{
         DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
         Event, MouseEvent, MouseEventKind,
@@ -148,6 +148,9 @@ pub fn init() -> Result<Tui> {
     }
 
     setup.state.cursor_restore_pending = true;
+    if let Err(error) = execute!(stdout, Hide).context("Failed to hide the terminal cursor") {
+        return setup.fail(error);
+    }
     let backend = CrosstermBackend::new(stdout);
     let terminal = match Terminal::new(backend).context("Failed to initialize terminal buffers") {
         Ok(terminal) => terminal,

--- a/src/tui/workspace/render.rs
+++ b/src/tui/workspace/render.rs
@@ -187,10 +187,7 @@ fn position_overlay_cursor(frame: &mut Frame, area: Rect, text: &str) {
         return;
     }
     let lines: Vec<&str> = text.split('\n').collect();
-    let caret_row = lines
-        .len()
-        .saturating_sub(1)
-        .min(inner.height as usize - 1);
+    let caret_row = lines.len().saturating_sub(1).min(inner.height as usize - 1);
     let caret_line = lines.get(caret_row).copied().unwrap_or("");
     let column = UnicodeWidthStr::width(caret_line).min(inner.width as usize) as u16;
     let row = inner.y.saturating_add(caret_row as u16);

--- a/src/tui/workspace/render.rs
+++ b/src/tui/workspace/render.rs
@@ -176,13 +176,25 @@ pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
 }
 
 /// Place the cursor just past the typed text inside an overlay's text area.
+///
+/// Pasted text can contain newlines, and `Paragraph` renders each line on its
+/// own row. The caret must therefore sit on the row of the *last* rendered line
+/// (clipped to the visible box when the text overflows it), not on the first
+/// row with the summed width of every line.
 fn position_overlay_cursor(frame: &mut Frame, area: Rect, text: &str) {
     let inner = area.inner(Margin::new(1, 1));
     if inner.width == 0 || inner.height == 0 {
         return;
     }
-    let column = UnicodeWidthStr::width(text).min(inner.width as usize) as u16;
-    frame.set_cursor_position(Position::new(inner.x.saturating_add(column), inner.y));
+    let lines: Vec<&str> = text.split('\n').collect();
+    let caret_row = lines
+        .len()
+        .saturating_sub(1)
+        .min(inner.height as usize - 1);
+    let caret_line = lines.get(caret_row).copied().unwrap_or("");
+    let column = UnicodeWidthStr::width(caret_line).min(inner.width as usize) as u16;
+    let row = inner.y.saturating_add(caret_row as u16);
+    frame.set_cursor_position(Position::new(inner.x.saturating_add(column), row));
 }
 
 fn render_footer(frame: &mut Frame, area: Rect, footer: WorkspaceFooterView<'_>) {
@@ -899,4 +911,51 @@ pub(crate) fn content_title(
         mode.label(),
         content_title_suffix(selected_dialogues, current_ref)
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::position_overlay_cursor;
+    use ratatui::backend::{Backend, TestBackend};
+    use ratatui::layout::Rect;
+    use ratatui::prelude::Terminal;
+
+    /// Render the overlay at `(2, 1, 14, 4)` — inner text area `(3, 2, 12, 2)` —
+    /// and return the caret position the frame recorded.
+    fn cursor_for(text: &str) -> (u16, u16) {
+        let backend = TestBackend::new(20, 8);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                position_overlay_cursor(frame, Rect::new(2, 1, 14, 4), text);
+            })
+            .unwrap();
+        let pos = terminal.backend_mut().get_cursor_position().unwrap();
+        (pos.x, pos.y)
+    }
+
+    #[test]
+    fn overlay_cursor_follows_single_line_text() {
+        assert_eq!(cursor_for("2:3"), (6, 2));
+        assert_eq!(cursor_for(""), (3, 2));
+    }
+
+    #[test]
+    fn overlay_cursor_tracks_the_last_rendered_line() {
+        // "1,3\n5:7" renders "1,3" on the first row and "5:7" on the second;
+        // the caret must sit at the end of "5:7", not at the summed width on
+        // the first row.
+        assert_eq!(cursor_for("1,3\n5:7"), (6, 3));
+        // A trailing newline opens an empty final row for the caret.
+        assert_eq!(cursor_for("1,3\n"), (3, 3));
+    }
+
+    #[test]
+    fn overlay_cursor_clamps_to_the_visible_box() {
+        // More lines than the box has rows: the caret stays on the last visible
+        // row, at the end of the line rendered there.
+        assert_eq!(cursor_for("1\n2\n3\n4"), (4, 3));
+        // A line wider than the box clamps the column to the right edge.
+        assert_eq!(cursor_for("1\n0123456789abcdefghij"), (15, 3));
+    }
 }

--- a/src/tui/workspace/render.rs
+++ b/src/tui/workspace/render.rs
@@ -1,10 +1,11 @@
 //! Workspace browser painting (lists, dual content panes, overlays, footer).
 
-use ratatui::layout::{Constraint, Direction, Layout, Rect};
-use ratatui::prelude::{Color, Frame, Modifier, Style};
+use ratatui::layout::{Constraint, Direction, Layout, Margin, Rect};
+use ratatui::prelude::{Color, Frame, Modifier, Position, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Clear, ListItem, ListState, Paragraph};
 use regex::Regex;
+use unicode_width::UnicodeWidthStr;
 
 use crate::tui::content::io::ContentIoFocus;
 use crate::tui::content::view::{
@@ -149,6 +150,16 @@ pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
         }
     }
 
+    // Put the caret at the end of the query in whichever overlay is being
+    // typed into; the picker keeps the cursor visible only in these modes.
+    if let Some(search) = view.search.as_ref().filter(|search| search.input_open) {
+        let area = centered_rect(chunks[0], 60, 12);
+        position_overlay_cursor(frame, area, search.query);
+    } else if view.line_filter_input_open {
+        let area = centered_rect(chunks[0], 60, 14);
+        position_overlay_cursor(frame, area, view.line_filter.unwrap_or_default());
+    }
+
     if let Some(search) = view.search.filter(|search| search.input_open) {
         render_search_box(frame, centered_rect(chunks[0], 60, 12), search);
     } else if view.line_filter_input_open || view.line_filter_error.is_some() {
@@ -162,6 +173,16 @@ pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
     } else if view.show_help {
         render_help_panel(frame, chunks[0], view.help_state);
     }
+}
+
+/// Place the cursor just past the typed text inside an overlay's text area.
+fn position_overlay_cursor(frame: &mut Frame, area: Rect, text: &str) {
+    let inner = area.inner(Margin::new(1, 1));
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+    let column = UnicodeWidthStr::width(text).min(inner.width as usize) as u16;
+    frame.set_cursor_position(Position::new(inner.x.saturating_add(column), inner.y));
 }
 
 fn render_footer(frame: &mut Frame, area: Rect, footer: WorkspaceFooterView<'_>) {


### PR DESCRIPTION
Ratatui reveals the cursor after every frame, so it blinked at a stale
position during normal browsing. init now hides it (the existing Show
restore path finally has something to undo), and after each draw the
picker shows it only while the search overlay, the line filter, or a
visual selection is active — with the caret positioned at the end of
the query in the open overlay.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>