### PR TITLE
refactor(tui): drop assert!/expect from production paths

### DIFF
--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -45,8 +45,8 @@ pub(crate) fn run(
     cwd: PathBuf,
     initial_focus: WorkspaceFocus,
 ) -> Result<WorkspacePickedContent> {
-    assert_eq!(sources.len(), selected_sources.len());
-    assert_eq!(sources.len(), source_states.len());
+    debug_assert_eq!(sources.len(), selected_sources.len());
+    debug_assert_eq!(sources.len(), source_states.len());
     let mut selected_sources = selected_sources;
     let mut session_state = ListState::default();
     let mut source_state = ListState::default();
@@ -82,8 +82,7 @@ pub(crate) fn run(
     let mut show_search = false;
     let mut search_query = String::new();
     let mut search_output = WorkspaceSearchOutput::default();
-    let mut search_index: Option<WorkspaceSearchIndex> = None;
-    let mut search_corpus: Option<Vec<WorkspaceSession>> = None;
+    let mut search_engine: Option<(WorkspaceSearchIndex, Vec<WorkspaceSession>)> = None;
     let mut search_cursor = 0usize;
     let mut search_dirty = true;
     let mut search_apply_pending = false;
@@ -124,10 +123,12 @@ pub(crate) fn run(
                 // corpus changed; both are cached across keystrokes so typing
                 // does not clone every hydrated session per keypress.
                 let fingerprint = search_corpus_fingerprint(&all_sessions, &sessions_pane);
-                let stale = search_index
+                if let Some((index, corpus)) = search_engine
                     .as_ref()
-                    .is_none_or(|index| index.fingerprint() != fingerprint);
-                if stale {
+                    .filter(|(index, _)| index.fingerprint() == fingerprint)
+                {
+                    search_output = index.search(corpus, &search_query);
+                } else {
                     let corpus: Vec<_> = all_sessions
                         .iter()
                         .map(|s| {
@@ -138,16 +139,10 @@ pub(crate) fn run(
                             full
                         })
                         .collect();
-                    search_index = Some(WorkspaceSearchIndex::new(&corpus));
-                    search_corpus = Some(corpus);
+                    let index = WorkspaceSearchIndex::new(&corpus);
+                    search_output = index.search(&corpus, &search_query);
+                    search_engine = Some((index, corpus));
                 }
-                search_output = search_index
-                    .as_ref()
-                    .expect("search index built above")
-                    .search(
-                        search_corpus.as_ref().expect("search corpus built above"),
-                        &search_query,
-                    );
             } else {
                 search_output = WorkspaceSearchOutput::default();
             }

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -7,7 +7,8 @@ use std::path::PathBuf;
 
 use crate::tui::content::view::{content_link_at, ContentViewMode};
 use crate::tui::search::{
-    workspace_search_has_query, workspace_search_scope, WorkspaceSearchIndex, WorkspaceSearchOutput,
+    workspace_search_fingerprint, workspace_search_has_query, workspace_search_scope,
+    WorkspaceSearchIndex, WorkspaceSearchOutput,
 };
 use crate::tui::terminal::read_interaction;
 use crate::tui::workspace::{
@@ -122,7 +123,12 @@ pub(crate) fn run(
                 // Rebuild the search corpus and index only when the loaded
                 // corpus changed; both are cached across keystrokes so typing
                 // does not clone every hydrated session per keypress.
-                let fingerprint = search_corpus_fingerprint(&all_sessions, &sessions_pane);
+                let fingerprint = workspace_search_fingerprint(
+                    &all_sessions,
+                    all_sessions
+                        .iter()
+                        .map(|session| sessions_pane.body_for(session).unwrap_or(&[])),
+                );
                 if let Some((index, corpus)) = search_engine
                     .as_ref()
                     .filter(|(index, _)| index.fingerprint() == fingerprint)
@@ -1025,24 +1031,6 @@ fn is_repeat_safe(code: KeyCode, modifiers: KeyModifiers, text_input: bool) -> b
     )
 }
 
-/// Fingerprint of the loaded search corpus without cloning it: hashes every
-/// hydrated record ref in corpus order. Matches `WorkspaceSearchIndex`'s
-/// internal fingerprint, so an equal value means the cached corpus is still
-/// current and neither the corpus clone nor the BM25 index need rebuilding.
-fn search_corpus_fingerprint(sessions: &[WorkspaceSession], pane: &SessionColumn) -> u64 {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-    let mut hasher = DefaultHasher::new();
-    for session in sessions {
-        if let Some(records) = pane.body_for(session) {
-            for record in records {
-                record.work_ref.whole().hash(&mut hasher);
-            }
-        }
-    }
-    hasher.finish()
-}
-
 #[cfg(test)]
 mod tests {
     fn tool_test_value(text: String) -> serde_json::Value {
@@ -1062,8 +1050,8 @@ mod tests {
     use crate::pane::{Pane, PaneInput, Viewport};
     use crate::tui::content::view::ContentViewMode;
     use crate::tui::search::{
-        workspace_search_query, workspace_search_regex, WorkspaceSearchIndex, WorkspaceSearchMatch,
-        WorkspaceSearchScope,
+        workspace_search_fingerprint, workspace_search_query, workspace_search_regex,
+        WorkspaceSearchIndex, WorkspaceSearchMatch, WorkspaceSearchScope,
     };
     use crate::tui::workspace::{
         ContentIoFocus, ContentScrolls, TextPair, WorkspaceCopyParts, WorkspaceDialogue,
@@ -1322,6 +1310,54 @@ mod tests {
         assert_eq!(dialogue_results.matches.len(), 1);
         assert_eq!(dialogue_results.matches[0].dialogue_index, 0);
         assert!(content_results.sessions.is_empty());
+    }
+
+    #[test]
+    fn workspace_search_fingerprint_tracks_searchable_fields() {
+        let source = WorkspaceSource::agent(AgentProvider::Codex);
+        let sessions = vec![workspace_test_session("session", source, &["dialogue"])];
+        let fingerprint = workspace_search_fingerprint(
+            &sessions,
+            sessions.iter().map(|session| session.records.as_slice()),
+        );
+
+        let mut session_title_changed = sessions.clone();
+        session_title_changed[0].search_title = "renamed session".into();
+        assert_ne!(
+            fingerprint,
+            workspace_search_fingerprint(
+                &session_title_changed,
+                session_title_changed
+                    .iter()
+                    .map(|session| session.records.as_slice()),
+            )
+        );
+
+        let mut dialogue_title_changed = sessions.clone();
+        dialogue_title_changed[0].records[0].title = "renamed dialogue".into();
+        assert_ne!(
+            fingerprint,
+            workspace_search_fingerprint(
+                &dialogue_title_changed,
+                dialogue_title_changed
+                    .iter()
+                    .map(|session| session.records.as_slice()),
+            )
+        );
+
+        let mut body_changed = sessions;
+        body_changed[0].records[0].parts[0].data = sivtr_core::record::WorkPartData::User {
+            content: "changed body".into(),
+        };
+        assert_ne!(
+            fingerprint,
+            workspace_search_fingerprint(
+                &body_changed,
+                body_changed
+                    .iter()
+                    .map(|session| session.records.as_slice()),
+            )
+        );
     }
 
     #[test]

--- a/src/commands/browse/selection.rs
+++ b/src/commands/browse/selection.rs
@@ -110,7 +110,7 @@ pub(super) fn select_sources(
     selected_sources: &mut [bool],
     selection: WorkspaceSourceSelection,
 ) {
-    assert_eq!(sources.len(), selected_sources.len());
+    debug_assert_eq!(sources.len(), selected_sources.len());
     for (idx, source) in sources.iter().enumerate() {
         selected_sources[idx] = match selection {
             WorkspaceSourceSelection::All => true,

--- a/src/commands/browse/selection.rs
+++ b/src/commands/browse/selection.rs
@@ -110,13 +110,19 @@ pub(super) fn select_sources(
     selected_sources: &mut [bool],
     selection: WorkspaceSourceSelection,
 ) {
-    debug_assert_eq!(sources.len(), selected_sources.len());
-    for (idx, source) in sources.iter().enumerate() {
+    // The mask is normally built from `sources`, but a length mismatch must
+    // not index out of bounds in release builds (debug_assert! is compiled
+    // out): apply over the overlap and clear any stale flags beyond it.
+    let overlap = sources.len().min(selected_sources.len());
+    for (idx, source) in sources.iter().take(overlap).enumerate() {
         selected_sources[idx] = match selection {
             WorkspaceSourceSelection::All => true,
             WorkspaceSourceSelection::Agents => source.is_agent(),
             WorkspaceSourceSelection::Terminal => source.is_terminal(),
         };
+    }
+    for flag in &mut selected_sources[overlap..] {
+        *flag = false;
     }
 }
 

--- a/src/commands/browse/vim.rs
+++ b/src/commands/browse/vim.rs
@@ -102,21 +102,20 @@ fn remove_dir_all_with_retry(
             "cleanup attempts must be greater than zero",
         ));
     }
-    let mut last_error = None;
-
-    for attempt in 0..attempts {
+    let mut failed = 0;
+    loop {
         match remove(path) {
             Ok(()) => return Ok(()),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-            Err(error) => last_error = Some(error),
-        }
-
-        if attempt + 1 < attempts {
-            std::thread::sleep(retry_delay);
+            Err(error) => {
+                failed += 1;
+                if failed == attempts {
+                    return Err(error);
+                }
+                std::thread::sleep(retry_delay);
+            }
         }
     }
-
-    Err(last_error.expect("cleanup attempts must be greater than zero"))
 }
 
 fn finish_vim_view(operation: Result<()>, cleanup: Result<()>) -> Result<()> {

--- a/src/tui/search.rs
+++ b/src/tui/search.rs
@@ -83,13 +83,24 @@ pub(crate) struct WorkspaceSearchIndex {
     fingerprint: u64,
 }
 
-/// Fingerprint of the loaded dialogue corpus: hash of every record ref.
-/// Identical when the corpus has the same records in the same order.
-fn workspace_records_fingerprint(sessions: &[WorkspaceSession]) -> u64 {
+/// Fingerprint of every value consumed by [`WorkspaceSearchIndex`].
+pub(crate) fn workspace_search_fingerprint<'a>(
+    sessions: &[WorkspaceSession],
+    body_records: impl Iterator<Item = &'a [WorkRecord]>,
+) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    for session in sessions {
-        for record in &session.records {
+    sessions.len().hash(&mut hasher);
+    for (session, records) in sessions.iter().zip(body_records) {
+        session.search_title.hash(&mut hasher);
+        records.len().hash(&mut hasher);
+        for record in records {
             record.work_ref.whole().hash(&mut hasher);
+            record.title.hash(&mut hasher);
+            for part in &record.parts {
+                part.seq.hash(&mut hasher);
+                std::mem::discriminant(&part.kind()).hash(&mut hasher);
+                part.text().hash(&mut hasher);
+            }
         }
     }
     hasher.finish()
@@ -132,7 +143,10 @@ impl WorkspaceSearchIndex {
             }
         }
 
-        let fingerprint = workspace_records_fingerprint(sessions);
+        let fingerprint = workspace_search_fingerprint(
+            sessions,
+            sessions.iter().map(|session| session.records.as_slice()),
+        );
         Self {
             sessions: session_entries,
             dialogues: dialogue_entries,


### PR DESCRIPTION
The picker's parameter checks and the search index access panicked on
logically-impossible states; select_sources and the vim temp cleanup
had the same pattern. Parameter alignment is now a debug assertion, the
search index pair degrades to an empty result instead of panicking, and
the cleanup path returns a real error when no attempt error was
recorded.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved browse search reuse by caching the search index and source data together when they remain valid.

- **Bug Fixes**
  - Improved directory cleanup error handling after repeated removal failures.
  - Reduced unnecessary runtime failures for internal consistency checks while retaining validation during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->