### PR TITLE
chore(tui): name background loader threads and surface spawn failures

### DIFF
--- a/src/commands/browse/load.rs
+++ b/src/commands/browse/load.rs
@@ -486,13 +486,17 @@ impl SourceLoadPump {
                             self.body_failed.insert(ik, "no body content".into());
                             return true;
                         }
-                        let mut changed = false;
+                        let mut requested_applied = false;
                         for s in sessions {
-                            if state.pane.apply_body(&s.session_id, s.records) {
-                                changed = true;
+                            let requested = s.session_id == session_id;
+                            if state.pane.apply_body(&s.session_id, s.records) && requested {
+                                requested_applied = true;
                             }
                         }
-                        changed
+                        if !requested_applied {
+                            self.body_failed.insert(ik, "session not found".into());
+                        }
+                        true
                     }
                     Err(message) => {
                         // The body query itself failed (timeout, remote error,
@@ -928,6 +932,67 @@ mod tests {
         assert!(column.pump.body_failed.contains_key("0\0s1"));
 
         // And a sync pass must not re-spawn the settled key.
+        let keep: HashSet<(usize, String)> = [(0, "s1".into())].into();
+        column.pump.sync_bodies(&sources, &mut column.states, &keep);
+        assert!(column.pump.body_inflight.is_empty());
+    }
+
+    #[test]
+    fn unmatched_body_result_is_terminal_and_not_retried() {
+        let source = WorkspaceSource::agent(AgentProvider::Codex);
+        let sources = vec![source.clone()];
+        let meta = SessionMeta {
+            source: source.clone(),
+            session_id: "s1".into(),
+            modified: UNIX_EPOCH,
+            title: "s1".into(),
+            search_title: "s1".into(),
+        };
+        let other_meta = SessionMeta {
+            source: source.clone(),
+            session_id: "other".into(),
+            modified: UNIX_EPOCH,
+            title: "other".into(),
+            search_title: "other".into(),
+        };
+        let state = SourceLoadState {
+            pane: SessionPane::ready(
+                vec![
+                    WindowRow::meta_only("s1".into(), meta),
+                    WindowRow::meta_only("other".into(), other_meta),
+                ],
+                10,
+                true,
+            ),
+        };
+        let mut column = SessionColumn::new(sources.clone(), vec![state], PathBuf::from("."));
+
+        column.pump.body_inflight.insert("0\0s1".into());
+        let unmatched = JobEvent {
+            index: 0,
+            gen: 0,
+            kind: JobKind::Body {
+                session_id: "s1".into(),
+            },
+            result: Ok(vec![WorkspaceSession {
+                source,
+                session_id: "other".into(),
+                modified: UNIX_EPOCH,
+                title: "other".into(),
+                search_title: "other".into(),
+                records: vec![],
+                body_loaded: true,
+            }]),
+            exhausted: true,
+        };
+
+        assert!(column.pump.apply(unmatched, &mut column.states));
+        assert!(column.pump.body_inflight.is_empty());
+        assert_eq!(
+            column.pump.body_failed.get("0\0s1").map(String::as_str),
+            Some("session not found")
+        );
+
         let keep: HashSet<(usize, String)> = [(0, "s1".into())].into();
         column.pump.sync_bodies(&sources, &mut column.states, &keep);
         assert!(column.pump.body_inflight.is_empty());

--- a/src/commands/browse/load.rs
+++ b/src/commands/browse/load.rs
@@ -6,7 +6,7 @@
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
 use std::thread;
@@ -149,6 +149,11 @@ pub struct SourceLoadPump {
     rx: Receiver<JobEvent>,
     cwd: PathBuf,
     body_inflight: HashSet<String>,
+    /// `{source_idx}\0{session_id}` → error message for body loads that failed
+    /// (thread spawn refused or the body query errored). Failed keys are not
+    /// retried by [`SourceLoadPump::sync_bodies`] and stay reachable through
+    /// [`SessionColumn::body_failure`].
+    body_failed: HashMap<String, String>,
 }
 
 impl SourceLoadPump {
@@ -159,6 +164,7 @@ impl SourceLoadPump {
             rx,
             cwd,
             body_inflight: HashSet::new(),
+            body_failed: HashMap::new(),
         }
     }
 
@@ -270,7 +276,7 @@ impl SourceLoadPump {
             };
             for session_id in missing {
                 let ik = format!("{source_idx}\0{session_id}");
-                if self.body_inflight.contains(&ik) {
+                if self.body_inflight.contains(&ik) || self.body_failed.contains_key(&ik) {
                     continue;
                 }
                 self.body_inflight.insert(ik);
@@ -289,6 +295,8 @@ impl SourceLoadPump {
             }
             self.body_inflight
                 .retain(|k| !k.starts_with(&format!("{idx}\0")));
+            self.body_failed
+                .retain(|k, _| !k.starts_with(&format!("{idx}\0")));
         }
     }
 
@@ -407,15 +415,15 @@ impl SourceLoadPump {
                 });
             });
         if let Err(error) = spawned {
-            let _ = self.tx.send(JobEvent {
-                index: idx,
-                gen,
-                kind: JobKind::Body {
-                    session_id: session_id.to_string(),
-                },
-                result: Err(format!("failed to spawn body loader thread: {error}")),
-                exhausted: true,
-            });
+            // The OS refused to start the loader thread. Record the failure
+            // directly instead of routing it through the channel: the body
+            // event path used to discard such errors, leaving the session
+            // silently unloaded and re-spawned on every sync_bodies pass.
+            let ik = format!("{idx}\0{session_id}");
+            self.body_inflight.remove(&ik);
+            eprintln!("sivtr: failed to load session body: {error}");
+            self.body_failed
+                .insert(ik, format!("failed to spawn body loader thread: {error}"));
         }
     }
 
@@ -441,18 +449,28 @@ impl SourceLoadPump {
         };
         match ev.kind {
             JobKind::Body { session_id } => {
-                self.body_inflight
-                    .remove(&format!("{}\0{session_id}", ev.index));
-                let Ok(sessions) = ev.result else {
-                    return false;
-                };
-                let mut changed = false;
-                for s in sessions {
-                    if state.pane.apply_body(&s.session_id, s.records) {
-                        changed = true;
+                let ik = format!("{}\0{session_id}", ev.index);
+                self.body_inflight.remove(&ik);
+                match ev.result {
+                    Ok(sessions) => {
+                        let mut changed = false;
+                        for s in sessions {
+                            if state.pane.apply_body(&s.session_id, s.records) {
+                                changed = true;
+                            }
+                        }
+                        changed
+                    }
+                    Err(message) => {
+                        // The body query itself failed (timeout, remote error,
+                        // ...). Keep the message instead of discarding it and
+                        // stop the pump from retrying a key that cannot load.
+                        // `true` wakes the picker so the change is noticed.
+                        eprintln!("sivtr: failed to load session body: {message}");
+                        self.body_failed.insert(ik, message);
+                        true
                     }
                 }
-                changed
             }
             JobKind::Meta { budget } => match ev.result {
                 Ok(sessions) => {
@@ -805,6 +823,39 @@ mod tests {
         assert!(keep.contains(&(0, "a".into())));
         assert!(keep.contains(&(0, "b".into())));
         assert!(keep.contains(&(0, "c".into())));
+    }
+
+    #[test]
+    fn body_load_failure_is_preserved_and_not_retried() {
+        let source = WorkspaceSource::agent(AgentProvider::Codex);
+        let sources = vec![source.clone()];
+        let meta = SessionMeta {
+            source: source.clone(),
+            session_id: "s1".into(),
+            modified: UNIX_EPOCH,
+            title: "s1".into(),
+            search_title: "s1".into(),
+        };
+        let state = SourceLoadState {
+            pane: SessionPane::ready(vec![WindowRow::meta_only("s1".into(), meta)], 10, true),
+        };
+        let mut column = SessionColumn::new(sources.clone(), vec![state], PathBuf::from("."));
+
+        // Simulate a refused spawn / failed query for session "s1".
+        column
+            .pump
+            .body_failed
+            .insert("0\0s1".into(), "boom".into());
+
+        // The body is still missing from the pane, but a sync pass must not
+        // re-spawn the failed key or clear its recorded error.
+        let keep: HashSet<(usize, String)> = [(0, "s1".into())].into();
+        column.pump.sync_bodies(&sources, &mut column.states, &keep);
+        assert!(column.pump.body_inflight.is_empty());
+        assert_eq!(
+            column.pump.body_failed.get("0\0s1").map(String::as_str),
+            Some("boom")
+        );
     }
 
     fn test_record(session: &str, index: usize, title: &str, ended: &str) -> WorkRecord {

--- a/src/commands/browse/load.rs
+++ b/src/commands/browse/load.rs
@@ -433,17 +433,15 @@ impl SourceLoadPump {
                 });
             });
         if let Err(error) = spawned {
-            // The OS refused to start the loader thread. Record the failure
-            // directly instead of routing it through the channel: the body
-            // event path used to discard such errors, leaving the session
-            // silently unloaded and re-spawned on every sync_bodies pass.
-            let ik = format!("{idx}\0{session_id}");
-            self.body_inflight.remove(&ik);
-            // The failure is rendered as a `[!]` marker from `body_failed`;
-            // writing to stderr while the TUI owns the terminal would corrupt
-            // the frame buffer.
-            self.body_failed
-                .insert(ik, format!("failed to spawn body loader thread: {error}"));
+            let _ = self.tx.send(JobEvent {
+                index: idx,
+                gen,
+                kind: JobKind::Body {
+                    session_id: session_id.to_string(),
+                },
+                result: Err(format!("failed to spawn body loader thread: {error}")),
+                exhausted: true,
+            });
         }
     }
 

--- a/src/commands/browse/load.rs
+++ b/src/commands/browse/load.rs
@@ -86,6 +86,9 @@ impl SourceLoadState {
             StorePhase::Idle => SourceLoadMarker::Idle,
             StorePhase::Booting => SourceLoadMarker::Loading,
             StorePhase::Ready if store.list_inflight => SourceLoadMarker::Loading,
+            // A refresh or pagination failure with rows still on screen:
+            // keep the stale list visible but flag the failed load.
+            StorePhase::Ready if store.fail_message.is_some() => SourceLoadMarker::Failed,
             StorePhase::Ready => SourceLoadMarker::Ready,
             StorePhase::Failed => SourceLoadMarker::Failed,
         }
@@ -151,13 +154,17 @@ pub struct SourceLoadPump {
     body_inflight: HashSet<String>,
     /// `{source_idx}\0{session_id}` → error message for body loads that failed
     /// (thread spawn refused or the body query errored). Failed keys are not
-    /// retried by [`SourceLoadPump::sync_bodies`] and stay reachable through
-    /// [`SessionColumn::body_failure`].
+    /// retried by [`SourceLoadPump::sync_bodies`] until an explicit refresh or
+    /// the source is reselected.
     body_failed: HashMap<String, String>,
+    /// Per-source generation for body jobs. Bumped when a source is dropped so
+    /// events from a canceled job cannot apply bodies or record failures
+    /// against a newer selection of the same source.
+    body_generation: Vec<u64>,
 }
 
 impl SourceLoadPump {
-    pub fn new(_source_count: usize, cwd: PathBuf) -> Self {
+    pub fn new(source_count: usize, cwd: PathBuf) -> Self {
         let (tx, rx) = mpsc::channel();
         Self {
             tx,
@@ -165,6 +172,7 @@ impl SourceLoadPump {
             cwd,
             body_inflight: HashSet::new(),
             body_failed: HashMap::new(),
+            body_generation: vec![0; source_count],
         }
     }
 
@@ -202,6 +210,11 @@ impl SourceLoadPump {
             if !selected.get(idx).copied().unwrap_or(false) {
                 continue;
             }
+            // An explicit refresh is a retry: drop recorded body failures so
+            // transient errors (remote timeouts, temporary transport issues)
+            // get another chance once connectivity recovers.
+            self.body_failed
+                .retain(|k, _| !k.starts_with(&format!("{idx}\0")));
             if let Some(need) = states[idx].pane.force_meta(viewport) {
                 self.spawn_meta(idx, source, need.gen, need.budget);
             }
@@ -297,6 +310,11 @@ impl SourceLoadPump {
                 .retain(|k| !k.starts_with(&format!("{idx}\0")));
             self.body_failed
                 .retain(|k, _| !k.starts_with(&format!("{idx}\0")));
+            // Invalidate body jobs spawned for this source: their results
+            // must not touch the state of a later re-selection.
+            if let Some(gen) = self.body_generation.get_mut(idx) {
+                *gen = gen.saturating_add(1);
+            }
         }
     }
 
@@ -369,7 +387,7 @@ impl SourceLoadPump {
     }
 
     fn spawn_body(&mut self, idx: usize, source: &WorkspaceSource, session_id: &str) {
-        let gen = sources_list_gen_placeholder();
+        let gen = self.body_generation.get(idx).copied().unwrap_or(0);
         let selector = source.selector();
         let remote = source.is_remote();
         let cwd = self.cwd.clone();
@@ -449,6 +467,12 @@ impl SourceLoadPump {
         };
         match ev.kind {
             JobKind::Body { session_id } => {
+                // Ignore events from a canceled body job: after the source was
+                // dropped and reselected, an old thread's result must neither
+                // apply bodies nor record failures against the new selection.
+                if self.body_generation.get(ev.index).copied().unwrap_or(0) != ev.gen {
+                    return false;
+                }
                 let ik = format!("{}\0{session_id}", ev.index);
                 self.body_inflight.remove(&ik);
                 match ev.result {
@@ -495,11 +519,6 @@ impl SourceLoadPump {
             },
         }
     }
-}
-
-/// Body jobs do not use list_gen cancellation; placeholder keeps the event shape.
-fn sources_list_gen_placeholder() -> u64 {
-    0
 }
 
 // ── Session column as unified [`Pane`] ──────────────────────────────────
@@ -856,6 +875,57 @@ mod tests {
             column.pump.body_failed.get("0\0s1").map(String::as_str),
             Some("boom")
         );
+    }
+
+    #[test]
+    fn refresh_clears_failed_bodies_and_stale_jobs_are_ignored() {
+        let source = WorkspaceSource::agent(AgentProvider::Codex);
+        let sources = vec![source.clone()];
+        let meta = SessionMeta {
+            source: source.clone(),
+            session_id: "s1".into(),
+            modified: UNIX_EPOCH,
+            title: "s1".into(),
+            search_title: "s1".into(),
+        };
+        let state = SourceLoadState {
+            pane: SessionPane::ready(vec![WindowRow::meta_only("s1".into(), meta)], 10, true),
+        };
+        let mut column = SessionColumn::new(sources.clone(), vec![state], PathBuf::from("."));
+
+        // A recorded failure is retried by an explicit refresh ...
+        column
+            .pump
+            .body_failed
+            .insert("0\0s1".into(), "boom".into());
+        column.pump.refresh_selected(
+            &sources,
+            &[true],
+            &mut column.states,
+            Viewport {
+                first: 0,
+                visible: 10,
+            },
+        );
+        assert!(column.pump.body_failed.is_empty());
+
+        // ... and events from a body job spawned before a source was dropped
+        // must not record failures against the newer selection.
+        column.pump.drop_unselected(&[false], &mut column.states); // gen 0 -> 1
+        column.pump.body_inflight.insert("0\0s1".into()); // new selection re-spawned
+        let stale = JobEvent {
+            index: 0,
+            gen: 0,
+            kind: JobKind::Body {
+                session_id: "s1".into(),
+            },
+            result: Err("stale job failed".into()),
+            exhausted: true,
+        };
+        assert!(!column.pump.apply(stale, &mut column.states));
+        assert!(!column.pump.body_failed.contains_key("0\0s1"));
+        // The fresh in-flight marker for the new job is untouched.
+        assert!(column.pump.body_inflight.contains("0\0s1"));
     }
 
     fn test_record(session: &str, index: usize, title: &str, ended: &str) -> WorkRecord {

--- a/src/commands/browse/load.rs
+++ b/src/commands/browse/load.rs
@@ -640,6 +640,9 @@ impl Pane for SessionColumn {
     }
 
     fn is_fetching(&self) -> bool {
+        // Body hydration runs past metadata loading; keep the poll cycle alive
+        // until every in-flight body job reports, so completion and failure
+        // events do not sit undrained behind a one-hour idle timeout.
         self.states.iter().any(SourceLoadState::is_fetching) || self.pump.has_inflight_bodies()
     }
 }

--- a/src/commands/browse/load.rs
+++ b/src/commands/browse/load.rs
@@ -439,7 +439,9 @@ impl SourceLoadPump {
             // silently unloaded and re-spawned on every sync_bodies pass.
             let ik = format!("{idx}\0{session_id}");
             self.body_inflight.remove(&ik);
-            eprintln!("sivtr: failed to load session body: {error}");
+            // The failure is rendered as a `[!]` marker from `body_failed`;
+            // writing to stderr while the TUI owns the terminal would corrupt
+            // the frame buffer.
             self.body_failed
                 .insert(ik, format!("failed to spawn body loader thread: {error}"));
         }
@@ -477,6 +479,15 @@ impl SourceLoadPump {
                 self.body_inflight.remove(&ik);
                 match ev.result {
                     Ok(sessions) => {
+                        if sessions.is_empty() {
+                            // A successful query that returned no records is
+                            // still a terminal outcome: leave the key out of
+                            // the retry set instead of respawning it on every
+                            // sync_bodies pass. `true` wakes the picker so the
+                            // `[!]` marker is noticed.
+                            self.body_failed.insert(ik, "no body content".into());
+                            return true;
+                        }
                         let mut changed = false;
                         for s in sessions {
                             if state.pane.apply_body(&s.session_id, s.records) {
@@ -490,7 +501,6 @@ impl SourceLoadPump {
                         // ...). Keep the message instead of discarding it and
                         // stop the pump from retrying a key that cannot load.
                         // `true` wakes the picker so the change is noticed.
-                        eprintln!("sivtr: failed to load session body: {message}");
                         self.body_failed.insert(ik, message);
                         true
                     }
@@ -885,6 +895,44 @@ mod tests {
             column.pump.body_failed.get("0\0s1").map(String::as_str),
             Some("boom")
         );
+    }
+
+    #[test]
+    fn empty_body_result_is_terminal_and_not_retried() {
+        let source = WorkspaceSource::agent(AgentProvider::Codex);
+        let sources = vec![source.clone()];
+        let meta = SessionMeta {
+            source: source.clone(),
+            session_id: "s1".into(),
+            modified: UNIX_EPOCH,
+            title: "s1".into(),
+            search_title: "s1".into(),
+        };
+        let state = SourceLoadState {
+            pane: SessionPane::ready(vec![WindowRow::meta_only("s1".into(), meta)], 10, true),
+        };
+        let mut column = SessionColumn::new(sources.clone(), vec![state], PathBuf::from("."));
+
+        // A successful body query that returns no records must still settle
+        // the key instead of respawning it on every sync_bodies pass.
+        column.pump.body_inflight.insert("0\0s1".into());
+        let empty = JobEvent {
+            index: 0,
+            gen: 0,
+            kind: JobKind::Body {
+                session_id: "s1".into(),
+            },
+            result: Ok(vec![]),
+            exhausted: true,
+        };
+        assert!(column.pump.apply(empty, &mut column.states));
+        assert!(column.pump.body_inflight.is_empty());
+        assert!(column.pump.body_failed.contains_key("0\0s1"));
+
+        // And a sync pass must not re-spawn the settled key.
+        let keep: HashSet<(usize, String)> = [(0, "s1".into())].into();
+        column.pump.sync_bodies(&sources, &mut column.states, &keep);
+        assert!(column.pump.body_inflight.is_empty());
     }
 
     #[test]

--- a/src/commands/browse/load.rs
+++ b/src/commands/browse/load.rs
@@ -308,42 +308,56 @@ impl SourceLoadPump {
         let cwd = self.cwd.clone();
         let tx = self.tx.clone();
         let source = source.clone();
-        thread::spawn(move || {
-            let qs = if remote {
-                QuerySource::remote(selector)
-            } else {
-                QuerySource::local(selector)
-            };
-            let (result, exhausted) = match workset::query_many(
-                &[qs],
-                Filter::browse_session_page(budget),
-                Some(&cwd),
-                REMOTE_QUERY_TIMEOUT,
-            ) {
-                Ok(mut results) => match results.pop() {
-                    Some(QuerySourceResult::Ok(set)) => {
-                        let n = set.records.len();
-                        let mut sessions = sessions_from_records(&source, set.records);
-                        for s in &mut sessions {
-                            s.records.clear();
-                            s.body_loaded = false;
+        let spawned = thread::Builder::new()
+            .name(format!("sivtr-meta-{idx}"))
+            .spawn(move || {
+                let qs = if remote {
+                    QuerySource::remote(selector)
+                } else {
+                    QuerySource::local(selector)
+                };
+                let (result, exhausted) = match workset::query_many(
+                    &[qs],
+                    Filter::browse_session_page(budget),
+                    Some(&cwd),
+                    REMOTE_QUERY_TIMEOUT,
+                ) {
+                    Ok(mut results) => match results.pop() {
+                        Some(QuerySourceResult::Ok(set)) => {
+                            let n = set.records.len();
+                            let mut sessions = sessions_from_records(&source, set.records);
+                            for s in &mut sessions {
+                                s.records.clear();
+                                s.body_loaded = false;
+                            }
+                            sessions.sort_by_key(|s| std::cmp::Reverse(s.modified));
+                            (Ok(sessions), n < budget)
                         }
-                        sessions.sort_by_key(|s| std::cmp::Reverse(s.modified));
-                        (Ok(sessions), n < budget)
-                    }
-                    Some(QuerySourceResult::Err(m)) => (Err(m), false),
-                    None => (Err("empty query".into()), false),
-                },
-                Err(e) => (Err(format!("{e:#}")), false),
-            };
-            let _ = tx.send(JobEvent {
+                        Some(QuerySourceResult::Err(m)) => (Err(m), false),
+                        None => (Err("empty query".into()), false),
+                    },
+                    Err(e) => (Err(format!("{e:#}")), false),
+                };
+                let _ = tx.send(JobEvent {
+                    index: idx,
+                    gen,
+                    kind: JobKind::Meta { budget },
+                    result,
+                    exhausted,
+                });
+            });
+        if let Err(error) = spawned {
+            // Without this event the pane would wait forever for a page that
+            // will never arrive; surface the spawn failure like any other
+            // query error.
+            let _ = self.tx.send(JobEvent {
                 index: idx,
                 gen,
                 kind: JobKind::Meta { budget },
-                result,
-                exhausted,
+                result: Err(format!("failed to spawn meta loader thread: {error}")),
+                exhausted: false,
             });
-        });
+        }
     }
 
     fn spawn_body(&mut self, idx: usize, source: &WorkspaceSource, session_id: &str) {
@@ -353,43 +367,56 @@ impl SourceLoadPump {
         let cwd = self.cwd.clone();
         let tx = self.tx.clone();
         let source = source.clone();
-        let session_id = session_id.to_string();
-        thread::spawn(move || {
-            let sel = format!("{selector}/{session_id}");
-            let qs = if remote {
-                QuerySource::remote(sel)
-            } else {
-                QuerySource::local(sel)
-            };
-            let result = match workset::query_many(
-                &[qs],
-                Filter::none(),
-                Some(&cwd),
-                REMOTE_QUERY_TIMEOUT,
-            ) {
-                Ok(mut results) => match results.pop() {
-                    Some(QuerySourceResult::Ok(set)) => {
-                        let mut sessions = sessions_from_records(&source, set.records);
-                        for s in &mut sessions {
-                            s.body_loaded = !s.records.is_empty();
+        let session_id_owned = session_id.to_string();
+        let spawned = thread::Builder::new()
+            .name(format!("sivtr-body-{idx}"))
+            .spawn(move || {
+                let sel = format!("{selector}/{session_id_owned}");
+                let qs = if remote {
+                    QuerySource::remote(sel)
+                } else {
+                    QuerySource::local(sel)
+                };
+                let result = match workset::query_many(
+                    &[qs],
+                    Filter::none(),
+                    Some(&cwd),
+                    REMOTE_QUERY_TIMEOUT,
+                ) {
+                    Ok(mut results) => match results.pop() {
+                        Some(QuerySourceResult::Ok(set)) => {
+                            let mut sessions = sessions_from_records(&source, set.records);
+                            for s in &mut sessions {
+                                s.body_loaded = !s.records.is_empty();
+                            }
+                            Ok(sessions)
                         }
-                        Ok(sessions)
-                    }
-                    Some(QuerySourceResult::Err(m)) => Err(m),
-                    None => Err("empty body".into()),
-                },
-                Err(e) => Err(format!("{e:#}")),
-            };
-            let _ = tx.send(JobEvent {
+                        Some(QuerySourceResult::Err(m)) => Err(m),
+                        None => Err("empty body".into()),
+                    },
+                    Err(e) => Err(format!("{e:#}")),
+                };
+                let _ = tx.send(JobEvent {
+                    index: idx,
+                    gen,
+                    kind: JobKind::Body {
+                        session_id: session_id_owned.clone(),
+                    },
+                    result,
+                    exhausted: true,
+                });
+            });
+        if let Err(error) = spawned {
+            let _ = self.tx.send(JobEvent {
                 index: idx,
                 gen,
                 kind: JobKind::Body {
-                    session_id: session_id.clone(),
+                    session_id: session_id.to_string(),
                 },
-                result,
+                result: Err(format!("failed to spawn body loader thread: {error}")),
                 exhausted: true,
             });
-        });
+        }
     }
 
     pub fn drain(&mut self, states: &mut [SourceLoadState]) -> bool {

--- a/src/commands/browse/load.rs
+++ b/src/commands/browse/load.rs
@@ -573,6 +573,13 @@ impl SessionColumn {
         self.states.get(idx)?.body(&session.session_id)
     }
 
+    /// Error message for a session whose body hydration failed, if any.
+    pub fn body_failure(&self, session: &WorkspaceSession) -> Option<&str> {
+        let idx = source_index_for_session(&self.sources, session)?;
+        let ik = format!("{}\0{}", idx, session.session_id);
+        self.pump.body_failed.get(&ik).map(String::as_str)
+    }
+
     /// Bootstrap / force-load selected sources.
     pub fn kick(&mut self, selected: &[bool], viewport: Viewport, force: bool) {
         self.pump

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -3,6 +3,7 @@ use crossterm::event::{
     self, Event, KeyCode, KeyEventKind, KeyModifiers, MouseButton, MouseEventKind,
 };
 use ratatui::widgets::ListState;
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use crate::tui::content::view::{content_link_at, ContentViewMode};
@@ -345,6 +346,10 @@ pub(crate) fn run(
             }
 
             let source_markers = sessions_pane.markers();
+            let body_failures: HashSet<String> = sessions
+                .iter()
+                .filter_map(|s| sessions_pane.body_failure(s).map(|_| s.session_id.clone()))
+                .collect();
             terminal.draw(|frame| {
                 render_workspace(
                     frame,
@@ -357,6 +362,7 @@ pub(crate) fn run(
                         sessions: &sessions,
                         selected_sessions: &selected_sessions,
                         session_state: &session_state,
+                        body_failures,
                         dialogue_titles: &dialogue_titles,
                         dialogues: &dialogues,
                         dialogue_state: &dialogue_state,

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -346,9 +346,13 @@ pub(crate) fn run(
             }
 
             let source_markers = sessions_pane.markers();
-            let body_failures: HashSet<String> = sessions
+            let body_failures: HashSet<(WorkspaceSource, String)> = sessions
                 .iter()
-                .filter_map(|s| sessions_pane.body_failure(s).map(|_| s.session_id.clone()))
+                .filter_map(|s| {
+                    sessions_pane
+                        .body_failure(s)
+                        .map(|_| (s.source.clone(), s.session_id.clone()))
+                })
                 .collect();
             terminal.draw(|frame| {
                 render_workspace(

--- a/src/pane/store.rs
+++ b/src/pane/store.rs
@@ -195,9 +195,12 @@ where
             return false;
         }
         self.list_inflight = false;
+        // Keep the message even when rows exist: a refresh/pagination failure
+        // after initial loading must not silently fall back to a stale list.
+        // The phase only hard-fails with nothing to show.
+        self.fail_message = Some(message);
         if self.rows.is_empty() {
             self.phase = StorePhase::Failed;
-            self.fail_message = Some(message);
         }
         true
     }
@@ -368,6 +371,21 @@ mod tests {
         assert_eq!(store.phase, StorePhase::Ready);
         assert!(store.list_inflight);
         assert_eq!(store.rows.len(), 1);
+    }
+
+    #[test]
+    fn apply_meta_err_preserves_message_when_rows_exist() {
+        let mut store: SlidingStore<u32, &str, String> =
+            SlidingStore::ready(vec![WindowRow::meta_only(1u32, "a")], 10, false);
+        store.begin_meta(1);
+        assert!(store.apply_meta_err(1, "refresh failed".into()));
+        assert_eq!(store.fail_message.as_deref(), Some("refresh failed"));
+        assert_eq!(store.phase, StorePhase::Ready, "rows remain browsable");
+
+        // A successful retry clears the error and the marker returns to Ready.
+        store.begin_meta(2);
+        assert!(store.apply_meta_ok(2, 10, true, vec![WindowRow::meta_only(2u32, "b")]));
+        assert_eq!(store.fail_message, None);
     }
 
     #[test]

--- a/src/tui/workspace/model.rs
+++ b/src/tui/workspace/model.rs
@@ -15,7 +15,7 @@ use crate::tui::search::WorkspaceSearchScope;
 use crate::tui::theme;
 
 /// Kind of memory source (local path body before any `scope:` prefix).
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum WorkspaceSourceKind {
     Terminal,
     Agent(AgentProvider),
@@ -66,7 +66,7 @@ impl WorkspaceSourceKind {
 
 /// One selectable Source pane entry. Local and remote share the same shape —
 /// remote is only a named scope that `workset::query` already understands.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct WorkspaceSource {
     /// Named scope (`desk`, `docs`); `None` = current local workspace.
     pub(crate) scope: Option<String>,
@@ -373,9 +373,11 @@ pub(crate) struct WorkspaceView<'a> {
     pub(crate) sessions: &'a [WorkspaceSession],
     pub(crate) selected_sessions: &'a [bool],
     pub(crate) session_state: &'a ListState,
-    /// Session ids whose body hydration failed (spawn or query error). Rows
-    /// render an error marker and the loader does not retry them.
-    pub(crate) body_failures: HashSet<String>,
+    /// `(source, session id)` pairs whose body hydration failed (spawn or
+    /// query error). Rows render an error marker and the loader does not retry
+    /// them. Source-qualified so a local session sharing an id with a remote
+    /// mirror does not mark the healthy row.
+    pub(crate) body_failures: HashSet<(WorkspaceSource, String)>,
     /// Dialogue list titles only (no body materialize on paint).
     pub(crate) dialogue_titles: &'a [&'a str],
     /// Materialized dialogues for content/copy (focus ∪ multi-select bodies).

--- a/src/tui/workspace/model.rs
+++ b/src/tui/workspace/model.rs
@@ -4,6 +4,7 @@ use ratatui::prelude::Color;
 use ratatui::widgets::ListState;
 use sivtr_core::ai::AgentProvider;
 use sivtr_core::record::{WorkAt, WorkRecord, WorkRef};
+use std::collections::HashSet;
 use std::time::SystemTime;
 
 use crate::commands::select::CommandSelection;
@@ -372,6 +373,9 @@ pub(crate) struct WorkspaceView<'a> {
     pub(crate) sessions: &'a [WorkspaceSession],
     pub(crate) selected_sessions: &'a [bool],
     pub(crate) session_state: &'a ListState,
+    /// Session ids whose body hydration failed (spawn or query error). Rows
+    /// render an error marker and the loader does not retry them.
+    pub(crate) body_failures: HashSet<String>,
     /// Dialogue list titles only (no body materialize on paint).
     pub(crate) dialogue_titles: &'a [&'a str],
     /// Materialized dialogues for content/copy (focus ∪ multi-select bodies).

--- a/src/tui/workspace/render.rs
+++ b/src/tui/workspace/render.rs
@@ -5,6 +5,7 @@ use ratatui::prelude::{Color, Frame, Modifier, Position, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Clear, ListItem, ListState, Paragraph};
 use regex::Regex;
+use std::collections::HashSet;
 use unicode_width::UnicodeWidthStr;
 
 use crate::tui::content::io::ContentIoFocus;
@@ -66,6 +67,7 @@ pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
         view.selected_sources,
         view.selected_sessions,
         view.session_state,
+        &view.body_failures,
         view.search.as_ref(),
         search_regex.as_ref(),
         view.focus == WorkspaceFocus::Sessions,
@@ -305,13 +307,15 @@ fn footer_status_spans(label: &str) -> Vec<Span<'static>> {
 
 /// Compact session row: `· cdx  title…` (origin glyph + short badge + title).
 ///
-/// `·` = local, `↗` = remote (named scope on the source or work_ref).
+/// `·` = local, `↗` = remote (named scope on the source or work_ref). A ` [!]`
+/// suffix marks a session whose body failed to hydrate.
 fn session_row_line(
     choice: &WorkspaceSession,
     selected: bool,
     active_panel: bool,
     base_style: Style,
     highlight: Option<&Regex>,
+    body_failed: bool,
 ) -> Line<'static> {
     let remote = choice.source.is_remote()
         || choice
@@ -332,7 +336,10 @@ fn session_row_line(
     let title = compact_session_title(choice);
     // Keep search highlighting over the full visible text, but paint origin/badge
     // with their own colors when the row is not using a solid selection background.
-    let plain = format!("{check}{origin} {badge}  {title}");
+    let plain = format!(
+        "{check}{origin} {badge}  {title}{}",
+        if body_failed { " [!]" } else { "" }
+    );
     if base_style.bg.is_some() {
         return Line::from(highlight_spans(&plain, highlight, base_style));
     }
@@ -359,6 +366,12 @@ fn session_row_line(
         highlight,
         Style::default().fg(Color::Rgb(226, 232, 240)),
     ));
+    if body_failed {
+        spans.push(Span::styled(
+            " [!]",
+            Style::default().fg(Color::Rgb(248, 113, 113)), // red-400
+        ));
+    }
     Line::from(spans)
 }
 
@@ -676,6 +689,7 @@ fn render_session_list(
     selected_sources: &[bool],
     selected_sessions: &[bool],
     state: &ListState,
+    body_failures: &HashSet<String>,
     search: Option<&WorkspaceSearchView<'_>>,
     search_regex: Option<&Regex>,
     active: bool,
@@ -699,7 +713,12 @@ fn render_session_list(
                 .filter(|search| search.scope == WorkspaceSearchScope::Session)
                 .and(search_regex);
             ListItem::new(session_row_line(
-                choice, selected, active, base_style, highlight,
+                choice,
+                selected,
+                active,
+                base_style,
+                highlight,
+                body_failures.contains(&choice.session_id),
             ))
         })
         .collect();

--- a/src/tui/workspace/render.rs
+++ b/src/tui/workspace/render.rs
@@ -689,7 +689,7 @@ fn render_session_list(
     selected_sources: &[bool],
     selected_sessions: &[bool],
     state: &ListState,
-    body_failures: &HashSet<String>,
+    body_failures: &HashSet<(WorkspaceSource, String)>,
     search: Option<&WorkspaceSearchView<'_>>,
     search_regex: Option<&Regex>,
     active: bool,
@@ -718,7 +718,7 @@ fn render_session_list(
                 active,
                 base_style,
                 highlight,
-                body_failures.contains(&choice.session_id),
+                body_failures.contains(&(choice.source.clone(), choice.session_id.clone())),
             ))
         })
         .collect();


### PR DESCRIPTION
The per-query loader threads were unnamed, so a panic inside them was
hard to attribute. Loaders now use thread::Builder with sivtr-meta-N /
sivtr-body-N names, and a thread-spawn failure posts a JobEvent error
through the normal channel so a pane cannot hang waiting for a page
that will never arrive.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session body-load failures are now clearly reported instead of remaining silently pending.
  * Failed loads are no longer retried automatically; explicit refreshes retry them.
  * Stale results from deselected sources are ignored.
  * Rows remain available when refresh or pagination errors occur.
  * Failed sessions display a visible `[!]` indicator.
  * Background polling continues while body loads are in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->