### PR TITLE
feat(tui): configurable theme with light/dark and truecolor detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -138,7 +138,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -165,11 +165,11 @@ dependencies = [
  "clipboard-win",
  "image",
  "log",
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
  "windows-sys 0.60.2",
@@ -196,6 +196,218 @@ name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "ashpd"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3d60bee1a1d38c2077030f4788e1b4e31058d2e79a8cfc8f2b440bd44db290"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.8.7",
+ "serde",
+ "serde_repr",
+ "url",
+ "zbus",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener 5.4.2",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.2",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.2",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -363,11 +575,33 @@ dependencies = [
 
 [[package]]
 name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2",
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -607,6 +841,15 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -890,6 +1133,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dark-light"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e1a09f280e29a8b00bc7e81eca5ac87dca0575639c9422a5fa25a07bb884b8"
+dependencies = [
+ "ashpd",
+ "async-std",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,7 +1237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1100,7 +1357,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1110,9 +1367,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -1204,10 +1461,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enum-assoc"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed8956bd5c1f0415200516e78ff07ec9e16415ade83c056c230d7b7ea0d55b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1227,7 +1511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1243,6 +1527,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.2",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1672,6 +1982,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2450,6 +2766,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lab"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2534,6 +2859,9 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "loom"
@@ -2735,7 +3063,7 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "569dfbdd2efd771b24ec9bb57f956e04d4fbfc72f62b2f11961723f9b3f4b020"
 dependencies = [
- "block2",
+ "block2 0.6.2",
  "dispatch2",
  "dlopen2",
  "ipnet",
@@ -2746,10 +3074,10 @@ dependencies = [
  "netlink-packet-core",
  "netlink-packet-route",
  "netlink-sys",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-wlan",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-system-configuration",
  "once_cell",
  "plist",
@@ -2959,7 +3287,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3020,6 +3348,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3035,9 +3379,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.0",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3047,10 +3391,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.6.2",
  "dispatch2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -3061,7 +3405,7 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.13.0",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
 ]
@@ -3073,9 +3417,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e34919aba0d701380d911702455038a8a3587467fe0141d6a71501e7ffe48"
 dependencies = [
  "bitflags 2.13.0",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-security",
  "objc2-security-foundation",
 ]
@@ -3088,14 +3432,26 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -3106,7 +3462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.13.0",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -3117,7 +3473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
 dependencies = [
  "bitflags 2.13.0",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -3127,8 +3483,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef76382e9cedd18123099f17638715cc3d81dba3637d4c0d39ab69df2ef345a5"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3140,7 +3496,7 @@ dependencies = [
  "bitflags 2.13.0",
  "dispatch2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-security",
 ]
@@ -3201,6 +3557,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3434,6 +3800,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3501,6 +3884,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3593,6 +3990,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prefix-trie"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3680,6 +4086,8 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
+ "libc",
+ "rand_chacha",
  "rand_core 0.6.4",
 ]
 
@@ -3695,10 +4103,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -4077,7 +4498,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4135,7 +4556,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4253,7 +4674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4330,6 +4751,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4507,6 +4939,7 @@ dependencies = [
  "clap",
  "criterion",
  "crossterm",
+ "dark-light",
  "dhat",
  "dialoguer",
  "dirs",
@@ -4581,7 +5014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4780,10 +5213,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4796,7 +5229,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5269,6 +5702,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5399,6 +5843,7 @@ dependencies = [
  "atomic",
  "getrandom 0.4.3",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -5407,6 +5852,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-bag"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068e763e8279de7ab94b6afebded2cb701678af094feb1c12ccb061b4783c1be"
 
 [[package]]
 name = "vcpkg"
@@ -5684,7 +6135,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5816,6 +6267,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5854,6 +6314,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5906,6 +6381,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5924,6 +6405,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5939,6 +6426,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5972,6 +6465,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5987,6 +6486,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6008,6 +6513,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6023,6 +6534,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6043,6 +6560,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6144,6 +6671,76 @@ dependencies = [
  "quote",
  "syn 2.0.118",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener 5.4.2",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6291,4 +6888,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e28c25bd8bb8da5a1f3e7065d0c156b9ee9a7973adf78b0e35eaefdf3b1b5c"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "url",
+ "winnow",
+ "zcheapstr",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d496a145685283b67e232bd9e47377f6b60ad9d51e3601b23867f77c42477f96"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629d80ece222cad20fe0e8741be493c4ab166acf3b85341bdc2cdbcfd8f3c2d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.3",
+ "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ chrono = { version = "0.4", features = ["clock"] }
 clap = { version = "4", features = ["derive"] }
 ratatui = "0.30"
 crossterm = "0.29"
+dark-light = "2.0.0"
 tokio = { version = "1", features = ["full"] }
 getrandom = "0.4"
 fs2 = "0.4"

--- a/crates/sivtr-core/src/config/mod.rs
+++ b/crates/sivtr-core/src/config/mod.rs
@@ -264,4 +264,23 @@ mod tests {
         assert!(toml.contains("idle_exit_secs = 60"));
         assert_eq!(SivtrConfig::default().mcp.idle_exit_secs, 0);
     }
+
+    #[test]
+    fn theme_config_round_trips_and_rejects_typos() {
+        let config = SivtrConfig {
+            theme: ThemeConfig {
+                mode: ThemeMode::Light,
+            },
+            ..SivtrConfig::default()
+        };
+
+        let toml = to_toml_string(&config).unwrap();
+        assert!(toml.contains("[theme]"));
+        assert!(toml.contains("mode = \"light\""));
+
+        // A typo such as `mode = "ligth"` must fail loudly instead of silently
+        // falling back to auto (which made the setting look ignored).
+        assert!(toml::from_str::<SivtrConfig>("[theme]\nmode = \"ligth\"\n").is_err());
+        assert!(toml::from_str::<SivtrConfig>("[theme]\nmode = \"light\"\n").is_ok());
+    }
 }

--- a/crates/sivtr-core/src/config/mod.rs
+++ b/crates/sivtr-core/src/config/mod.rs
@@ -98,7 +98,7 @@ pub enum ThemeMode {
 
 /// TUI theme configuration.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct ThemeConfig {
     /// Color scheme: `"auto"` (default), `"dark"`, or `"light"`.
     pub mode: ThemeMode,
@@ -282,5 +282,9 @@ mod tests {
         // falling back to auto (which made the setting look ignored).
         assert!(toml::from_str::<SivtrConfig>("[theme]\nmode = \"ligth\"\n").is_err());
         assert!(toml::from_str::<SivtrConfig>("[theme]\nmode = \"light\"\n").is_ok());
+
+        // A misspelled key (`mod` instead of `mode`) is rejected too; serde
+        // would otherwise ignore the unknown field and keep `mode` at auto.
+        assert!(toml::from_str::<SivtrConfig>("[theme]\nmod = \"light\"\n").is_err());
     }
 }

--- a/crates/sivtr-core/src/config/mod.rs
+++ b/crates/sivtr-core/src/config/mod.rs
@@ -20,6 +20,8 @@ pub struct SivtrConfig {
     pub codex: CodexConfig,
     /// Global hotkey settings.
     pub hotkey: HotkeyConfig,
+    /// TUI theme settings.
+    pub theme: ThemeConfig,
     /// MCP stdio server settings.
     pub mcp: McpConfig,
 }
@@ -79,6 +81,27 @@ pub struct CodexConfig {
 pub struct HotkeyConfig {
     /// Hotkey chord used by `sivtr hotkey start`.
     pub chord: String,
+}
+
+/// TUI color scheme preference.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ThemeMode {
+    /// Detect light/dark and truecolor support from the terminal environment.
+    #[default]
+    Auto,
+    /// Always use the dark palette.
+    Dark,
+    /// Always use the light palette.
+    Light,
+}
+
+/// TUI theme configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ThemeConfig {
+    /// Color scheme: `"auto"` (default), `"dark"`, or `"light"`.
+    pub mode: ThemeMode,
 }
 
 /// MCP stdio server settings (shared by every agent host registration —

--- a/src/commands/browse/help.rs
+++ b/src/commands/browse/help.rs
@@ -20,7 +20,7 @@ use super::content::{
 };
 use super::nav::{
     move_workspace_cursor_down, move_workspace_cursor_up, reset_workspace_after_source_change,
-    reset_workspace_dialogue_state, reset_workspace_search_state,
+    reset_workspace_dialogue_state,
 };
 use super::selection::{select_sources, WorkspaceSourceSelection};
 use super::vim::open_vim_view;
@@ -341,7 +341,7 @@ pub(super) fn apply_workspace_help_action(
             *show_search = true;
             search_query.clear();
             *search_dirty = true;
-            reset_workspace_search_state(
+            reset_workspace_after_source_change(
                 session_state,
                 selected_sessions,
                 dialogue_state,

--- a/src/commands/browse/nav.rs
+++ b/src/commands/browse/nav.rs
@@ -46,24 +46,6 @@ pub(super) fn reset_workspace_after_source_change(
     content_scrolls.clear();
 }
 
-pub(super) fn reset_workspace_search_state(
-    session_state: &mut ListState,
-    selected_sessions: &mut Vec<bool>,
-    dialogue_state: &mut ListState,
-    selected_dialogues: &mut Vec<bool>,
-    range_anchor: &mut Option<usize>,
-    content_scrolls: &mut ContentScrolls,
-) {
-    reset_workspace_after_source_change(
-        session_state,
-        selected_sessions,
-        dialogue_state,
-        selected_dialogues,
-        range_anchor,
-        content_scrolls,
-    );
-}
-
 pub(super) fn resize_workspace_dialogue_selection(
     dialogue_count: usize,
     selected_dialogues: &mut Vec<bool>,

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -419,17 +419,22 @@ pub(crate) fn run(
         }
 
         // Wait for input. While a load is in flight, keep a short poll so the
-        // spinner animates and results repaint without a keypress. When
-        // nothing is loading, block until an event arrives instead of
-        // redrawing the whole frame at a fixed rate.
+        // spinner animates and results repaint without a keypress. In auto
+        // theme mode, poll periodically so a system appearance change swaps
+        // the palette while the TUI stays up. When nothing is loading and the
+        // theme is fixed, block until an event arrives instead of redrawing
+        // the whole frame at a fixed rate.
         let poll_timeout = if sessions_pane.is_fetching() {
             std::time::Duration::from_millis(100)
         } else {
-            std::time::Duration::from_secs(3600)
+            crate::tui::theme::auto_interval().unwrap_or(std::time::Duration::from_secs(3600))
         };
         if !event::poll(poll_timeout)? {
             if sessions_pane.is_fetching() {
                 loading_tick = loading_tick.wrapping_add(1);
+                redraw = true;
+            }
+            if crate::tui::theme::refresh_if_changed() {
                 redraw = true;
             }
             continue;

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -433,8 +433,9 @@ pub(crate) fn run(
             if sessions_pane.is_fetching() {
                 loading_tick = loading_tick.wrapping_add(1);
                 redraw = true;
-            }
-            if crate::tui::theme::refresh_if_changed() {
+            } else if crate::tui::theme::refresh_if_changed() {
+                // Idle polls already honor `auto_interval`; a loading poll is
+                // too fast to re-probe the desktop portal on every tick.
                 redraw = true;
             }
             continue;

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -27,7 +27,7 @@ use super::help::{apply_workspace_help_action, set_focus, HelpDispatch};
 use super::load::{SessionColumn, SessionCtx, SourceLoadState};
 use super::nav::{
     clamp_list_state, move_workspace_cursor_down, move_workspace_cursor_up, open_link_target,
-    reset_workspace_dialogue_state, reset_workspace_search_state,
+    reset_workspace_after_source_change, reset_workspace_dialogue_state,
     resize_workspace_dialogue_selection, row_list_index, source_list_index,
 };
 use super::panes::{ContentCtx, ContentPane, DialogueCtx, DialoguePane, SourcePane};
@@ -518,7 +518,7 @@ pub(crate) fn run(
                             search_dirty = true;
                             search_apply_pending = false;
                             search_cursor = 0;
-                            reset_workspace_search_state(
+                            reset_workspace_after_source_change(
                                 &mut session_state,
                                 &mut selected_sessions,
                                 &mut dialogue_state,
@@ -726,7 +726,7 @@ pub(crate) fn run(
                             search_dirty = true;
                             search_cursor = 0;
                             search_apply_pending = false;
-                            reset_workspace_search_state(
+                            reset_workspace_after_source_change(
                                 &mut session_state,
                                 &mut selected_sessions,
                                 &mut dialogue_state,
@@ -995,7 +995,7 @@ fn search_query_edited(
     *search_dirty = true;
     *search_cursor = 0;
     *search_apply_pending = true;
-    reset_workspace_search_state(
+    reset_workspace_after_source_change(
         session_state,
         selected_sessions,
         dialogue_state,

--- a/src/tui/content/markdown.rs
+++ b/src/tui/content/markdown.rs
@@ -185,6 +185,16 @@ fn markdown_line_parts(line: &str) -> MarkdownLineParts<'_> {
         };
     }
 
+    // Read-mode fold summaries ("tools: Bash x2", "thinking x7").
+    if let Some(style) = fold_summary_style(trimmed) {
+        return MarkdownLineParts {
+            prefix: leading.to_string(),
+            prefix_style: Style::default(),
+            content: trimmed,
+            content_style: style,
+        };
+    }
+
     if let Some(rest) = trimmed.strip_prefix("> ") {
         return MarkdownLineParts {
             prefix: format!("{leading}> "),
@@ -723,15 +733,33 @@ fn agent_heading_style(text: &str) -> Option<Style> {
     Some(Style::default().fg(color).add_modifier(Modifier::BOLD))
 }
 
-/// Style for `<:channel:…:>` structure markers (tools/skills/thinking/mcp).
+/// Style for `<:channel:…:>` structure markers (tools/skills/thinking/mcp)
+/// and read-mode fold summaries: structural content renders in a subdued
+/// gray in every content mode, distinct from the default-foreground body.
 fn structure_marker_style(text: &str) -> Option<Style> {
-    // `<:/…:>` and ` result:>` are subsumed by the broader `<:` / ` result:`
-    // forms below, so they need no extra alternatives of their own.
     if !text.starts_with("<:") {
         return None;
     }
-    let is_result = text.contains(" result:");
-    Some(crate::tui::theme::structure_style(is_result))
+    Some(structural_gray_style())
+}
+
+/// Read-mode fold summaries produced by `collapse_structure_markers`
+/// (content/text.rs): `tools: …`, `mcp: …`, `skills: …`, `thinking xN`.
+fn fold_summary_style(text: &str) -> Option<Style> {
+    let channel = ["tools:", "mcp:", "skills:"]
+        .iter()
+        .any(|prefix| text.starts_with(prefix));
+    let thinking = text.strip_prefix("thinking").is_some_and(|rest| {
+        rest.is_empty()
+            || rest.strip_prefix(" x").is_some_and(|count| {
+                !count.is_empty() && count.chars().all(|ch| ch.is_ascii_digit())
+            })
+    });
+    (channel || thinking).then(structural_gray_style)
+}
+
+fn structural_gray_style() -> Style {
+    Style::default().fg(crate::tui::theme::muted())
 }
 
 fn heading_style(level: usize) -> Style {
@@ -816,27 +844,43 @@ mod tests {
         assert_eq!(
             lines[0].line.spans[1].style.fg,
             Some(crate::tui::theme::structure_color(false))
-        ); // Command
-        assert_eq!(
-            lines[1].line.spans[0].style.fg,
-            Some(crate::tui::theme::structure_color(false))
-        ); // tool call
-        assert_eq!(
-            lines[2].line.spans[0].style.fg,
-            Some(crate::tui::theme::structure_color(true))
-        ); // tool result
-        assert_eq!(
-            lines[3].line.spans[0].style.fg,
-            Some(crate::tui::theme::structure_color(false))
-        ); // skill
-        assert_eq!(
-            lines[4].line.spans[0].style.fg,
-            Some(crate::tui::theme::structure_color(false))
-        ); // thinking
+        ); // Command heading stays amber
+        for marker in [1, 2, 3, 4] {
+            assert_eq!(
+                lines[marker].line.spans[0].style.fg,
+                Some(crate::tui::theme::muted()),
+                "structure marker line {marker} must render gray"
+            );
+        }
         assert_eq!(
             lines[5].line.spans[1].style.fg,
             Some(crate::tui::theme::failure())
         ); // Error
+    }
+
+    #[test]
+    fn renders_read_mode_fold_summaries_in_gray() {
+        let lines = render_markdown_window(
+            &[
+                "tools: Bash x2",
+                "mcp: read_file",
+                "skills: sivtr-memory",
+                "thinking",
+                "thinking x7",
+            ],
+            0,
+            5,
+            80,
+        );
+
+        for line in lines {
+            assert_eq!(
+                line.line.spans[0].style.fg,
+                Some(crate::tui::theme::muted()),
+                "fold summary must render gray: {:?}",
+                line.line.spans[0].content
+            );
+        }
     }
 
     #[test]

--- a/src/tui/content/markdown.rs
+++ b/src/tui/content/markdown.rs
@@ -725,10 +725,12 @@ fn agent_heading_style(text: &str) -> Option<Style> {
 
 /// Style for `<:channel:…:>` structure markers (tools/skills/thinking/mcp).
 fn structure_marker_style(text: &str) -> Option<Style> {
-    if !(text.starts_with("<:") || text.starts_with("<:/")) {
+    // `<:/…:>` and ` result:>` are subsumed by the broader `<:` / ` result:`
+    // forms below, so they need no extra alternatives of their own.
+    if !text.starts_with("<:") {
         return None;
     }
-    let is_result = text.contains(" result:>") || text.contains(" result:");
+    let is_result = text.contains(" result:");
     Some(crate::tui::theme::structure_style(is_result))
 }
 

--- a/src/tui/content/markdown.rs
+++ b/src/tui/content/markdown.rs
@@ -1,5 +1,5 @@
 use pulldown_cmark::{Event, Options as MarkdownOptions, Parser, Tag, TagEnd};
-use ratatui::prelude::{Color, Modifier, Style};
+use ratatui::prelude::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use unicode_width::UnicodeWidthStr;
 
@@ -106,7 +106,7 @@ fn render_markdown_line(line: &str, in_code_block: &mut bool, width: usize) -> M
         return MarkdownLine {
             line: Line::from(Span::styled(
                 "─".repeat(width.max(3)),
-                structural_marker_style(),
+                structure_prefix_style(),
             )),
             kind: MarkdownLineKind::Normal,
             links: Vec::new(),
@@ -169,7 +169,7 @@ fn markdown_line_parts(line: &str) -> MarkdownLineParts<'_> {
         let style = agent_heading_style(rest).unwrap_or_else(|| heading_style(level));
         return MarkdownLineParts {
             prefix: format!("{leading}{} ", "#".repeat(level)),
-            prefix_style: structural_marker_style(),
+            prefix_style: structure_prefix_style(),
             content: rest,
             content_style: style,
         };
@@ -188,7 +188,7 @@ fn markdown_line_parts(line: &str) -> MarkdownLineParts<'_> {
     if let Some(rest) = trimmed.strip_prefix("> ") {
         return MarkdownLineParts {
             prefix: format!("{leading}> "),
-            prefix_style: structural_marker_style(),
+            prefix_style: structure_prefix_style(),
             content: rest,
             content_style: blockquote_style(),
         };
@@ -206,7 +206,7 @@ fn markdown_line_parts(line: &str) -> MarkdownLineParts<'_> {
     if let Some((marker, rest)) = markdown_list_item(trimmed) {
         return MarkdownLineParts {
             prefix: format!("{leading}{marker}"),
-            prefix_style: structural_marker_style(),
+            prefix_style: structure_prefix_style(),
             content: rest,
             content_style: Style::default(),
         };
@@ -232,7 +232,7 @@ fn markdown_heading(line: &str) -> Option<(usize, &str)> {
 fn markdown_task_item(line: &str) -> Option<(String, &str, Style)> {
     let (_marker, rest) = markdown_list_item(line)?;
     let (symbol, rest, style) = if let Some(rest) = rest.strip_prefix("[ ] ") {
-        ("□ ", rest, structural_marker_style())
+        ("□ ", rest, structure_prefix_style())
     } else {
         let rest = rest
             .strip_prefix("[x] ")
@@ -411,11 +411,11 @@ fn render_table_row(row: &TableRenderRow) -> MarkdownLine {
     }
 
     let mut spans = Vec::new();
-    spans.push(Span::styled("│ ", structural_marker_style()));
+    spans.push(Span::styled("│ ", structure_prefix_style()));
 
     for (idx, width) in row.widths.iter().enumerate() {
         if idx > 0 {
-            spans.push(Span::styled(" │ ", structural_marker_style()));
+            spans.push(Span::styled(" │ ", structure_prefix_style()));
         }
 
         let cell = row.cells.get(idx).map(String::as_str).unwrap_or_default();
@@ -426,7 +426,7 @@ fn render_table_row(row: &TableRenderRow) -> MarkdownLine {
         }
     }
 
-    spans.push(Span::styled(" │", structural_marker_style()));
+    spans.push(Span::styled(" │", structure_prefix_style()));
     MarkdownLine {
         line: Line::from(spans),
         kind: MarkdownLineKind::Table,
@@ -453,7 +453,7 @@ fn render_table_border(row: &TableRenderRow) -> Option<MarkdownLine> {
     line.push_str(right);
 
     Some(MarkdownLine {
-        line: Line::from(Span::styled(line, structural_marker_style())),
+        line: Line::from(Span::styled(line, structure_prefix_style())),
         kind: MarkdownLineKind::Table,
         links: Vec::new(),
     })
@@ -707,35 +707,20 @@ fn current_style(styles: &[Style]) -> Style {
 }
 
 fn agent_heading_style(text: &str) -> Option<Style> {
-    if text.starts_with("Assistant") {
-        Some(
-            Style::default()
-                .fg(Color::Green)
-                .add_modifier(Modifier::BOLD),
-        )
+    let color = if text.starts_with("Assistant") {
+        crate::tui::theme::success()
     } else if text.starts_with("User") {
-        Some(
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        )
+        crate::tui::theme::user()
     } else if text.starts_with("Command") {
-        Some(
-            Style::default()
-                .fg(Color::Yellow)
-                .add_modifier(Modifier::BOLD),
-        )
+        crate::tui::theme::structure_color(false)
     } else if text.starts_with("Error") {
-        Some(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD))
+        crate::tui::theme::failure()
     } else if text.starts_with("Output") {
-        Some(
-            Style::default()
-                .fg(Color::Blue)
-                .add_modifier(Modifier::BOLD),
-        )
+        crate::tui::theme::output()
     } else {
-        None
-    }
+        return None;
+    };
+    Some(Style::default().fg(color).add_modifier(Modifier::BOLD))
 }
 
 /// Style for `<:channel:…:>` structure markers (tools/skills/thinking/mcp).
@@ -743,17 +728,8 @@ fn structure_marker_style(text: &str) -> Option<Style> {
     if !(text.starts_with("<:") || text.starts_with("<:/")) {
         return None;
     }
-    // Result channels lean blue; everything else structural yellow.
     let is_result = text.contains(" result:>") || text.contains(" result:");
-    Some(
-        Style::default()
-            .fg(if is_result {
-                Color::Blue
-            } else {
-                Color::Yellow
-            })
-            .add_modifier(Modifier::BOLD),
-    )
+    Some(crate::tui::theme::structure_style(is_result))
 }
 
 fn heading_style(level: usize) -> Style {
@@ -763,48 +739,46 @@ fn heading_style(level: usize) -> Style {
     }
 }
 
-fn structural_marker_style() -> Style {
-    Style::default().fg(Color::DarkGray)
+fn structure_prefix_style() -> Style {
+    Style::default().fg(crate::tui::theme::dim())
 }
 
 fn task_done_marker_style() -> Style {
     Style::default()
-        .fg(Color::Green)
+        .fg(crate::tui::theme::success())
         .add_modifier(Modifier::BOLD)
 }
 
 fn code_style() -> Style {
-    Style::default().fg(Color::Gray)
+    Style::default().fg(crate::tui::theme::code())
 }
 
 fn code_block_style() -> Style {
-    Style::default().fg(Color::Gray)
+    Style::default().fg(crate::tui::theme::code())
 }
 
 fn code_block_margin_style() -> Style {
-    Style::default().fg(Color::DarkGray)
+    Style::default().fg(crate::tui::theme::dim())
 }
 
 fn code_fence_style() -> Style {
     Style::default()
-        .fg(Color::DarkGray)
+        .fg(crate::tui::theme::dim())
         .add_modifier(Modifier::ITALIC)
 }
 
 fn link_style() -> Style {
-    Style::default()
-        .fg(Color::Blue)
-        .add_modifier(Modifier::UNDERLINED)
+    crate::tui::theme::link_style()
 }
 
 fn blockquote_style() -> Style {
-    Style::default().fg(Color::Green)
+    Style::default().fg(crate::tui::theme::quote())
 }
 
 #[cfg(test)]
 mod tests {
     use super::{render_markdown_window, MarkdownLineKind, CODE_INDENT};
-    use ratatui::prelude::{Color, Modifier};
+    use ratatui::prelude::Modifier;
 
     #[test]
     fn renders_agent_headings_with_provider_roles() {
@@ -814,8 +788,11 @@ mod tests {
 
         assert_eq!(user.spans[0].content.as_ref(), "## ");
         assert_eq!(user.spans[1].content.as_ref(), "User");
-        assert_eq!(user.spans[1].style.fg, Some(Color::Cyan));
-        assert_eq!(assistant.spans[1].style.fg, Some(Color::Green));
+        assert_eq!(user.spans[1].style.fg, Some(crate::tui::theme::user()));
+        assert_eq!(
+            assistant.spans[1].style.fg,
+            Some(crate::tui::theme::success())
+        );
     }
 
     #[test]
@@ -834,12 +811,30 @@ mod tests {
             80,
         );
 
-        assert_eq!(lines[0].line.spans[1].style.fg, Some(Color::Yellow)); // Command
-        assert_eq!(lines[1].line.spans[0].style.fg, Some(Color::Yellow)); // tool call
-        assert_eq!(lines[2].line.spans[0].style.fg, Some(Color::Blue)); // tool result
-        assert_eq!(lines[3].line.spans[0].style.fg, Some(Color::Yellow)); // skill
-        assert_eq!(lines[4].line.spans[0].style.fg, Some(Color::Yellow)); // thinking
-        assert_eq!(lines[5].line.spans[1].style.fg, Some(Color::Red)); // Error
+        assert_eq!(
+            lines[0].line.spans[1].style.fg,
+            Some(crate::tui::theme::structure_color(false))
+        ); // Command
+        assert_eq!(
+            lines[1].line.spans[0].style.fg,
+            Some(crate::tui::theme::structure_color(false))
+        ); // tool call
+        assert_eq!(
+            lines[2].line.spans[0].style.fg,
+            Some(crate::tui::theme::structure_color(true))
+        ); // tool result
+        assert_eq!(
+            lines[3].line.spans[0].style.fg,
+            Some(crate::tui::theme::structure_color(false))
+        ); // skill
+        assert_eq!(
+            lines[4].line.spans[0].style.fg,
+            Some(crate::tui::theme::structure_color(false))
+        ); // thinking
+        assert_eq!(
+            lines[5].line.spans[1].style.fg,
+            Some(crate::tui::theme::failure())
+        ); // Error
     }
 
     #[test]
@@ -868,11 +863,11 @@ mod tests {
         let line = &lines[0].line;
 
         assert_eq!(line.spans[0].content.as_ref(), "- ");
-        assert_eq!(line.spans[0].style.fg, Some(Color::DarkGray));
+        assert_eq!(line.spans[0].style.fg, Some(crate::tui::theme::dim()));
         assert_eq!(line.spans[1].content.as_ref(), "bold");
         assert!(line.spans[1].style.add_modifier.contains(Modifier::BOLD));
         assert_eq!(line.spans[3].content.as_ref(), "code");
-        assert_eq!(line.spans[3].style.fg, Some(Color::Gray));
+        assert_eq!(line.spans[3].style.fg, Some(crate::tui::theme::code()));
         assert_eq!(line.spans[3].style.bg, None);
     }
 
@@ -884,7 +879,10 @@ mod tests {
         assert_eq!(line.spans[0].content.as_ref(), "em");
         assert!(line.spans[0].style.add_modifier.contains(Modifier::ITALIC));
         assert_eq!(line.spans[2].content.as_ref(), "site");
-        assert_eq!(line.spans[2].style.fg, Some(Color::Blue));
+        assert_eq!(
+            line.spans[2].style.fg,
+            Some(crate::tui::theme::link_style().fg.unwrap())
+        );
         assert!(line.spans[2]
             .style
             .add_modifier
@@ -902,7 +900,10 @@ mod tests {
 
         assert_eq!(line.spans[0].content.as_ref(), "See ");
         assert_eq!(line.spans[1].content.as_ref(), "https://example.com/docs");
-        assert_eq!(line.spans[1].style.fg, Some(Color::Blue));
+        assert_eq!(
+            line.spans[1].style.fg,
+            Some(crate::tui::theme::link_style().fg.unwrap())
+        );
         assert_eq!(line.spans[2].content.as_ref(), ".");
         assert_eq!(lines[0].links[0].start, 4);
         assert_eq!(lines[0].links[0].end, 28);
@@ -914,12 +915,21 @@ mod tests {
         let lines = render_markdown_window(&["> quote", "1. item"], 0, 2, 80);
 
         assert_eq!(lines[0].line.spans[0].content.as_ref(), "> ");
-        assert_eq!(lines[0].line.spans[0].style.fg, Some(Color::DarkGray));
+        assert_eq!(
+            lines[0].line.spans[0].style.fg,
+            Some(crate::tui::theme::dim())
+        );
         assert_eq!(lines[0].line.spans[1].content.as_ref(), "quote");
-        assert_eq!(lines[0].line.spans[1].style.fg, Some(Color::Green));
+        assert_eq!(
+            lines[0].line.spans[1].style.fg,
+            Some(crate::tui::theme::quote())
+        );
 
         assert_eq!(lines[1].line.spans[0].content.as_ref(), "1. ");
-        assert_eq!(lines[1].line.spans[0].style.fg, Some(Color::DarkGray));
+        assert_eq!(
+            lines[1].line.spans[0].style.fg,
+            Some(crate::tui::theme::dim())
+        );
         assert_eq!(lines[1].line.spans[1].content.as_ref(), "item");
     }
 
@@ -928,11 +938,17 @@ mod tests {
         let lines = render_markdown_window(&["- [ ] open", "- [x] done"], 0, 2, 80);
 
         assert_eq!(lines[0].line.spans[0].content.as_ref(), "□ ");
-        assert_eq!(lines[0].line.spans[0].style.fg, Some(Color::DarkGray));
+        assert_eq!(
+            lines[0].line.spans[0].style.fg,
+            Some(crate::tui::theme::dim())
+        );
         assert_eq!(lines[0].line.spans[1].content.as_ref(), "open");
 
         assert_eq!(lines[1].line.spans[0].content.as_ref(), "■ ");
-        assert_eq!(lines[1].line.spans[0].style.fg, Some(Color::Green));
+        assert_eq!(
+            lines[1].line.spans[0].style.fg,
+            Some(crate::tui::theme::success())
+        );
         assert_eq!(lines[1].line.spans[1].content.as_ref(), "done");
     }
 
@@ -941,7 +957,10 @@ mod tests {
         let lines = render_markdown_window(&["---"], 0, 1, 12);
 
         assert_eq!(lines[0].line.spans[0].content.as_ref(), "────────────");
-        assert_eq!(lines[0].line.spans[0].style.fg, Some(Color::DarkGray));
+        assert_eq!(
+            lines[0].line.spans[0].style.fg,
+            Some(crate::tui::theme::dim())
+        );
     }
 
     #[test]
@@ -991,7 +1010,10 @@ mod tests {
         assert_eq!(lines[1].kind, MarkdownLineKind::CodeBlock);
         assert_eq!(lines[1].line.spans[0].content.as_ref(), CODE_INDENT);
         assert_eq!(lines[1].line.spans[1].content.as_ref(), "-> value");
-        assert_eq!(lines[1].line.spans[1].style.fg, Some(Color::Gray));
+        assert_eq!(
+            lines[1].line.spans[1].style.fg,
+            Some(crate::tui::theme::code())
+        );
         assert_eq!(lines[2].kind, MarkdownLineKind::CodeFence);
         assert!(lines[2].line.spans.is_empty());
     }
@@ -1002,7 +1024,10 @@ mod tests {
 
         assert_eq!(lines[0].kind, MarkdownLineKind::CodeBlock);
         assert_eq!(lines[0].line.spans[1].content.as_ref(), "beta");
-        assert_eq!(lines[0].line.spans[1].style.fg, Some(Color::Gray));
+        assert_eq!(
+            lines[0].line.spans[1].style.fg,
+            Some(crate::tui::theme::code())
+        );
     }
 
     #[test]

--- a/src/tui/content/view.rs
+++ b/src/tui/content/view.rs
@@ -374,17 +374,16 @@ fn visible_content_lines(
         .collect()
 }
 
+/// Lay the document out per mode. Read/fold renders markdown (tables, code
+/// fences, headings, links); raw/full keeps the text literal but still
+/// styles structure markers in gray — so both modes share one body/structure
+/// color treatment and differ only in markdown layout.
 fn all_content_lines(text: &str, width: usize, mode: ContentViewMode) -> Vec<ContentLine> {
     let lines = raw_lines(text);
     let logical_lines = match mode {
         ContentViewMode::Raw => lines
             .iter()
-            .map(|line| Line::from((*line).to_string()))
-            .map(|line| ContentLine {
-                line,
-                kind: MarkdownLineKind::Normal,
-                links: Vec::new(),
-            })
+            .map(|line| raw_content_line(line))
             .collect::<Vec<_>>(),
         ContentViewMode::Reading => render_markdown_lines(&lines, width)
             .into_iter()
@@ -408,6 +407,22 @@ fn all_content_lines(text: &str, width: usize, mode: ContentViewMode) -> Vec<Con
         .into_iter()
         .flat_map(|line| fit_content_line(line, width))
         .collect()
+}
+
+/// Literal rendering for raw/full content: no markdown layout, but
+/// `<:channel:…:>` structure markers use the same structural gray as
+/// read/fold summaries so the two modes stay visually consistent.
+fn raw_content_line(line: &str) -> ContentLine {
+    let style = if line.starts_with("<:") {
+        Style::default().fg(crate::tui::theme::muted())
+    } else {
+        Style::default()
+    };
+    ContentLine {
+        line: Line::from(Span::styled(line.to_string(), style)),
+        kind: MarkdownLineKind::Normal,
+        links: Vec::new(),
+    }
 }
 
 /// Lay out the document and converge the gutter width (digit count of the
@@ -1395,13 +1410,34 @@ mod tests {
     }
 
     #[test]
-    fn raw_content_lines_preserve_markdown_syntax() {
-        let rendered =
-            render_content_lines("```text\n**bold**\n```", 0, 3, None, ContentViewMode::Raw);
+    fn raw_mode_keeps_literal_layout_but_styles_markers_gray() {
+        // Raw/full renders tables, code fences, and inline markup literally —
+        // no markdown layout — while `<:…:>` structure markers share the same
+        // structural gray as read-mode fold summaries.
+        let rendered = render_content_lines(
+            "plain body\n<:tool:bash call:>\n```\n**bold**\n```\n| a | b |",
+            0,
+            6,
+            None,
+            ContentViewMode::Raw,
+        );
 
-        assert_eq!(rendered.lines[0].spans[0].content.as_ref(), "```text");
-        assert_eq!(rendered.lines[1].spans[0].content.as_ref(), "**bold**");
+        assert_eq!(rendered.lines[0].spans[0].content.as_ref(), "plain body");
+        assert_eq!(rendered.lines[0].spans[0].style.fg, None);
+        assert_eq!(
+            rendered.lines[1].spans[0].content.as_ref(),
+            "<:tool:bash call:>"
+        );
+        assert_eq!(
+            rendered.lines[1].spans[0].style.fg,
+            Some(crate::tui::theme::muted())
+        );
+        // Literal: fences, emphasis, and table pipes stay as-is.
         assert_eq!(rendered.lines[2].spans[0].content.as_ref(), "```");
+        assert_eq!(rendered.lines[3].spans[0].content.as_ref(), "**bold**");
+        assert_eq!(rendered.lines[4].spans[0].content.as_ref(), "```");
+        assert_eq!(rendered.lines[5].spans[0].content.as_ref(), "| a | b |");
+        assert_eq!(rendered.lines[5].spans[0].style.fg, None);
     }
 
     #[test]

--- a/src/tui/content/view.rs
+++ b/src/tui/content/view.rs
@@ -517,7 +517,7 @@ fn selection_range_for_line(
 }
 
 fn visual_selection_style() -> Style {
-    Style::default().fg(Color::White).bg(Color::DarkGray)
+    crate::tui::theme::selected_row()
 }
 
 fn style_line_columns(
@@ -980,10 +980,9 @@ fn separator_lines(height: usize, visible: &[ContentLine]) -> Text<'static> {
 fn gutter_style(kind: Option<MarkdownLineKind>) -> Style {
     match kind {
         Some(MarkdownLineKind::CodeBlock | MarkdownLineKind::CodeFence) => {
-            Style::default().fg(Color::Blue)
+            Style::default().fg(crate::tui::theme::accent())
         }
-        Some(MarkdownLineKind::Table) => Style::default().fg(Color::DarkGray),
-        _ => Style::default().fg(Color::DarkGray),
+        _ => Style::default().fg(crate::tui::theme::dim()),
     }
 }
 
@@ -1018,7 +1017,9 @@ pub(crate) fn highlight_spans(
         }
         spans.push(Span::styled(
             text[matched.start()..matched.end()].to_string(),
-            base_style.fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            base_style
+                .fg(crate::tui::theme::range_fg())
+                .add_modifier(Modifier::BOLD),
         ));
         cursor = matched.end();
     }
@@ -1101,7 +1102,9 @@ fn split_span_by_matches(
         }
         pieces.push(Span::styled(
             text[start - span_start..end - span_start].to_string(),
-            span.style.fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            span.style
+                .fg(crate::tui::theme::range_fg())
+                .add_modifier(Modifier::BOLD),
         ));
         cursor = end;
     }
@@ -1147,7 +1150,7 @@ mod tests {
     use crate::tui::pane::Panel;
     use ratatui::backend::TestBackend;
     use ratatui::layout::Rect;
-    use ratatui::prelude::{Color, Modifier};
+    use ratatui::prelude::Modifier;
     use ratatui::text::Text;
     use ratatui::Terminal;
     use regex::Regex;
@@ -1217,13 +1220,19 @@ mod tests {
         assert_eq!(rendered.lines.len(), 2);
         assert_eq!(rendered.lines[0].spans[0].content.as_ref(), "## ");
         assert_eq!(rendered.lines[0].spans[1].content.as_ref(), "User");
-        assert_eq!(rendered.lines[0].spans[1].style.fg, Some(Color::Cyan));
+        assert_eq!(
+            rendered.lines[0].spans[1].style.fg,
+            Some(crate::tui::theme::user())
+        );
         assert!(rendered.lines[1].spans[0]
             .style
             .add_modifier
             .contains(Modifier::BOLD));
         assert_eq!(rendered.lines[1].spans[2].content.as_ref(), "code");
-        assert_eq!(rendered.lines[1].spans[2].style.fg, Some(Color::Gray));
+        assert_eq!(
+            rendered.lines[1].spans[2].style.fg,
+            Some(crate::tui::theme::code())
+        );
         assert_eq!(rendered.lines[1].spans[2].style.bg, None);
         assert_eq!(line_count("## User\n**bold** and `code`"), 2);
     }
@@ -1240,7 +1249,10 @@ mod tests {
         );
 
         assert_eq!(rendered.lines[0].spans[0].content.as_ref(), "bold");
-        assert_eq!(rendered.lines[0].spans[0].style.fg, Some(Color::Yellow));
+        assert_eq!(
+            rendered.lines[0].spans[0].style.fg,
+            Some(crate::tui::theme::range_fg())
+        );
         assert!(rendered.lines[0].spans[0]
             .style
             .add_modifier
@@ -1455,8 +1467,14 @@ mod tests {
 
         assert_eq!(rendered.lines[0].spans[1].content.as_ref(), "bcd");
         assert_eq!(rendered.lines[1].spans[1].content.as_ref(), "vwx");
-        assert_eq!(rendered.lines[0].spans[1].style.bg, Some(Color::DarkGray));
-        assert_eq!(rendered.lines[1].spans[1].style.bg, Some(Color::DarkGray));
+        assert_eq!(
+            rendered.lines[0].spans[1].style.bg,
+            crate::tui::theme::selected_row().bg
+        );
+        assert_eq!(
+            rendered.lines[1].spans[1].style.bg,
+            crate::tui::theme::selected_row().bg
+        );
     }
 
     #[test]
@@ -1474,7 +1492,10 @@ mod tests {
 
         assert_eq!(rendered_line_text(&rendered, 0), "alpha");
         assert_eq!(rendered.lines[0].spans[1].content.as_ref(), "lph");
-        assert_eq!(rendered.lines[0].spans[1].style.bg, Some(Color::DarkGray));
+        assert_eq!(
+            rendered.lines[0].spans[1].style.bg,
+            crate::tui::theme::selected_row().bg
+        );
     }
 
     #[test]

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -94,7 +94,7 @@ pub fn init() -> Result<Tui> {
     // terminal environment. A missing config file already yields defaults;
     // a real read/parse failure must surface instead of silently looking
     // like the theme setting was ignored.
-    let config = SivtrConfig::load().context("Failed to load theme config")?;
+    let config = SivtrConfig::load().context("Failed to load the sivtr config file")?;
     theme::apply(config.theme.mode);
 
     let mut setup = TerminalSetup::default();

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -91,8 +91,10 @@ pub fn init() -> Result<Tui> {
 
     // Pick the palette before the first frame draws: honor the config
     // override, otherwise detect light/dark and truecolor from the
-    // terminal environment.
-    let config = SivtrConfig::load().unwrap_or_default();
+    // terminal environment. A missing config file already yields defaults;
+    // a real read/parse failure must surface instead of silently looking
+    // like the theme setting was ignored.
+    let config = SivtrConfig::load().context("Failed to load theme config")?;
     theme::apply(config.theme.mode);
 
     let mut setup = TerminalSetup::default();

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -13,6 +13,7 @@ use crossterm::{
     terminal::{enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use ratatui::{buffer::CellDiffOption, prelude::*};
+use sivtr_core::config::SivtrConfig;
 #[cfg(windows)]
 use std::cell::Cell;
 use std::io::IsTerminal;
@@ -27,6 +28,7 @@ use std::{
 use unicode_width::UnicodeWidthStr;
 
 use super::panic;
+use crate::tui::theme;
 
 type InnerTui = Terminal<CrosstermBackend<Stdout>>;
 
@@ -86,6 +88,12 @@ pub fn init() -> Result<Tui> {
     // here too. `install` is idempotent, and `register_panic_restore` below arms the closure.
     panic::install();
     ensure_tui_stdout()?;
+
+    // Pick the palette before the first frame draws: honor the config
+    // override, otherwise detect light/dark and truecolor from the
+    // terminal environment.
+    let config = SivtrConfig::load().unwrap_or_default();
+    theme::apply(config.theme.mode);
 
     let mut setup = TerminalSetup::default();
     match ConsoleInputHandle::ensure_console() {

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -292,6 +292,9 @@ impl Theme {
 thread_local! {
     static ACTIVE: Cell<Theme> = const { Cell::new(Theme::dark()) };
     static PREFERENCE: Cell<ThemeMode> = const { Cell::new(ThemeMode::Auto) };
+    /// Latched once `dark_light::detect()` errors, so the event loop stops
+    /// re-probing an unavailable desktop portal on every poll.
+    static DETECT_FAILED: Cell<bool> = const { Cell::new(false) };
 }
 
 /// Pick the palette for this process. The preference decides light vs dark —
@@ -322,32 +325,46 @@ pub(crate) fn apply(preference: ThemeMode) {
     ACTIVE.set(theme);
 }
 
-/// Truecolor when the terminal advertises it (`COLORTERM=truecolor|24bit`).
+/// Truecolor when the terminal advertises it: `COLORTERM=truecolor|24bit`,
+/// or a `-direct` terminfo name (`xterm-direct`, …) for terminals that do
+/// not export `COLORTERM` (tmux and screen often strip it).
 fn supports_truecolor() -> bool {
     matches!(
         std::env::var("COLORTERM").as_deref(),
         Ok("truecolor") | Ok("24bit")
-    )
+    ) || std::env::var("TERM")
+        .as_deref()
+        .is_ok_and(|term| term.ends_with("-direct"))
 }
 
 /// Light when the desktop session reports a light appearance. Cross-platform
 /// (macOS / Linux XDG portal / Windows registry) via `dark-light`; anything
-/// else — dark, unspecified, or a detection error — stays dark.
+/// else — dark, unspecified, or a detection error — stays dark. The first
+/// error is latched so the event loop stops re-probing the portal.
 fn light_from_system() -> bool {
-    matches!(dark_light::detect(), Ok(Mode::Light))
+    match dark_light::detect() {
+        Ok(Mode::Light) => true,
+        Ok(_) => false,
+        Err(_) => {
+            DETECT_FAILED.set(true);
+            false
+        }
+    }
 }
 
 /// Poll interval for appearance changes while the theme is in auto mode.
-/// `None` when a fixed dark/light palette is active, so the event loop does
-/// not wake up to re-check.
+/// `None` when a fixed dark/light palette is active or detection has failed,
+/// so the event loop does not wake up to re-check.
 pub(crate) fn auto_interval() -> Option<Duration> {
-    (PREFERENCE.get() == ThemeMode::Auto).then_some(AUTO_POLL_INTERVAL)
+    let auto = PREFERENCE.get() == ThemeMode::Auto && !DETECT_FAILED.get();
+    auto.then_some(AUTO_POLL_INTERVAL)
 }
 
 /// Re-check the system appearance and swap the palette when it changed.
-/// Returns true when the next frame must be redrawn. No-op outside auto mode.
+/// Returns true when the next frame must be redrawn. No-op outside auto mode
+/// or once detection has failed.
 pub(crate) fn refresh_if_changed() -> bool {
-    if PREFERENCE.get() != ThemeMode::Auto {
+    if PREFERENCE.get() != ThemeMode::Auto || DETECT_FAILED.get() {
         return false;
     }
     let before = ACTIVE.get().mode;

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -1,52 +1,184 @@
 //! Shared TUI palette — keep panel chrome and list accents consistent.
+//!
+//! The active palette lives in a thread-local so the existing accessor call
+//! sites (`accent()`, `focus_row()`, …) stay unchanged while the palette is
+//! chosen once at TUI startup from the terminal environment and the optional
+//! `[theme]` config section.
 
 use ratatui::prelude::{Color, Modifier, Style};
 use sivtr_core::ai::AgentProvider;
+use sivtr_core::config::ThemeMode;
+use std::cell::Cell;
+
+/// One palette: chrome, text, and selection colors for a color scheme.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Theme {
+    pub(crate) accent: Color,
+    pub(crate) muted: Color,
+    pub(crate) dim: Color,
+    pub(crate) local_origin: Color,
+    pub(crate) remote_origin: Color,
+    pub(crate) focus_bg: Color,
+    pub(crate) focus_fg: Color,
+    pub(crate) selected_bg: Color,
+    pub(crate) selected_fg: Color,
+    pub(crate) range_fg: Color,
+    pub(crate) title_active: Color,
+    pub(crate) muted_text: Color,
+    pub(crate) key_hint: Color,
+    pub(crate) footer: Color,
+    pub(crate) text_primary: Color,
+    pub(crate) failure: Color,
+}
+
+impl Theme {
+    /// Dark-background palette (the default).
+    pub(crate) const fn dark() -> Self {
+        Self {
+            accent: Color::Rgb(56, 189, 248),         // sky-400
+            muted: Color::Rgb(100, 116, 139),         // slate-500
+            dim: Color::Rgb(71, 85, 105),             // slate-600
+            local_origin: Color::Rgb(52, 211, 153),   // emerald-400
+            remote_origin: Color::Rgb(244, 114, 182), // pink-400
+            focus_bg: Color::Rgb(30, 64, 175),        // blue-800
+            focus_fg: Color::Rgb(240, 249, 255),      // slate-50
+            selected_bg: Color::Rgb(51, 65, 85),      // slate-700
+            selected_fg: Color::Rgb(226, 232, 240),   // slate-200
+            range_fg: Color::Rgb(251, 191, 36),       // amber-400
+            title_active: Color::Rgb(224, 242, 254),  // sky-100
+            muted_text: Color::Rgb(203, 213, 225),    // slate-300
+            key_hint: Color::Rgb(125, 211, 252),      // sky-300
+            footer: Color::Rgb(148, 163, 184),        // slate-400
+            text_primary: Color::Rgb(226, 232, 240),  // slate-200
+            failure: Color::Rgb(248, 113, 113),       // red-400
+        }
+    }
+
+    /// Light-background palette (darker variants of the same hues).
+    pub(crate) const fn light() -> Self {
+        Self {
+            accent: Color::Rgb(2, 132, 199),         // sky-600
+            muted: Color::Rgb(100, 116, 139),        // slate-500
+            dim: Color::Rgb(148, 163, 184),          // slate-400
+            local_origin: Color::Rgb(5, 150, 105),   // emerald-600
+            remote_origin: Color::Rgb(219, 39, 119), // pink-600
+            focus_bg: Color::Rgb(219, 234, 254),     // blue-100
+            focus_fg: Color::Rgb(30, 41, 59),        // slate-800
+            selected_bg: Color::Rgb(226, 232, 240),  // slate-200
+            selected_fg: Color::Rgb(51, 65, 85),     // slate-700
+            range_fg: Color::Rgb(217, 119, 6),       // amber-600
+            title_active: Color::Rgb(15, 23, 42),    // slate-900
+            muted_text: Color::Rgb(100, 116, 139),   // slate-500
+            key_hint: Color::Rgb(3, 105, 161),       // sky-700
+            footer: Color::Rgb(71, 85, 105),         // slate-600
+            text_primary: Color::Rgb(30, 41, 59),    // slate-800
+            failure: Color::Rgb(220, 38, 38),        // red-600
+        }
+    }
+
+    /// Terminal-defined palette for terminals without truecolor: ANSI 16
+    /// colors render correctly everywhere, while RGB sequences may be
+    /// ignored or mis-mapped by older terminals.
+    pub(crate) const fn ansi() -> Self {
+        Self {
+            accent: Color::Cyan,
+            muted: Color::DarkGray,
+            dim: Color::DarkGray,
+            local_origin: Color::Green,
+            remote_origin: Color::Magenta,
+            focus_bg: Color::Blue,
+            focus_fg: Color::White,
+            selected_bg: Color::DarkGray,
+            selected_fg: Color::White,
+            range_fg: Color::Yellow,
+            title_active: Color::White,
+            muted_text: Color::Gray,
+            key_hint: Color::Cyan,
+            footer: Color::Gray,
+            text_primary: Color::Gray,
+            failure: Color::Red,
+        }
+    }
+}
+
+thread_local! {
+    static ACTIVE: Cell<Theme> = const { Cell::new(Theme::dark()) };
+}
+
+/// Pick the palette for this process from the config preference
+/// (auto-detect from the environment when not overridden).
+pub(crate) fn apply(preference: ThemeMode) {
+    let theme = match preference {
+        ThemeMode::Auto => detect(),
+        ThemeMode::Dark => Theme::dark(),
+        ThemeMode::Light => Theme::light(),
+    };
+    ACTIVE.set(theme);
+}
+
+fn detect() -> Theme {
+    if supports_truecolor() {
+        if light_background() {
+            Theme::light()
+        } else {
+            Theme::dark()
+        }
+    } else {
+        Theme::ansi()
+    }
+}
+
+/// Truecolor when the terminal advertises it (`COLORTERM=truecolor|24bit`).
+fn supports_truecolor() -> bool {
+    matches!(
+        std::env::var("COLORTERM").as_deref(),
+        Ok("truecolor") | Ok("24bit")
+    )
+}
+
+/// Light background when `COLORFGBG`'s background half is a bright ANSI
+/// color (8–15); anything else (dark, unset, `default`) stays dark.
+fn light_background() -> bool {
+    std::env::var("COLORFGBG")
+        .ok()
+        .and_then(|value| value.rsplit(';').next()?.parse::<u8>().ok())
+        .is_some_and(|background| background >= 8)
+}
 
 /// Active panel chrome (focused border / scrollbar).
 pub(crate) fn accent() -> Color {
-    Color::Rgb(56, 189, 248) // sky-400
+    ACTIVE.get().accent
 }
 
 /// Inactive panel chrome.
 pub(crate) fn muted() -> Color {
-    Color::Rgb(100, 116, 139) // slate-500
+    ACTIVE.get().muted
 }
 
 /// Dim text / empty placeholders.
 pub(crate) fn dim() -> Color {
-    Color::Rgb(71, 85, 105) // slate-600
-}
-
-/// Local origin marker.
-pub(crate) fn local_origin() -> Color {
-    Color::Rgb(52, 211, 153) // emerald-400
-}
-
-/// Remote origin marker.
-pub(crate) fn remote_origin() -> Color {
-    Color::Rgb(244, 114, 182) // pink-400
+    ACTIVE.get().dim
 }
 
 /// Cursor / focus highlight on a list row.
 pub(crate) fn focus_row() -> Style {
+    let theme = ACTIVE.get();
     Style::default()
-        .bg(Color::Rgb(30, 64, 175)) // blue-800
-        .fg(Color::Rgb(240, 249, 255)) // slate-50
+        .bg(theme.focus_bg)
+        .fg(theme.focus_fg)
         .add_modifier(Modifier::BOLD)
 }
 
 /// Multi-selected row (not necessarily focused).
 pub(crate) fn selected_row() -> Style {
-    Style::default()
-        .bg(Color::Rgb(51, 65, 85)) // slate-700
-        .fg(Color::Rgb(226, 232, 240)) // slate-200
+    let theme = ACTIVE.get();
+    Style::default().bg(theme.selected_bg).fg(theme.selected_fg)
 }
 
 /// Range selection (visual span).
 pub(crate) fn range_row() -> Style {
     Style::default()
-        .fg(Color::Rgb(251, 191, 36)) // amber-400
+        .fg(ACTIVE.get().range_fg)
         .add_modifier(Modifier::BOLD)
 }
 
@@ -69,7 +201,7 @@ pub(crate) fn provider_color(provider: AgentProvider) -> Color {
 }
 
 pub(crate) fn terminal_color() -> Color {
-    Color::Rgb(148, 163, 184) // slate-400
+    ACTIVE.get().footer
 }
 
 /// Local `·` / remote `↗` glyph.
@@ -82,27 +214,59 @@ pub(crate) fn origin_glyph(remote: bool) -> &'static str {
 }
 
 pub(crate) fn origin_style(remote: bool) -> Style {
+    let theme = ACTIVE.get();
     Style::default().fg(if remote {
-        remote_origin()
+        theme.remote_origin
     } else {
-        local_origin()
+        theme.local_origin
     })
 }
 
 pub(crate) fn title_style(active: bool) -> Style {
+    let theme = ACTIVE.get();
     if active {
         Style::default()
-            .fg(Color::Rgb(224, 242, 254)) // sky-100
+            .fg(theme.title_active)
             .add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(Color::Rgb(203, 213, 225)) // slate-300
+        Style::default().fg(theme.muted_text)
     }
 }
 
 pub(crate) fn key_hint_style() -> Style {
-    Style::default().fg(Color::Rgb(125, 211, 252)) // sky-300
+    Style::default().fg(ACTIVE.get().key_hint)
 }
 
 pub(crate) fn footer_style() -> Style {
-    Style::default().fg(Color::Rgb(148, 163, 184)) // slate-400
+    Style::default().fg(ACTIVE.get().footer)
+}
+
+/// Primary content text (session titles, …).
+pub(crate) fn text_primary() -> Color {
+    ACTIVE.get().text_primary
+}
+
+/// Help / hint descriptions.
+pub(crate) fn help_text() -> Color {
+    ACTIVE.get().muted_text
+}
+
+/// Error / failed-load markers.
+pub(crate) fn failure() -> Color {
+    ACTIVE.get().failure
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_switches_the_active_palette() {
+        apply(ThemeMode::Dark);
+        let dark_accent = accent();
+        apply(ThemeMode::Light);
+        assert_ne!(accent(), dark_accent, "light palette must differ from dark");
+        apply(ThemeMode::Dark);
+        assert_eq!(accent(), dark_accent);
+    }
 }

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -501,8 +501,8 @@ pub(crate) fn output() -> Color {
     ACTIVE.get().output
 }
 
-/// Structural marker color for a `<:channel:…:>` role. Result channels
-/// (`… result:>`) lean blue, everything else yellow.
+/// Color for the `## Command` dialogue heading and structural roles. Result
+/// channels (`… result:>`) lean blue, everything else yellow.
 pub(crate) fn structure_color(is_result: bool) -> Color {
     let theme = ACTIVE.get();
     if is_result {
@@ -510,13 +510,6 @@ pub(crate) fn structure_color(is_result: bool) -> Color {
     } else {
         theme.structure
     }
-}
-
-/// Structural markers: `<:tool:…:>`, `<:skill:…:>`, `<:thinking:…:>`.
-pub(crate) fn structure_style(is_result: bool) -> Style {
-    Style::default()
-        .fg(structure_color(is_result))
-        .add_modifier(Modifier::BOLD)
 }
 
 #[cfg(test)]

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -292,9 +292,6 @@ impl Theme {
 thread_local! {
     static ACTIVE: Cell<Theme> = const { Cell::new(Theme::dark()) };
     static PREFERENCE: Cell<ThemeMode> = const { Cell::new(ThemeMode::Auto) };
-    /// Latched once `dark_light::detect()` errors, so the event loop stops
-    /// re-probing an unavailable desktop portal on every poll.
-    static DETECT_FAILED: Cell<bool> = const { Cell::new(false) };
 }
 
 /// Pick the palette for this process. The preference decides light vs dark —
@@ -339,32 +336,22 @@ fn supports_truecolor() -> bool {
 
 /// Light when the desktop session reports a light appearance. Cross-platform
 /// (macOS / Linux XDG portal / Windows registry) via `dark-light`; anything
-/// else — dark, unspecified, or a detection error — stays dark. The first
-/// error is latched so the event loop stops re-probing the portal.
+/// else — dark, unspecified, or a detection error — stays dark.
 fn light_from_system() -> bool {
-    match dark_light::detect() {
-        Ok(Mode::Light) => true,
-        Ok(_) => false,
-        Err(_) => {
-            DETECT_FAILED.set(true);
-            false
-        }
-    }
+    matches!(dark_light::detect(), Ok(Mode::Light))
 }
 
 /// Poll interval for appearance changes while the theme is in auto mode.
-/// `None` when a fixed dark/light palette is active or detection has failed,
-/// so the event loop does not wake up to re-check.
+/// `None` when a fixed dark/light palette is active, so the event loop does
+/// not wake up to re-check.
 pub(crate) fn auto_interval() -> Option<Duration> {
-    let auto = PREFERENCE.get() == ThemeMode::Auto && !DETECT_FAILED.get();
-    auto.then_some(AUTO_POLL_INTERVAL)
+    (PREFERENCE.get() == ThemeMode::Auto).then_some(AUTO_POLL_INTERVAL)
 }
 
 /// Re-check the system appearance and swap the palette when it changed.
-/// Returns true when the next frame must be redrawn. No-op outside auto mode
-/// or once detection has failed.
+/// Returns true when the next frame must be redrawn. No-op outside auto mode.
 pub(crate) fn refresh_if_changed() -> bool {
-    if PREFERENCE.get() != ThemeMode::Auto || DETECT_FAILED.get() {
+    if PREFERENCE.get() != ThemeMode::Auto {
         return false;
     }
     let before = ACTIVE.get().mode;

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -207,20 +207,18 @@ thread_local! {
     static ACTIVE: Cell<Theme> = const { Cell::new(Theme::dark()) };
 }
 
-/// Pick the palette for this process from the config preference
-/// (auto-detect from the environment when not overridden).
+/// Pick the palette for this process from the config preference. The
+/// preference decides light vs dark (auto-detecting the background), and the
+/// terminal's truecolor support decides RGB vs ANSI - so a forced light/dark
+/// mode still falls back to the ANSI palette when `COLORTERM` is absent,
+/// instead of emitting RGB sequences a non-truecolor terminal cannot render.
 pub(crate) fn apply(preference: ThemeMode) {
-    let theme = match preference {
-        ThemeMode::Auto => detect(),
-        ThemeMode::Dark => Theme::dark(),
-        ThemeMode::Light => Theme::light(),
+    let light = match preference {
+        ThemeMode::Auto => light_background(),
+        ThemeMode::Dark => false,
+        ThemeMode::Light => true,
     };
-    ACTIVE.set(theme);
-}
-
-fn detect() -> Theme {
-    let light = light_background();
-    if supports_truecolor() {
+    let theme = if supports_truecolor() {
         if light {
             Theme::light()
         } else {
@@ -232,7 +230,8 @@ fn detect() -> Theme {
         Theme::ansi_light()
     } else {
         Theme::ansi()
-    }
+    };
+    ACTIVE.set(theme);
 }
 
 /// Truecolor when the terminal advertises it (`COLORTERM=truecolor|24bit`).

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -4,15 +4,32 @@
 //! sites (`accent()`, `focus_row()`, …) stay unchanged while the palette is
 //! chosen once at TUI startup from the terminal environment and the optional
 //! `[theme]` config section.
+//!
+//! Agent label colors live in a single table, [`provider_colors`]: one row per
+//! agent holding all four palette variants. Adding an agent means adding one
+//! row there — the compiler enforces the table stays complete because the
+//! match is exhaustive over `AgentProvider`.
 
 use ratatui::prelude::{Color, Modifier, Style};
 use sivtr_core::ai::AgentProvider;
 use sivtr_core::config::ThemeMode;
 use std::cell::Cell;
 
+/// Which of the four color schemes is active. Chrome colors and agent label
+/// colors are selected from this together, so a single `ACTIVE` cell drives
+/// both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PaletteMode {
+    Dark,
+    Light,
+    Ansi,
+    AnsiLight,
+}
+
 /// One palette: chrome, text, and selection colors for a color scheme.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Theme {
+    pub(crate) mode: PaletteMode,
     pub(crate) accent: Color,
     pub(crate) muted: Color,
     pub(crate) dim: Color,
@@ -29,38 +46,101 @@ pub(crate) struct Theme {
     pub(crate) footer: Color,
     pub(crate) text_primary: Color,
     pub(crate) failure: Color,
-    /// Per-agent label colors, chosen per palette so light and ANSI
-    /// terminals get readable, non-RGB variants.
-    pub(crate) provider: ProviderPalette,
 }
 
-/// Per-agent label colors for one palette.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct ProviderPalette {
-    pub(crate) codex: Color,
-    pub(crate) claude: Color,
-    pub(crate) cursor: Color,
-    pub(crate) opencode: Color,
-    pub(crate) openclaw: Color,
-    pub(crate) hermes: Color,
-    pub(crate) grok: Color,
-    pub(crate) pi: Color,
-    pub(crate) qoder: Color,
+/// The four agent-label colors for one provider, one per palette. Chosen by
+/// hand so light and ANSI terminals get readable, non-RGB variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProviderColors {
+    pub(crate) dark: Color,
+    pub(crate) light: Color,
+    pub(crate) ansi: Color,
+    pub(crate) ansi_light: Color,
 }
 
-impl ProviderPalette {
-    pub(crate) const fn color(self, provider: AgentProvider) -> Color {
-        match provider {
-            AgentProvider::Codex => self.codex,
-            AgentProvider::Claude => self.claude,
-            AgentProvider::Cursor => self.cursor,
-            AgentProvider::OpenCode => self.opencode,
-            AgentProvider::OpenClaw => self.openclaw,
-            AgentProvider::Hermes => self.hermes,
-            AgentProvider::Grok => self.grok,
-            AgentProvider::Pi => self.pi,
-            AgentProvider::Qoder => self.qoder,
-        }
+/// One row per agent: the four curated label colors, selected by the active
+/// palette. Exhaustive by construction — adding a provider to `AgentProvider`
+/// makes the compiler demand its row here.
+pub(crate) const fn provider_colors(provider: AgentProvider) -> ProviderColors {
+    match provider {
+        AgentProvider::Codex => ProviderColors {
+            dark: Color::Rgb(129, 140, 248), // indigo-400
+            light: Color::Rgb(79, 70, 229),  // indigo-600
+            ansi: Color::Blue,
+            ansi_light: Color::Blue,
+        },
+        AgentProvider::Claude => ProviderColors {
+            dark: Color::Rgb(251, 146, 60), // orange-400
+            light: Color::Rgb(234, 88, 12), // orange-600
+            ansi: Color::Yellow,
+            ansi_light: Color::Yellow,
+        },
+        AgentProvider::Cursor => ProviderColors {
+            dark: Color::Rgb(167, 139, 250), // violet-400
+            light: Color::Rgb(124, 58, 237), // violet-600
+            ansi: Color::Magenta,
+            ansi_light: Color::Magenta,
+        },
+        AgentProvider::OpenCode => ProviderColors {
+            dark: Color::Rgb(45, 212, 191),  // teal-400
+            light: Color::Rgb(13, 148, 136), // teal-600
+            ansi: Color::Cyan,
+            ansi_light: Color::Cyan,
+        },
+        AgentProvider::OpenClaw => ProviderColors {
+            dark: Color::Rgb(248, 113, 113), // red-400
+            light: Color::Rgb(220, 38, 38),  // red-600
+            ansi: Color::Red,
+            ansi_light: Color::Red,
+        },
+        AgentProvider::Hermes => ProviderColors {
+            dark: Color::Rgb(250, 204, 21), // yellow-400
+            light: Color::Rgb(202, 138, 4), // yellow-600
+            ansi: Color::LightYellow,
+            ansi_light: Color::Gray,
+        },
+        AgentProvider::Grok => ProviderColors {
+            dark: Color::Rgb(244, 114, 182), // pink-400
+            light: Color::Rgb(219, 39, 119), // pink-600
+            ansi: Color::LightMagenta,
+            ansi_light: Color::DarkGray,
+        },
+        AgentProvider::Pi => ProviderColors {
+            dark: Color::Rgb(74, 222, 128), // green-400
+            light: Color::Rgb(22, 163, 74), // green-600
+            ansi: Color::Green,
+            ansi_light: Color::Green,
+        },
+        AgentProvider::Qoder => ProviderColors {
+            dark: Color::Rgb(34, 211, 238), // cyan-400
+            light: Color::Rgb(8, 145, 178), // cyan-600
+            ansi: Color::LightCyan,
+            ansi_light: Color::Cyan,
+        },
+        AgentProvider::QoderCn => ProviderColors {
+            dark: Color::Rgb(125, 211, 252), // sky-300
+            light: Color::Rgb(3, 105, 161),  // sky-600
+            ansi: Color::LightCyan,
+            ansi_light: Color::Cyan,
+        },
+        AgentProvider::Gemini => ProviderColors {
+            dark: Color::Rgb(96, 165, 250), // blue-400
+            light: Color::Rgb(37, 99, 235), // blue-600
+            ansi: Color::LightBlue,
+            ansi_light: Color::Blue,
+        },
+        AgentProvider::Goose => ProviderColors {
+            dark: Color::Rgb(251, 191, 36), // amber-400
+            light: Color::Rgb(217, 119, 6), // amber-600
+            ansi: Color::LightYellow,
+            ansi_light: Color::Yellow,
+        },
+        AgentProvider::Qwen => ProviderColors {
+            dark: Color::Rgb(232, 121, 249), // fuchsia-400
+            light: Color::Rgb(192, 38, 211), // fuchsia-600
+            ansi: Color::LightMagenta,
+            ansi_light: Color::Magenta,
+        },
     }
 }
 
@@ -68,6 +148,7 @@ impl Theme {
     /// Dark-background palette (the default).
     pub(crate) const fn dark() -> Self {
         Self {
+            mode: PaletteMode::Dark,
             accent: Color::Rgb(56, 189, 248),         // sky-400
             muted: Color::Rgb(100, 116, 139),         // slate-500
             dim: Color::Rgb(71, 85, 105),             // slate-600
@@ -84,23 +165,13 @@ impl Theme {
             footer: Color::Rgb(148, 163, 184),        // slate-400
             text_primary: Color::Rgb(226, 232, 240),  // slate-200
             failure: Color::Rgb(248, 113, 113),       // red-400
-            provider: ProviderPalette {
-                codex: Color::Rgb(129, 140, 248),    // indigo-400
-                claude: Color::Rgb(251, 146, 60),    // orange-400
-                cursor: Color::Rgb(167, 139, 250),   // violet-400
-                opencode: Color::Rgb(45, 212, 191),  // teal-400
-                openclaw: Color::Rgb(248, 113, 113), // red-400
-                hermes: Color::Rgb(250, 204, 21),    // yellow-400
-                grok: Color::Rgb(244, 114, 182),     // pink-400
-                pi: Color::Rgb(74, 222, 128),        // green-400
-                qoder: Color::Rgb(34, 211, 238),     // cyan-400
-            },
         }
     }
 
     /// Light-background palette (darker variants of the same hues).
     pub(crate) const fn light() -> Self {
         Self {
+            mode: PaletteMode::Light,
             accent: Color::Rgb(2, 132, 199),         // sky-600
             muted: Color::Rgb(100, 116, 139),        // slate-500
             dim: Color::Rgb(148, 163, 184),          // slate-400
@@ -117,17 +188,6 @@ impl Theme {
             footer: Color::Rgb(71, 85, 105),         // slate-600
             text_primary: Color::Rgb(30, 41, 59),    // slate-800
             failure: Color::Rgb(220, 38, 38),        // red-600
-            provider: ProviderPalette {
-                codex: Color::Rgb(79, 70, 229),     // indigo-600
-                claude: Color::Rgb(234, 88, 12),    // orange-600
-                cursor: Color::Rgb(124, 58, 237),   // violet-600
-                opencode: Color::Rgb(13, 148, 136), // teal-600
-                openclaw: Color::Rgb(220, 38, 38),  // red-600
-                hermes: Color::Rgb(202, 138, 4),    // yellow-600
-                grok: Color::Rgb(219, 39, 119),     // pink-600
-                pi: Color::Rgb(22, 163, 74),        // green-600
-                qoder: Color::Rgb(8, 145, 178),     // cyan-600
-            },
         }
     }
 
@@ -136,6 +196,7 @@ impl Theme {
     /// ignored or mis-mapped by older terminals.
     pub(crate) const fn ansi() -> Self {
         Self {
+            mode: PaletteMode::Ansi,
             accent: Color::Cyan,
             muted: Color::DarkGray,
             dim: Color::DarkGray,
@@ -152,17 +213,6 @@ impl Theme {
             footer: Color::Gray,
             text_primary: Color::Gray,
             failure: Color::Red,
-            provider: ProviderPalette {
-                codex: Color::Blue,
-                claude: Color::Yellow,
-                cursor: Color::Magenta,
-                opencode: Color::Cyan,
-                openclaw: Color::Red,
-                hermes: Color::LightYellow,
-                grok: Color::LightMagenta,
-                pi: Color::Green,
-                qoder: Color::LightCyan,
-            },
         }
     }
 
@@ -172,6 +222,7 @@ impl Theme {
     /// would wash out).
     pub(crate) const fn ansi_light() -> Self {
         Self {
+            mode: PaletteMode::AnsiLight,
             accent: Color::Blue,
             muted: Color::DarkGray,
             dim: Color::Gray,
@@ -188,17 +239,6 @@ impl Theme {
             footer: Color::DarkGray,
             text_primary: Color::Black,
             failure: Color::Red,
-            provider: ProviderPalette {
-                codex: Color::Blue,
-                claude: Color::Yellow,
-                cursor: Color::Magenta,
-                opencode: Color::Cyan,
-                openclaw: Color::Red,
-                hermes: Color::Gray,
-                grok: Color::DarkGray,
-                pi: Color::Green,
-                qoder: Color::Cyan,
-            },
         }
     }
 }
@@ -297,8 +337,16 @@ pub(crate) fn range_row() -> Style {
         .add_modifier(Modifier::BOLD)
 }
 
+/// Agent label color for the active palette. Reads the per-provider row from
+/// [`provider_colors`] and picks the variant that matches the active scheme.
 pub(crate) fn provider_color(provider: AgentProvider) -> Color {
-    ACTIVE.get().provider.color(provider)
+    let colors = provider_colors(provider);
+    match ACTIVE.get().mode {
+        PaletteMode::Dark => colors.dark,
+        PaletteMode::Light => colors.light,
+        PaletteMode::Ansi => colors.ansi,
+        PaletteMode::AnsiLight => colors.ansi_light,
+    }
 }
 
 pub(crate) fn terminal_color() -> Color {
@@ -372,13 +420,13 @@ mod tests {
     }
 
     #[test]
-    fn provider_colors_follow_the_active_palette() {
+    fn provider_colors_cover_every_agent_with_distinct_schemes() {
         for spec in AgentProvider::all() {
-            let provider = spec.provider;
+            let colors = provider_colors(spec.provider);
             assert_ne!(
-                Theme::dark().provider.color(provider),
-                Theme::light().provider.color(provider),
-                "{provider:?} must have a light variant distinct from its dark one"
+                colors.dark, colors.light,
+                "{} must have a light variant distinct from its dark one",
+                spec.name
             );
         }
         apply(ThemeMode::Dark);
@@ -388,14 +436,14 @@ mod tests {
     }
 
     #[test]
-    fn ansi_provider_palette_emits_no_rgb() {
-        for palette in [Theme::ansi().provider, Theme::ansi_light().provider] {
-            for spec in AgentProvider::all() {
-                let color = palette.color(spec.provider);
+    fn ansi_provider_colors_emit_no_rgb() {
+        for spec in AgentProvider::all() {
+            let colors = provider_colors(spec.provider);
+            for color in [colors.ansi, colors.ansi_light] {
                 assert!(
                     !matches!(color, Color::Rgb(..)),
-                    "{:?} leaks RGB through the ANSI fallback: {color:?}",
-                    spec.provider
+                    "{} leaks RGB through the ANSI fallback: {color:?}",
+                    spec.name
                 );
             }
         }

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -29,6 +29,39 @@ pub(crate) struct Theme {
     pub(crate) footer: Color,
     pub(crate) text_primary: Color,
     pub(crate) failure: Color,
+    /// Per-agent label colors, chosen per palette so light and ANSI
+    /// terminals get readable, non-RGB variants.
+    pub(crate) provider: ProviderPalette,
+}
+
+/// Per-agent label colors for one palette.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ProviderPalette {
+    pub(crate) codex: Color,
+    pub(crate) claude: Color,
+    pub(crate) cursor: Color,
+    pub(crate) opencode: Color,
+    pub(crate) openclaw: Color,
+    pub(crate) hermes: Color,
+    pub(crate) grok: Color,
+    pub(crate) pi: Color,
+    pub(crate) qoder: Color,
+}
+
+impl ProviderPalette {
+    pub(crate) const fn color(self, provider: AgentProvider) -> Color {
+        match provider {
+            AgentProvider::Codex => self.codex,
+            AgentProvider::Claude => self.claude,
+            AgentProvider::Cursor => self.cursor,
+            AgentProvider::OpenCode => self.opencode,
+            AgentProvider::OpenClaw => self.openclaw,
+            AgentProvider::Hermes => self.hermes,
+            AgentProvider::Grok => self.grok,
+            AgentProvider::Pi => self.pi,
+            AgentProvider::Qoder => self.qoder,
+        }
+    }
 }
 
 impl Theme {
@@ -51,6 +84,17 @@ impl Theme {
             footer: Color::Rgb(148, 163, 184),        // slate-400
             text_primary: Color::Rgb(226, 232, 240),  // slate-200
             failure: Color::Rgb(248, 113, 113),       // red-400
+            provider: ProviderPalette {
+                codex: Color::Rgb(129, 140, 248),    // indigo-400
+                claude: Color::Rgb(251, 146, 60),    // orange-400
+                cursor: Color::Rgb(167, 139, 250),   // violet-400
+                opencode: Color::Rgb(45, 212, 191),  // teal-400
+                openclaw: Color::Rgb(248, 113, 113), // red-400
+                hermes: Color::Rgb(250, 204, 21),    // yellow-400
+                grok: Color::Rgb(244, 114, 182),     // pink-400
+                pi: Color::Rgb(74, 222, 128),        // green-400
+                qoder: Color::Rgb(34, 211, 238),     // cyan-400
+            },
         }
     }
 
@@ -73,6 +117,17 @@ impl Theme {
             footer: Color::Rgb(71, 85, 105),         // slate-600
             text_primary: Color::Rgb(30, 41, 59),    // slate-800
             failure: Color::Rgb(220, 38, 38),        // red-600
+            provider: ProviderPalette {
+                codex: Color::Rgb(79, 70, 229),     // indigo-600
+                claude: Color::Rgb(234, 88, 12),    // orange-600
+                cursor: Color::Rgb(124, 58, 237),   // violet-600
+                opencode: Color::Rgb(13, 148, 136), // teal-600
+                openclaw: Color::Rgb(220, 38, 38),  // red-600
+                hermes: Color::Rgb(202, 138, 4),    // yellow-600
+                grok: Color::Rgb(219, 39, 119),     // pink-600
+                pi: Color::Rgb(22, 163, 74),        // green-600
+                qoder: Color::Rgb(8, 145, 178),     // cyan-600
+            },
         }
     }
 
@@ -97,6 +152,17 @@ impl Theme {
             footer: Color::Gray,
             text_primary: Color::Gray,
             failure: Color::Red,
+            provider: ProviderPalette {
+                codex: Color::Blue,
+                claude: Color::Yellow,
+                cursor: Color::Magenta,
+                opencode: Color::Cyan,
+                openclaw: Color::Red,
+                hermes: Color::LightYellow,
+                grok: Color::LightMagenta,
+                pi: Color::Green,
+                qoder: Color::LightCyan,
+            },
         }
     }
 }
@@ -137,12 +203,21 @@ fn supports_truecolor() -> bool {
 }
 
 /// Light background when `COLORFGBG`'s background half is a bright ANSI
-/// color (8–15); anything else (dark, unset, `default`) stays dark.
+/// color (8–15); anything else — dark 256-color indexes such as 16 or 232,
+/// unset, `default` — stays dark.
 fn light_background() -> bool {
     std::env::var("COLORFGBG")
         .ok()
-        .and_then(|value| value.rsplit(';').next()?.parse::<u8>().ok())
-        .is_some_and(|background| background >= 8)
+        .is_some_and(|value| colorfgbg_is_light(&value))
+}
+
+/// Whether a `COLORFGBG` value ("fg;bg") denotes a light background.
+fn colorfgbg_is_light(value: &str) -> bool {
+    value
+        .rsplit(';')
+        .next()
+        .and_then(|background| background.parse::<u8>().ok())
+        .is_some_and(|background| (8..=15).contains(&background))
 }
 
 /// Active panel chrome (focused border / scrollbar).
@@ -183,21 +258,7 @@ pub(crate) fn range_row() -> Style {
 }
 
 pub(crate) fn provider_color(provider: AgentProvider) -> Color {
-    match provider {
-        AgentProvider::Codex => Color::Rgb(129, 140, 248), // indigo-400
-        AgentProvider::Claude => Color::Rgb(251, 146, 60), // orange-400
-        AgentProvider::Cursor => Color::Rgb(167, 139, 250), // violet-400
-        AgentProvider::OpenCode => Color::Rgb(45, 212, 191), // teal-400
-        AgentProvider::OpenClaw => Color::Rgb(248, 113, 113), // red-400
-        AgentProvider::Hermes => Color::Rgb(250, 204, 21), // yellow-400
-        AgentProvider::Grok => Color::Rgb(244, 114, 182),  // pink-400
-        AgentProvider::Pi => Color::Rgb(74, 222, 128),     // green-400
-        AgentProvider::Qoder => Color::Rgb(34, 211, 238),  // cyan-400
-        AgentProvider::QoderCn => Color::Rgb(125, 211, 252), // sky-300
-        AgentProvider::Gemini => Color::Rgb(96, 165, 250), // blue-400
-        AgentProvider::Goose => Color::Rgb(251, 191, 36),  // amber-400
-        AgentProvider::Qwen => Color::Rgb(232, 121, 249),  // fuchsia-400
-    }
+    ACTIVE.get().provider.color(provider)
 }
 
 pub(crate) fn terminal_color() -> Color {
@@ -268,5 +329,44 @@ mod tests {
         assert_ne!(accent(), dark_accent, "light palette must differ from dark");
         apply(ThemeMode::Dark);
         assert_eq!(accent(), dark_accent);
+    }
+
+    #[test]
+    fn provider_colors_follow_the_active_palette() {
+        for spec in AgentProvider::all() {
+            let provider = spec.provider;
+            assert_ne!(
+                Theme::dark().provider.color(provider),
+                Theme::light().provider.color(provider),
+                "{provider:?} must have a light variant distinct from its dark one"
+            );
+        }
+        apply(ThemeMode::Dark);
+        let dark = provider_color(AgentProvider::Hermes);
+        apply(ThemeMode::Light);
+        assert_ne!(provider_color(AgentProvider::Hermes), dark);
+    }
+
+    #[test]
+    fn ansi_provider_palette_emits_no_rgb() {
+        let palette = Theme::ansi().provider;
+        for spec in AgentProvider::all() {
+            let color = palette.color(spec.provider);
+            assert!(
+                !matches!(color, Color::Rgb(..)),
+                "{:?} leaks RGB through the ANSI fallback: {color:?}",
+                spec.provider
+            );
+        }
+    }
+
+    #[test]
+    fn only_bright_ansi_backgrounds_count_as_light() {
+        assert!(colorfgbg_is_light("0;15"), "bright white background");
+        assert!(!colorfgbg_is_light("15;0"), "black background");
+        assert!(!colorfgbg_is_light("15;16"), "256-color dark blue");
+        assert!(!colorfgbg_is_light("15;232"), "256-color near-black");
+        assert!(!colorfgbg_is_light("15;default"));
+        assert!(!colorfgbg_is_light("garbage"));
     }
 }

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -165,6 +165,42 @@ impl Theme {
             },
         }
     }
+
+    /// Terminal-defined palette for light-background terminals without
+    /// truecolor: darker ANSI colors that stay readable against a light
+    /// default background (the light `Light*` variants used by [`Theme::ansi`]
+    /// would wash out).
+    pub(crate) const fn ansi_light() -> Self {
+        Self {
+            accent: Color::Blue,
+            muted: Color::DarkGray,
+            dim: Color::Gray,
+            local_origin: Color::Green,
+            remote_origin: Color::Magenta,
+            focus_bg: Color::Blue,
+            focus_fg: Color::White,
+            selected_bg: Color::DarkGray,
+            selected_fg: Color::White,
+            range_fg: Color::Yellow,
+            title_active: Color::Black,
+            muted_text: Color::DarkGray,
+            key_hint: Color::Blue,
+            footer: Color::DarkGray,
+            text_primary: Color::Black,
+            failure: Color::Red,
+            provider: ProviderPalette {
+                codex: Color::Blue,
+                claude: Color::Yellow,
+                cursor: Color::Magenta,
+                opencode: Color::Cyan,
+                openclaw: Color::Red,
+                hermes: Color::Gray,
+                grok: Color::DarkGray,
+                pi: Color::Green,
+                qoder: Color::Cyan,
+            },
+        }
+    }
 }
 
 thread_local! {
@@ -183,12 +219,17 @@ pub(crate) fn apply(preference: ThemeMode) {
 }
 
 fn detect() -> Theme {
+    let light = light_background();
     if supports_truecolor() {
-        if light_background() {
+        if light {
             Theme::light()
         } else {
             Theme::dark()
         }
+    } else if light {
+        // No truecolor does not mean the terminal is dark: pick the darker
+        // ANSI palette on a light background so labels stay readable.
+        Theme::ansi_light()
     } else {
         Theme::ansi()
     }
@@ -349,13 +390,44 @@ mod tests {
 
     #[test]
     fn ansi_provider_palette_emits_no_rgb() {
-        let palette = Theme::ansi().provider;
-        for spec in AgentProvider::all() {
-            let color = palette.color(spec.provider);
+        for palette in [Theme::ansi().provider, Theme::ansi_light().provider] {
+            for spec in AgentProvider::all() {
+                let color = palette.color(spec.provider);
+                assert!(
+                    !matches!(color, Color::Rgb(..)),
+                    "{:?} leaks RGB through the ANSI fallback: {color:?}",
+                    spec.provider
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn ansi_light_uses_darker_foregrounds_for_light_backgrounds() {
+        let dark = Theme::ansi();
+        let light = Theme::ansi_light();
+        assert_ne!(light.text_primary, dark.text_primary);
+        assert_ne!(light.title_active, dark.title_active);
+        // The light ANSI palette must avoid the bright foregrounds that wash
+        // out against a light default background.
+        for color in [
+            light.text_primary,
+            light.title_active,
+            light.footer,
+            light.muted_text,
+        ] {
             assert!(
-                !matches!(color, Color::Rgb(..)),
-                "{:?} leaks RGB through the ANSI fallback: {color:?}",
-                spec.provider
+                !matches!(
+                    color,
+                    Color::White
+                        | Color::LightRed
+                        | Color::LightGreen
+                        | Color::LightYellow
+                        | Color::LightBlue
+                        | Color::LightMagenta
+                        | Color::LightCyan
+                ),
+                "bright foreground on a light ANSI background: {color:?}"
             );
         }
     }

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -1,19 +1,25 @@
-//! Shared TUI palette — keep panel chrome and list accents consistent.
+//! Shared TUI palette — single source for every color.
 //!
-//! The active palette lives in a thread-local so the existing accessor call
+//! The active palette lives in a thread-local so existing accessor call
 //! sites (`accent()`, `focus_row()`, …) stay unchanged while the palette is
-//! chosen once at TUI startup from the terminal environment and the optional
-//! `[theme]` config section.
+//! chosen at TUI startup and swapped at runtime when the system appearance
+//! changes.
 //!
-//! Agent label colors live in a single table, [`provider_colors`]: one row per
-//! agent holding all four palette variants. Adding an agent means adding one
-//! row there — the compiler enforces the table stays complete because the
-//! match is exhaustive over `AgentProvider`.
+//! Light/dark follows the desktop session's appearance (macOS, Linux XDG
+//! portal, Windows registry) via `dark-light`; RGB vs ANSI rendering is
+//! decided by the terminal's truecolor advertisement. Agent label colors
+//! live in a single table, [`provider_colors`]: one row per agent holding
+//! all four palette variants.
 
+use dark_light::Mode;
 use ratatui::prelude::{Color, Modifier, Style};
 use sivtr_core::ai::AgentProvider;
 use sivtr_core::config::ThemeMode;
 use std::cell::Cell;
+use std::time::Duration;
+
+/// How often the event loop re-checks the system appearance in auto mode.
+pub(crate) const AUTO_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Which of the four color schemes is active. Chrome colors and agent label
 /// colors are selected from this together, so a single `ACTIVE` cell drives
@@ -26,7 +32,7 @@ pub(crate) enum PaletteMode {
     AnsiLight,
 }
 
-/// One palette: chrome, text, and selection colors for a color scheme.
+/// One palette: chrome, text, selection, and markdown colors for a scheme.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Theme {
     pub(crate) mode: PaletteMode,
@@ -46,6 +52,14 @@ pub(crate) struct Theme {
     pub(crate) footer: Color,
     pub(crate) text_primary: Color,
     pub(crate) failure: Color,
+    pub(crate) code: Color,
+    pub(crate) link: Color,
+    pub(crate) quote: Color,
+    pub(crate) success: Color,
+    pub(crate) user: Color,
+    pub(crate) output: Color,
+    pub(crate) structure: Color,
+    pub(crate) structure_result: Color,
 }
 
 /// The four agent-label colors for one provider, one per palette. Chosen by
@@ -73,7 +87,7 @@ pub(crate) const fn provider_colors(provider: AgentProvider) -> ProviderColors {
             dark: Color::Rgb(251, 146, 60), // orange-400
             light: Color::Rgb(234, 88, 12), // orange-600
             ansi: Color::Yellow,
-            ansi_light: Color::Yellow,
+            ansi_light: Color::Red,
         },
         AgentProvider::Cursor => ProviderColors {
             dark: Color::Rgb(167, 139, 250), // violet-400
@@ -85,7 +99,7 @@ pub(crate) const fn provider_colors(provider: AgentProvider) -> ProviderColors {
             dark: Color::Rgb(45, 212, 191),  // teal-400
             light: Color::Rgb(13, 148, 136), // teal-600
             ansi: Color::Cyan,
-            ansi_light: Color::Cyan,
+            ansi_light: Color::Blue,
         },
         AgentProvider::OpenClaw => ProviderColors {
             dark: Color::Rgb(248, 113, 113), // red-400
@@ -97,7 +111,7 @@ pub(crate) const fn provider_colors(provider: AgentProvider) -> ProviderColors {
             dark: Color::Rgb(250, 204, 21), // yellow-400
             light: Color::Rgb(202, 138, 4), // yellow-600
             ansi: Color::LightYellow,
-            ansi_light: Color::Gray,
+            ansi_light: Color::DarkGray,
         },
         AgentProvider::Grok => ProviderColors {
             dark: Color::Rgb(244, 114, 182), // pink-400
@@ -109,19 +123,19 @@ pub(crate) const fn provider_colors(provider: AgentProvider) -> ProviderColors {
             dark: Color::Rgb(74, 222, 128), // green-400
             light: Color::Rgb(22, 163, 74), // green-600
             ansi: Color::Green,
-            ansi_light: Color::Green,
+            ansi_light: Color::Blue,
         },
         AgentProvider::Qoder => ProviderColors {
             dark: Color::Rgb(34, 211, 238), // cyan-400
             light: Color::Rgb(8, 145, 178), // cyan-600
             ansi: Color::LightCyan,
-            ansi_light: Color::Cyan,
+            ansi_light: Color::Blue,
         },
         AgentProvider::QoderCn => ProviderColors {
             dark: Color::Rgb(125, 211, 252), // sky-300
             light: Color::Rgb(3, 105, 161),  // sky-600
             ansi: Color::LightCyan,
-            ansi_light: Color::Cyan,
+            ansi_light: Color::Blue,
         },
         AgentProvider::Gemini => ProviderColors {
             dark: Color::Rgb(96, 165, 250), // blue-400
@@ -133,7 +147,7 @@ pub(crate) const fn provider_colors(provider: AgentProvider) -> ProviderColors {
             dark: Color::Rgb(251, 191, 36), // amber-400
             light: Color::Rgb(217, 119, 6), // amber-600
             ansi: Color::LightYellow,
-            ansi_light: Color::Yellow,
+            ansi_light: Color::Red,
         },
         AgentProvider::Qwen => ProviderColors {
             dark: Color::Rgb(232, 121, 249), // fuchsia-400
@@ -149,22 +163,30 @@ impl Theme {
     pub(crate) const fn dark() -> Self {
         Self {
             mode: PaletteMode::Dark,
-            accent: Color::Rgb(56, 189, 248),         // sky-400
-            muted: Color::Rgb(100, 116, 139),         // slate-500
-            dim: Color::Rgb(71, 85, 105),             // slate-600
-            local_origin: Color::Rgb(52, 211, 153),   // emerald-400
-            remote_origin: Color::Rgb(244, 114, 182), // pink-400
-            focus_bg: Color::Rgb(30, 64, 175),        // blue-800
-            focus_fg: Color::Rgb(240, 249, 255),      // slate-50
-            selected_bg: Color::Rgb(51, 65, 85),      // slate-700
-            selected_fg: Color::Rgb(226, 232, 240),   // slate-200
-            range_fg: Color::Rgb(251, 191, 36),       // amber-400
-            title_active: Color::Rgb(224, 242, 254),  // sky-100
-            muted_text: Color::Rgb(203, 213, 225),    // slate-300
-            key_hint: Color::Rgb(125, 211, 252),      // sky-300
-            footer: Color::Rgb(148, 163, 184),        // slate-400
-            text_primary: Color::Rgb(226, 232, 240),  // slate-200
-            failure: Color::Rgb(248, 113, 113),       // red-400
+            accent: Color::Rgb(56, 189, 248),           // sky-400
+            muted: Color::Rgb(100, 116, 139),           // slate-500
+            dim: Color::Rgb(71, 85, 105),               // slate-600
+            local_origin: Color::Rgb(52, 211, 153),     // emerald-400
+            remote_origin: Color::Rgb(244, 114, 182),   // pink-400
+            focus_bg: Color::Rgb(30, 64, 175),          // blue-800
+            focus_fg: Color::Rgb(240, 249, 255),        // slate-50
+            selected_bg: Color::Rgb(51, 65, 85),        // slate-700
+            selected_fg: Color::Rgb(226, 232, 240),     // slate-200
+            range_fg: Color::Rgb(251, 191, 36),         // amber-400
+            title_active: Color::Rgb(224, 242, 254),    // sky-100
+            muted_text: Color::Rgb(203, 213, 225),      // slate-300
+            key_hint: Color::Rgb(125, 211, 252),        // sky-300
+            footer: Color::Rgb(148, 163, 184),          // slate-400
+            text_primary: Color::Rgb(226, 232, 240),    // slate-200
+            failure: Color::Rgb(248, 113, 113),         // red-400
+            code: Color::Rgb(148, 163, 184),            // slate-400
+            link: Color::Rgb(125, 211, 252),            // sky-300
+            quote: Color::Rgb(52, 211, 153),            // emerald-400
+            success: Color::Rgb(74, 222, 128),          // green-400
+            user: Color::Rgb(34, 211, 238),             // cyan-400
+            output: Color::Rgb(96, 165, 250),           // blue-400
+            structure: Color::Rgb(251, 191, 36),        // amber-400
+            structure_result: Color::Rgb(56, 189, 248), // sky-400
         }
     }
 
@@ -172,22 +194,30 @@ impl Theme {
     pub(crate) const fn light() -> Self {
         Self {
             mode: PaletteMode::Light,
-            accent: Color::Rgb(2, 132, 199),         // sky-600
-            muted: Color::Rgb(100, 116, 139),        // slate-500
-            dim: Color::Rgb(148, 163, 184),          // slate-400
-            local_origin: Color::Rgb(5, 150, 105),   // emerald-600
-            remote_origin: Color::Rgb(219, 39, 119), // pink-600
-            focus_bg: Color::Rgb(219, 234, 254),     // blue-100
-            focus_fg: Color::Rgb(30, 41, 59),        // slate-800
-            selected_bg: Color::Rgb(226, 232, 240),  // slate-200
-            selected_fg: Color::Rgb(51, 65, 85),     // slate-700
-            range_fg: Color::Rgb(217, 119, 6),       // amber-600
-            title_active: Color::Rgb(15, 23, 42),    // slate-900
-            muted_text: Color::Rgb(100, 116, 139),   // slate-500
-            key_hint: Color::Rgb(3, 105, 161),       // sky-700
-            footer: Color::Rgb(71, 85, 105),         // slate-600
-            text_primary: Color::Rgb(30, 41, 59),    // slate-800
-            failure: Color::Rgb(220, 38, 38),        // red-600
+            accent: Color::Rgb(2, 132, 199),           // sky-600
+            muted: Color::Rgb(100, 116, 139),          // slate-500
+            dim: Color::Rgb(148, 163, 184),            // slate-400
+            local_origin: Color::Rgb(5, 150, 105),     // emerald-600
+            remote_origin: Color::Rgb(219, 39, 119),   // pink-600
+            focus_bg: Color::Rgb(219, 234, 254),       // blue-100
+            focus_fg: Color::Rgb(30, 41, 59),          // slate-800
+            selected_bg: Color::Rgb(226, 232, 240),    // slate-200
+            selected_fg: Color::Rgb(51, 65, 85),       // slate-700
+            range_fg: Color::Rgb(217, 119, 6),         // amber-600
+            title_active: Color::Rgb(15, 23, 42),      // slate-900
+            muted_text: Color::Rgb(100, 116, 139),     // slate-500
+            key_hint: Color::Rgb(3, 105, 161),         // sky-700
+            footer: Color::Rgb(71, 85, 105),           // slate-600
+            text_primary: Color::Rgb(30, 41, 59),      // slate-800
+            failure: Color::Rgb(220, 38, 38),          // red-600
+            code: Color::Rgb(71, 85, 105),             // slate-600
+            link: Color::Rgb(3, 105, 161),             // sky-700
+            quote: Color::Rgb(5, 150, 105),            // emerald-600
+            success: Color::Rgb(22, 163, 74),          // green-600
+            user: Color::Rgb(8, 145, 178),             // cyan-600
+            output: Color::Rgb(37, 99, 235),           // blue-600
+            structure: Color::Rgb(217, 119, 6),        // amber-600
+            structure_result: Color::Rgb(2, 132, 199), // sky-600
         }
     }
 
@@ -213,6 +243,14 @@ impl Theme {
             footer: Color::Gray,
             text_primary: Color::Gray,
             failure: Color::Red,
+            code: Color::Gray,
+            link: Color::Blue,
+            quote: Color::Green,
+            success: Color::Green,
+            user: Color::Cyan,
+            output: Color::Blue,
+            structure: Color::Yellow,
+            structure_result: Color::Blue,
         }
     }
 
@@ -225,36 +263,46 @@ impl Theme {
             mode: PaletteMode::AnsiLight,
             accent: Color::Blue,
             muted: Color::DarkGray,
-            dim: Color::Gray,
-            local_origin: Color::Green,
+            dim: Color::DarkGray,
+            local_origin: Color::Blue,
             remote_origin: Color::Magenta,
             focus_bg: Color::Blue,
             focus_fg: Color::White,
             selected_bg: Color::DarkGray,
             selected_fg: Color::White,
-            range_fg: Color::Yellow,
+            range_fg: Color::Blue,
             title_active: Color::Black,
             muted_text: Color::DarkGray,
             key_hint: Color::Blue,
             footer: Color::DarkGray,
             text_primary: Color::Black,
             failure: Color::Red,
+            code: Color::DarkGray,
+            link: Color::Blue,
+            quote: Color::DarkGray,
+            success: Color::Blue,
+            user: Color::Magenta,
+            output: Color::Blue,
+            structure: Color::Red,
+            structure_result: Color::Blue,
         }
     }
 }
 
 thread_local! {
     static ACTIVE: Cell<Theme> = const { Cell::new(Theme::dark()) };
+    static PREFERENCE: Cell<ThemeMode> = const { Cell::new(ThemeMode::Auto) };
 }
 
-/// Pick the palette for this process from the config preference. The
-/// preference decides light vs dark (auto-detecting the background), and the
-/// terminal's truecolor support decides RGB vs ANSI - so a forced light/dark
-/// mode still falls back to the ANSI palette when `COLORTERM` is absent,
-/// instead of emitting RGB sequences a non-truecolor terminal cannot render.
+/// Pick the palette for this process. The preference decides light vs dark —
+/// auto follows the system appearance via desktop APIs — and the terminal's
+/// truecolor support decides RGB vs ANSI, so a forced light/dark mode still
+/// falls back to the ANSI palette when `COLORTERM` is absent, instead of
+/// emitting RGB sequences a non-truecolor terminal cannot render.
 pub(crate) fn apply(preference: ThemeMode) {
+    PREFERENCE.set(preference);
     let light = match preference {
-        ThemeMode::Auto => light_background(),
+        ThemeMode::Auto => light_from_system(),
         ThemeMode::Dark => false,
         ThemeMode::Light => true,
     };
@@ -282,22 +330,29 @@ fn supports_truecolor() -> bool {
     )
 }
 
-/// Light background when `COLORFGBG`'s background half is a bright ANSI
-/// color (8–15); anything else — dark 256-color indexes such as 16 or 232,
-/// unset, `default` — stays dark.
-fn light_background() -> bool {
-    std::env::var("COLORFGBG")
-        .ok()
-        .is_some_and(|value| colorfgbg_is_light(&value))
+/// Light when the desktop session reports a light appearance. Cross-platform
+/// (macOS / Linux XDG portal / Windows registry) via `dark-light`; anything
+/// else — dark, unspecified, or a detection error — stays dark.
+fn light_from_system() -> bool {
+    matches!(dark_light::detect(), Ok(Mode::Light))
 }
 
-/// Whether a `COLORFGBG` value ("fg;bg") denotes a light background.
-fn colorfgbg_is_light(value: &str) -> bool {
-    value
-        .rsplit(';')
-        .next()
-        .and_then(|background| background.parse::<u8>().ok())
-        .is_some_and(|background| (8..=15).contains(&background))
+/// Poll interval for appearance changes while the theme is in auto mode.
+/// `None` when a fixed dark/light palette is active, so the event loop does
+/// not wake up to re-check.
+pub(crate) fn auto_interval() -> Option<Duration> {
+    (PREFERENCE.get() == ThemeMode::Auto).then_some(AUTO_POLL_INTERVAL)
+}
+
+/// Re-check the system appearance and swap the palette when it changed.
+/// Returns true when the next frame must be redrawn. No-op outside auto mode.
+pub(crate) fn refresh_if_changed() -> bool {
+    if PREFERENCE.get() != ThemeMode::Auto {
+        return false;
+    }
+    let before = ACTIVE.get().mode;
+    apply(ThemeMode::Auto);
+    ACTIVE.get().mode != before
 }
 
 /// Active panel chrome (focused border / scrollbar).
@@ -335,6 +390,11 @@ pub(crate) fn range_row() -> Style {
     Style::default()
         .fg(ACTIVE.get().range_fg)
         .add_modifier(Modifier::BOLD)
+}
+
+/// Range / search-highlight foreground.
+pub(crate) fn range_fg() -> Color {
+    ACTIVE.get().range_fg
 }
 
 /// Agent label color for the active palette. Reads the per-provider row from
@@ -405,6 +465,56 @@ pub(crate) fn failure() -> Color {
     ACTIVE.get().failure
 }
 
+/// Inline code and code-block content.
+pub(crate) fn code() -> Color {
+    ACTIVE.get().code
+}
+
+/// Clickable links (underlined).
+pub(crate) fn link_style() -> Style {
+    Style::default()
+        .fg(ACTIVE.get().link)
+        .add_modifier(Modifier::UNDERLINED)
+}
+
+/// Blockquote content.
+pub(crate) fn quote() -> Color {
+    ACTIVE.get().quote
+}
+
+/// Completed-task and assistant-success markers.
+pub(crate) fn success() -> Color {
+    ACTIVE.get().success
+}
+
+/// User role headings.
+pub(crate) fn user() -> Color {
+    ACTIVE.get().user
+}
+
+/// Output role headings.
+pub(crate) fn output() -> Color {
+    ACTIVE.get().output
+}
+
+/// Structural marker color for a `<:channel:…:>` role. Result channels
+/// (`… result:>`) lean blue, everything else yellow.
+pub(crate) fn structure_color(is_result: bool) -> Color {
+    let theme = ACTIVE.get();
+    if is_result {
+        theme.structure_result
+    } else {
+        theme.structure
+    }
+}
+
+/// Structural markers: `<:tool:…:>`, `<:skill:…:>`, `<:thinking:…:>`.
+pub(crate) fn structure_style(is_result: bool) -> Style {
+    Style::default()
+        .fg(structure_color(is_result))
+        .add_modifier(Modifier::BOLD)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -455,18 +565,16 @@ mod tests {
         let light = Theme::ansi_light();
         assert_ne!(light.text_primary, dark.text_primary);
         assert_ne!(light.title_active, dark.title_active);
-        // The light ANSI palette must avoid the bright foregrounds that wash
-        // out against a light default background.
-        for color in [
-            light.text_primary,
-            light.title_active,
-            light.footer,
-            light.muted_text,
-        ] {
+        // These ANSI colors can wash out against a light default background.
+        let assert_dark_foreground = |name: &str, color: Color| {
             assert!(
                 !matches!(
                     color,
                     Color::White
+                        | Color::Yellow
+                        | Color::Green
+                        | Color::Cyan
+                        | Color::Gray
                         | Color::LightRed
                         | Color::LightGreen
                         | Color::LightYellow
@@ -474,18 +582,49 @@ mod tests {
                         | Color::LightMagenta
                         | Color::LightCyan
                 ),
-                "bright foreground on a light ANSI background: {color:?}"
+                "low-contrast foreground for {name} on a light ANSI background: {color:?}"
             );
+        };
+        for (name, color) in [
+            ("text", light.text_primary),
+            ("title", light.title_active),
+            ("footer", light.footer),
+            ("muted text", light.muted_text),
+            ("range", light.range_fg),
+            ("local origin", light.local_origin),
+            ("remote origin", light.remote_origin),
+            ("code", light.code),
+            ("link", light.link),
+            ("quote", light.quote),
+            ("success", light.success),
+            ("user", light.user),
+            ("output", light.output),
+            ("structure", light.structure),
+            ("structure result", light.structure_result),
+        ] {
+            assert_dark_foreground(name, color);
+        }
+        for spec in AgentProvider::all() {
+            assert_dark_foreground(spec.name, provider_colors(spec.provider).ansi_light);
         }
     }
 
     #[test]
-    fn only_bright_ansi_backgrounds_count_as_light() {
-        assert!(colorfgbg_is_light("0;15"), "bright white background");
-        assert!(!colorfgbg_is_light("15;0"), "black background");
-        assert!(!colorfgbg_is_light("15;16"), "256-color dark blue");
-        assert!(!colorfgbg_is_light("15;232"), "256-color near-black");
-        assert!(!colorfgbg_is_light("15;default"));
-        assert!(!colorfgbg_is_light("garbage"));
+    fn fixed_preference_disables_auto_polling() {
+        assert!(auto_interval().is_some(), "auto mode polls by default");
+        apply(ThemeMode::Dark);
+        assert_eq!(auto_interval(), None, "fixed dark does not poll");
+        apply(ThemeMode::Light);
+        assert_eq!(auto_interval(), None, "fixed light does not poll");
+        apply(ThemeMode::Auto);
+        assert!(auto_interval().is_some());
+    }
+
+    #[test]
+    fn refresh_outside_auto_mode_never_swaps() {
+        apply(ThemeMode::Dark);
+        assert!(!refresh_if_changed());
+        apply(ThemeMode::Light);
+        assert!(!refresh_if_changed());
     }
 }

--- a/src/tui/workspace/render.rs
+++ b/src/tui/workspace/render.rs
@@ -367,10 +367,7 @@ fn session_row_line(
         Style::default().fg(theme::text_primary()),
     ));
     if body_failed {
-        spans.push(Span::styled(
-            " [!]",
-            Style::default().fg(Color::Rgb(248, 113, 113)), // red-400
-        ));
+        spans.push(Span::styled(" [!]", Style::default().fg(theme::failure())));
     }
     Line::from(spans)
 }

--- a/src/tui/workspace/render.rs
+++ b/src/tui/workspace/render.rs
@@ -1,7 +1,7 @@
 //! Workspace browser painting (lists, dual content panes, overlays, footer).
 
 use ratatui::layout::{Constraint, Direction, Layout, Margin, Rect};
-use ratatui::prelude::{Color, Frame, Modifier, Position, Style};
+use ratatui::prelude::{Frame, Modifier, Position, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Clear, ListItem, ListState, Paragraph};
 use regex::Regex;
@@ -364,7 +364,7 @@ fn session_row_line(
     spans.extend(highlight_spans(
         &title,
         highlight,
-        Style::default().fg(Color::Rgb(226, 232, 240)),
+        Style::default().fg(theme::text_primary()),
     ));
     if body_failed {
         spans.push(Span::styled(
@@ -546,7 +546,7 @@ fn render_help_panel(frame: &mut Frame, area: Rect, state: &ListState) {
                 Span::styled(format!("{:<12}", entry.key), theme::key_hint_style()),
                 Span::styled(
                     entry.description.to_string(),
-                    Style::default().fg(Color::Rgb(203, 213, 225)),
+                    Style::default().fg(theme::help_text()),
                 ),
             ]))
         })
@@ -653,7 +653,7 @@ fn render_source_strip(
             active_item_style()
         } else {
             match load {
-                SourceLoadMarker::Failed => Style::default().fg(Color::Rgb(248, 113, 113)),
+                SourceLoadMarker::Failed => Style::default().fg(theme::failure()),
                 SourceLoadMarker::Loading => Style::default().fg(theme::accent()),
                 SourceLoadMarker::Ready if selected => Style::default().fg(source.color()),
                 SourceLoadMarker::Idle if selected => Style::default().fg(theme::muted()),
@@ -798,7 +798,7 @@ fn render_dialogue_list(
                 ListItem::new(Line::from(highlight_spans(
                     &line,
                     highlight,
-                    Style::default().fg(Color::Rgb(203, 213, 225)),
+                    Style::default().fg(theme::help_text()),
                 )))
             }
         })


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable TUI themes with automatic, dark, and light modes.
  * Added terminal-aware color palettes, including ANSI-compatible themes.
  * Applied theme settings across markdown, workspace content, selections, search highlights, and interface elements.
  * Automatic theme mode refreshes when system appearance changes.
  * Added validation for theme configuration values and settings.
  * Improved raw-mode styling for structural markers while preserving literal content.

* **Bug Fixes**
  * Improved workspace reset behavior when changing sources or clearing search state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->