### PR TITLE
fix(codex): make watch exports incremental

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,6 +1348,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2031,6 +2040,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+dependencies = [
+ "bitflags 2.13.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,6 +2393,26 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.19",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
 ]
 
 [[package]]
@@ -2841,6 +2890,33 @@ dependencies = [
  "socket2",
  "tracing",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.13.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4406,6 +4482,7 @@ dependencies = [
  "getrandom 0.4.3",
  "iroh",
  "libc",
+ "notify",
  "pulldown-cmark",
  "ratatui",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ ureq = { version = "3.3.0", default-features = false, features = ["rustls"] }
 zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
 flate2 = "1.1.9"
 tar = { version = "0.4.46", default-features = false }
+notify = "8.2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/docs-site/src/content/docs/reference/cli.md
+++ b/docs-site/src/content/docs/reference/cli.md
@@ -725,9 +725,14 @@ Options:
 | --- | --- |
 | `--dest <PATH>` | Destination directory that will receive the `sessions/` tree |
 | `--limit <N>` | Keep only newest N session files; `0` means export all |
-| `--watch` | Continue mirroring local sessions |
-| `--interval <SECONDS>` | Seconds between sync passes when watching; default is `1` |
-| `--interval-ms <MILLISECONDS>` | Milliseconds between sync passes; overrides `--interval` |
+| `--watch` | Continue mirroring with native filesystem wakeups and periodic reconciliation |
+| `--interval <SECONDS>` | Maximum seconds between reconciliation passes; default is `1` |
+| `--interval-ms <MILLISECONDS>` | Maximum milliseconds between reconciliation passes; overrides `--interval` |
+
+Native filesystem events can trigger an earlier pass. If native watching is unavailable or
+disconnects, export falls back to periodic polling. Stable files are not republished; verified
+append-only growth writes only the new suffix. After a restart or filesystem migration, export
+verifies file content before resuming incremental writes.
 
 Examples:
 

--- a/docs-site/src/content/docs/zh-cn/reference/cli.md
+++ b/docs-site/src/content/docs/zh-cn/reference/cli.md
@@ -723,9 +723,13 @@ sivtr codex export --dest <PATH> [OPTIONS]
 | --- | --- |
 | `--dest <PATH>` | 接收 `sessions/` 树的目标目录 |
 | `--limit <N>` | 只保留最新 N 个 session 文件；`0` 表示全部导出 |
-| `--watch` | 持续 mirror 本地 session |
-| `--interval <SECONDS>` | watch 时两次同步之间的秒数；默认 `1` |
-| `--interval-ms <MILLISECONDS>` | 两次同步之间的毫秒数；覆盖 `--interval` |
+| `--watch` | 通过原生文件事件唤醒与周期 reconcile 持续 mirror 本地 session |
+| `--interval <SECONDS>` | 两次周期 reconcile 的最大秒数；默认 `1` |
+| `--interval-ms <MILLISECONDS>` | 两次周期 reconcile 的最大毫秒数；覆盖 `--interval` |
+
+原生文件事件可以提前触发同步。原生 watcher 不可用或断开时，export 会回退到周期轮询。
+稳定文件不会重新发布；经过验证的追加增长只写入新增后缀。进程重启或文件系统迁移后，
+export 会先验证文件内容，再恢复增量写入。
 
 示例：
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1177,11 +1177,11 @@ pub struct CodexExportArgs {
     #[arg(long, default_value_t = false)]
     pub watch: bool,
 
-    /// Seconds between sync passes when `--watch` is enabled
+    /// Maximum seconds between periodic reconciliation passes when `--watch` is enabled
     #[arg(long, value_name = "SECONDS", default_value_t = 1, requires = "watch")]
     pub interval: u64,
 
-    /// Milliseconds between sync passes when `--watch` is enabled (overrides `--interval`)
+    /// Maximum milliseconds between periodic reconciliation passes (overrides `--interval`)
     #[arg(long, value_name = "MILLISECONDS", requires = "watch")]
     pub interval_ms: Option<u64>,
 }

--- a/src/commands/system/codex.rs
+++ b/src/commands/system/codex.rs
@@ -1,12 +1,39 @@
 use crate::cli::{CodexAction, CodexCommand, CodexExportArgs};
 use anyhow::{Context, Result};
+use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use sha2::{Digest, Sha256};
 use sivtr_core::codex::local_codex_sessions_dir;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
+use std::io::{ErrorKind, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+use std::sync::mpsc::{sync_channel, Receiver, RecvTimeoutError, TryRecvError, TrySendError};
 use std::thread;
 use std::time::Duration;
 use std::time::SystemTime;
+
+const MAX_INCREMENTAL_APPEND_BYTES: u64 = 8 * 1024 * 1024;
+const CONTENT_FINGERPRINT_BUFFER_BYTES: usize = 64 * 1024;
+const APPEND_PREFIX_GUARD_BYTES: u64 = 64 * 1024;
+const WATCH_DEBOUNCE_LIMIT: Duration = Duration::from_millis(250);
+
+#[derive(Debug)]
+enum WatchSignal {
+    Changed,
+    Failed(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExportWait {
+    Changed,
+    ReconcileTimeout,
+    WatcherDisconnected,
+}
+
+struct ExportWakeup {
+    receiver: Receiver<WatchSignal>,
+    _watcher: RecommendedWatcher,
+}
 
 pub fn execute(command: CodexCommand) -> Result<()> {
     match command.action {
@@ -25,19 +52,40 @@ fn export(args: CodexExportArgs) -> Result<()> {
         .watch
         .then(|| resolve_watch_interval(&args))
         .transpose()?;
+    let mut export_wakeup = watch_interval.and_then(|_| match start_export_wakeup(&source_root) {
+        Ok(wakeup) => Some(wakeup),
+        Err(error) => {
+            eprintln!(
+                "sivtr: warning: native Codex session watching is unavailable; polling instead: {error}"
+            );
+            None
+        }
+    });
+    let mut checkpoints = HashMap::new();
 
     loop {
-        let copied = export_once(&source_root, &target_root, args.limit)?;
-        eprintln!(
-            "sivtr: mirrored {} Codex session file(s) to {}",
-            copied,
-            target_root.display()
-        );
+        let copied = export_once(&source_root, &target_root, args.limit, &mut checkpoints)?;
+        if copied > 0 || watch_interval.is_none() {
+            eprintln!(
+                "sivtr: updated {} Codex session file(s) in {}",
+                copied,
+                target_root.display()
+            );
+        }
 
         let Some(watch_interval) = watch_interval else {
             return Ok(());
         };
-        thread::sleep(watch_interval);
+        let wait = export_wakeup
+            .as_ref()
+            .map(|wakeup| wait_for_export_cycle(&wakeup.receiver, watch_interval));
+        if wait == Some(ExportWait::WatcherDisconnected) {
+            eprintln!("sivtr: warning: Codex session watcher disconnected; polling instead");
+            export_wakeup = None;
+            thread::sleep(watch_interval);
+        } else if wait.is_none() {
+            thread::sleep(watch_interval);
+        }
     }
 }
 
@@ -56,7 +104,60 @@ fn resolve_watch_interval(args: &CodexExportArgs) -> Result<Duration> {
     Ok(Duration::from_secs(args.interval))
 }
 
-fn export_once(source_root: &Path, target_root: &Path, limit: usize) -> Result<usize> {
+fn wait_for_export_cycle(receiver: &Receiver<WatchSignal>, interval: Duration) -> ExportWait {
+    match receiver.recv_timeout(interval) {
+        Ok(signal) => {
+            report_watch_signal(signal);
+            thread::sleep(interval.min(WATCH_DEBOUNCE_LIMIT));
+            loop {
+                match receiver.try_recv() {
+                    Ok(signal) => report_watch_signal(signal),
+                    Err(TryRecvError::Empty) => return ExportWait::Changed,
+                    Err(TryRecvError::Disconnected) => return ExportWait::WatcherDisconnected,
+                }
+            }
+        }
+        Err(RecvTimeoutError::Timeout) => ExportWait::ReconcileTimeout,
+        Err(RecvTimeoutError::Disconnected) => ExportWait::WatcherDisconnected,
+    }
+}
+
+fn report_watch_signal(signal: WatchSignal) {
+    if let WatchSignal::Failed(error) = signal {
+        eprintln!("sivtr: warning: Codex session watcher failed: {error}");
+    }
+}
+
+fn start_export_wakeup(source_root: &Path) -> Result<ExportWakeup> {
+    let (sender, receiver) = sync_channel(1);
+    let mut watcher = notify::recommended_watcher(move |event: notify::Result<notify::Event>| {
+        let signal = match event {
+            Ok(_) => WatchSignal::Changed,
+            Err(error) => WatchSignal::Failed(error.to_string()),
+        };
+        // Capacity one deliberately coalesces bursts; reconciliation covers dropped wakeups.
+        match sender.try_send(signal) {
+            Ok(()) | Err(TrySendError::Full(_)) => {}
+            Err(TrySendError::Disconnected(_)) => (),
+        }
+    })
+    .context("Failed to initialize native filesystem watcher")?;
+    watcher
+        .watch(source_root, RecursiveMode::Recursive)
+        .with_context(|| format!("Failed to watch {}", source_root.display()))?;
+
+    Ok(ExportWakeup {
+        receiver,
+        _watcher: watcher,
+    })
+}
+
+fn export_once(
+    source_root: &Path,
+    target_root: &Path,
+    limit: usize,
+    checkpoints: &mut HashMap<PathBuf, LocalFileObservation>,
+) -> Result<usize> {
     let files = collect_session_files(source_root, limit)?;
     if files.is_empty() {
         anyhow::bail!("No local Codex sessions found at {}", source_root.display());
@@ -67,6 +168,7 @@ fn export_once(source_root: &Path, target_root: &Path, limit: usize) -> Result<u
     set_shared_read_permissions(target_root)?;
 
     let mut kept = HashSet::new();
+    let mut updated = 0;
     let mut seen_dirs = HashSet::new();
     // Copy oldest -> newest so exported mtimes preserve true recency.
     // Copying newest first would make older files appear newer in the shared tree.
@@ -84,11 +186,17 @@ fn export_once(source_root: &Path, target_root: &Path, limit: usize) -> Result<u
                 set_shared_read_permissions_recursive(target_root, parent)?;
             }
         }
-        copy_session_file_atomically(source, &target)?;
+        let published =
+            synchronize_session_file(source, &target, checkpoints.get(relative).copied())?;
+        checkpoints.insert(relative.to_path_buf(), published.source);
+        if published.change != SessionFileChange::Unchanged {
+            updated += 1;
+        }
     }
 
     remove_stale_exported_files(target_root, &kept);
-    Ok(files.len())
+    checkpoints.retain(|relative, _| kept.contains(relative));
+    Ok(updated)
 }
 
 fn collect_session_files(root: &Path, limit: usize) -> Result<Vec<PathBuf>> {
@@ -119,11 +227,218 @@ fn modified_time(path: &Path) -> Result<SystemTime> {
     Ok(fs::metadata(path)?.modified()?)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct LocalFileObservation {
+    len: u64,
+    modified: SystemTime,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PortableContentFingerprint {
+    len: u64,
+    sha256: [u8; 32],
+}
+
+fn local_file_observation(path: &Path) -> Result<LocalFileObservation> {
+    let metadata = fs::metadata(path)?;
+    Ok(LocalFileObservation {
+        len: metadata.len(),
+        modified: metadata.modified()?,
+    })
+}
+
+fn exported_file_observation(path: &Path) -> Result<Option<LocalFileObservation>> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    if !metadata.file_type().is_file() {
+        return Ok(None);
+    }
+    Ok(Some(LocalFileObservation {
+        len: metadata.len(),
+        modified: metadata.modified()?,
+    }))
+}
+
+fn portable_content_fingerprint(path: &Path, byte_len: u64) -> Result<PortableContentFingerprint> {
+    let mut file = fs::File::open(path)
+        .with_context(|| format!("Failed to open {} for content verification", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0; CONTENT_FINGERPRINT_BUFFER_BYTES];
+    let mut remaining = byte_len;
+
+    while remaining > 0 {
+        let chunk_len = remaining.min(buffer.len() as u64) as usize;
+        file.read_exact(&mut buffer[..chunk_len]).with_context(|| {
+            format!(
+                "File changed while verifying {} at {} bytes",
+                path.display(),
+                byte_len
+            )
+        })?;
+        hasher.update(&buffer[..chunk_len]);
+        remaining -= chunk_len as u64;
+    }
+
+    Ok(PortableContentFingerprint {
+        len: byte_len,
+        sha256: hasher.finalize().into(),
+    })
+}
+
+fn target_is_source_prefix(source: &Path, target: &Path, target_len: u64) -> Result<bool> {
+    Ok(portable_content_fingerprint(source, target_len)?
+        == portable_content_fingerprint(target, target_len)?)
+}
+
+fn source_matches_target_tail(source: &Path, target: &Path, target_len: u64) -> Result<bool> {
+    let guard_len = target_len.min(APPEND_PREFIX_GUARD_BYTES);
+    let offset = target_len - guard_len;
+    let guard_len = usize::try_from(guard_len).context("Codex prefix guard is too large")?;
+    let mut source_guard = vec![0; guard_len];
+    let mut target_guard = vec![0; guard_len];
+
+    let mut source_file = fs::File::open(source)
+        .with_context(|| format!("Failed to open Codex session {}", source.display()))?;
+    source_file
+        .seek(SeekFrom::Start(offset))
+        .with_context(|| format!("Failed to seek Codex session {}", source.display()))?;
+    source_file
+        .read_exact(&mut source_guard)
+        .with_context(|| format!("Codex session changed while verifying {}", source.display()))?;
+
+    let mut target_file = fs::File::open(target)
+        .with_context(|| format!("Failed to open Codex export {}", target.display()))?;
+    target_file
+        .seek(SeekFrom::Start(offset))
+        .with_context(|| format!("Failed to seek Codex export {}", target.display()))?;
+    target_file
+        .read_exact(&mut target_guard)
+        .with_context(|| format!("Codex export changed while verifying {}", target.display()))?;
+
+    Ok(source_guard == target_guard)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionFileChange {
+    Unchanged,
+    Appended,
+    Replaced,
+}
+
+struct PublishedSessionFile {
+    change: SessionFileChange,
+    source: LocalFileObservation,
+}
+
+fn synchronize_session_file(
+    source: &Path,
+    target: &Path,
+    last_published: Option<LocalFileObservation>,
+) -> Result<PublishedSessionFile> {
+    let source_observation = local_file_observation(source)?;
+    let target_observation = exported_file_observation(target)?;
+
+    if target_observation == Some(source_observation) && last_published == Some(source_observation)
+    {
+        set_shared_read_permissions(target)?;
+        return Ok(PublishedSessionFile {
+            change: SessionFileChange::Unchanged,
+            source: source_observation,
+        });
+    }
+
+    if target_observation.is_some_and(|target| target.len == source_observation.len)
+        && target_is_source_prefix(source, target, source_observation.len)?
+    {
+        set_shared_read_permissions(target)?;
+        if target_observation != Some(source_observation) {
+            preserve_source_modified_time(source, target);
+        }
+        return Ok(PublishedSessionFile {
+            change: SessionFileChange::Unchanged,
+            source: source_observation,
+        });
+    }
+
+    let append_fits_memory = target_observation.is_some_and(|target| {
+        source_observation.len > target.len
+            && source_observation.len - target.len <= MAX_INCREMENTAL_APPEND_BYTES
+    });
+    let hot_prefix_candidate = last_published == target_observation
+        && last_published.is_some_and(|published| source_observation.len > published.len)
+        && append_fits_memory;
+    let trusted_hot_prefix = if hot_prefix_candidate {
+        let target_len = target_observation
+            .map(|observation| observation.len)
+            .context("Missing target observation for prefix guard")?;
+        source_matches_target_tail(source, target, target_len)?
+    } else {
+        false
+    };
+    let verified_cold_prefix = if !trusted_hot_prefix && append_fits_memory {
+        let target_len = target_observation
+            .map(|observation| observation.len)
+            .context("Missing target observation for prefix verification")?;
+        target_is_source_prefix(source, target, target_len)?
+    } else {
+        false
+    };
+
+    if trusted_hot_prefix || verified_cold_prefix {
+        let offset = target_observation
+            .map(|observation| observation.len)
+            .context("Missing target observation for incremental append")?;
+        append_session_file_snapshot(source, target, offset, source_observation)?;
+        return Ok(PublishedSessionFile {
+            change: SessionFileChange::Appended,
+            source: source_observation,
+        });
+    }
+
+    copy_session_file_atomically(source, target)?;
+    Ok(PublishedSessionFile {
+        change: SessionFileChange::Replaced,
+        source: source_observation,
+    })
+}
+
+fn append_session_file_snapshot(
+    source: &Path,
+    target: &Path,
+    offset: u64,
+    source_observation: LocalFileObservation,
+) -> Result<()> {
+    let append_len = source_observation.len - offset;
+    let append_len = usize::try_from(append_len).context("Codex append is too large for memory")?;
+    let mut appended = vec![0; append_len];
+    let mut source_file = fs::File::open(source)
+        .with_context(|| format!("Failed to open Codex session {}", source.display()))?;
+    source_file
+        .seek(SeekFrom::Start(offset))
+        .with_context(|| format!("Failed to seek Codex session {}", source.display()))?;
+    source_file
+        .read_exact(&mut appended)
+        .with_context(|| format!("Codex session changed while reading {}", source.display()))?;
+
+    let mut target_file = fs::OpenOptions::new()
+        .append(true)
+        .open(target)
+        .with_context(|| format!("Failed to append Codex session {}", target.display()))?;
+    target_file
+        .write_all(&appended)
+        .with_context(|| format!("Failed to append Codex session {}", target.display()))?;
+    drop(target_file);
+    set_shared_read_permissions(target)?;
+    preserve_source_modified_time(source, target);
+    Ok(())
+}
+
 fn copy_session_file_atomically(source: &Path, target: &Path) -> Result<()> {
     let temp = target.with_extension("jsonl.tmp");
-    if temp.exists() {
-        fs::remove_file(&temp).with_context(|| format!("Failed to remove {}", temp.display()))?;
-    }
+    remove_existing_atomic_temp_file(&temp)?;
 
     fs::copy(source, &temp).with_context(|| {
         format!(
@@ -135,6 +450,19 @@ fn copy_session_file_atomically(source: &Path, target: &Path) -> Result<()> {
     set_shared_read_permissions(&temp)?;
     fs::rename(&temp, target).with_context(|| format!("Failed to publish {}", target.display()))?;
     preserve_source_modified_time(source, target);
+    Ok(())
+}
+
+fn remove_existing_atomic_temp_file(temp: &Path) -> Result<()> {
+    let metadata = match fs::symlink_metadata(temp) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.file_type().is_dir() {
+        anyhow::bail!("Atomic export temp path is a directory: {}", temp.display());
+    }
+    fs::remove_file(temp).with_context(|| format!("Failed to remove {}", temp.display()))?;
     Ok(())
 }
 
@@ -251,6 +579,9 @@ fn set_shared_read_permissions(path: &Path) -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
     let mode = if path.is_dir() { 0o755 } else { 0o644 };
+    if fs::metadata(path)?.permissions().mode() & 0o7777 == mode {
+        return Ok(());
+    }
     fs::set_permissions(path, fs::Permissions::from_mode(mode))
         .with_context(|| format!("Failed to chmod {}", path.display()))?;
     Ok(())
@@ -282,12 +613,17 @@ mod tests {
     #[cfg(unix)]
     use super::set_shared_read_permissions_recursive;
     use super::{
-        collect_session_files, copy_session_file_atomically, export_once, resolve_watch_interval,
+        collect_session_files, copy_session_file_atomically, export_once, local_file_observation,
+        resolve_watch_interval, start_export_wakeup, synchronize_session_file,
+        wait_for_export_cycle, ExportWait, SessionFileChange, WatchSignal,
     };
     use crate::cli::CodexExportArgs;
+    use std::collections::HashMap;
+    use std::io::Write;
     #[cfg(unix)]
     use std::path::Path;
     use std::path::PathBuf;
+    use std::sync::mpsc::sync_channel;
     use std::time::Duration;
 
     #[test]
@@ -364,10 +700,79 @@ mod tests {
         )
         .unwrap();
 
-        export_once(&source_root, &target_root, 1).unwrap();
+        let mut checkpoints = HashMap::new();
+        export_once(&source_root, &target_root, 1, &mut checkpoints).unwrap();
 
         assert!(target_root.join("2026/05/08/newest.jsonl").exists());
         assert!(!target_root.join("2026/05/08/older.jsonl").exists());
+        assert_eq!(checkpoints.len(), 1);
+        assert!(checkpoints.contains_key(&PathBuf::from("2026/05/08/newest.jsonl")));
+    }
+
+    #[test]
+    fn export_once_skips_unchanged_files_and_republishes_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_root = dir.path().join("source");
+        let target_root = dir.path().join("target").join("sessions");
+        std::fs::create_dir_all(&source_root).unwrap();
+        let source = source_root.join("session.jsonl");
+        let mut checkpoints = HashMap::new();
+
+        std::fs::write(&source, "initial\n").unwrap();
+        assert_eq!(
+            export_once(&source_root, &target_root, 0, &mut checkpoints).unwrap(),
+            1
+        );
+        let target = target_root.join("session.jsonl");
+        let stable_metadata = std::fs::metadata(&target).unwrap();
+
+        assert_eq!(
+            export_once(&source_root, &target_root, 0, &mut checkpoints).unwrap(),
+            0
+        );
+        let unchanged_metadata = std::fs::metadata(&target).unwrap();
+        assert_eq!(
+            unchanged_metadata.modified().unwrap(),
+            stable_metadata.modified().unwrap()
+        );
+
+        std::fs::write(&source, "changed-content\n").unwrap();
+        assert_eq!(
+            export_once(&source_root, &target_root, 0, &mut checkpoints).unwrap(),
+            1
+        );
+        assert_eq!(
+            std::fs::read_to_string(target).unwrap(),
+            "changed-content\n"
+        );
+    }
+
+    #[test]
+    fn export_once_preserves_target_identity_for_append_growth() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_root = dir.path().join("source");
+        let target_root = dir.path().join("target").join("sessions");
+        std::fs::create_dir_all(&source_root).unwrap();
+        let source = source_root.join("session.jsonl");
+        std::fs::write(&source, "first\n").unwrap();
+        let mut checkpoints = HashMap::new();
+        export_once(&source_root, &target_root, 0, &mut checkpoints).unwrap();
+        let target = target_root.join("session.jsonl");
+        let target_alias = target_root.join("session-alias");
+        std::fs::hard_link(&target, &target_alias).unwrap();
+
+        let mut source_file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&source)
+            .unwrap();
+        source_file.write_all(b"second\n").unwrap();
+        drop(source_file);
+        export_once(&source_root, &target_root, 0, &mut checkpoints).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(target_alias).unwrap(),
+            "first\nsecond\n"
+        );
     }
 
     #[test]
@@ -392,7 +797,8 @@ mod tests {
         )
         .unwrap();
 
-        export_once(&source_root, &target_root, 0).unwrap();
+        let mut checkpoints = HashMap::new();
+        export_once(&source_root, &target_root, 0, &mut checkpoints).unwrap();
 
         let exported = collect_session_files(&target_root, 0).unwrap();
         assert_eq!(exported.len(), 2);
@@ -418,6 +824,172 @@ mod tests {
 
         assert_eq!(std::fs::read_to_string(&target).unwrap(), "new data\n");
         assert!(!dir.path().join("target.jsonl.tmp").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_copy_does_not_follow_dangling_temp_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.jsonl");
+        let target = dir.path().join("target.jsonl");
+        let temp = dir.path().join("target.jsonl.tmp");
+        let victim = dir.path().join("victim.jsonl");
+        std::fs::write(&source, "safe\n").unwrap();
+        symlink(&victim, &temp).unwrap();
+
+        copy_session_file_atomically(&source, &target).unwrap();
+
+        assert!(!victim.exists());
+        assert_eq!(std::fs::read_to_string(target).unwrap(), "safe\n");
+        assert!(std::fs::symlink_metadata(temp).is_err());
+    }
+
+    #[test]
+    fn session_file_sync_appends_verified_growth() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.jsonl");
+        let target = dir.path().join("target.jsonl");
+        std::fs::write(&source, "first\n").unwrap();
+        copy_session_file_atomically(&source, &target).unwrap();
+        let last_published = local_file_observation(&source).unwrap();
+
+        let mut source_file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&source)
+            .unwrap();
+        source_file.write_all(b"second\n").unwrap();
+        drop(source_file);
+
+        let published = synchronize_session_file(&source, &target, Some(last_published)).unwrap();
+
+        assert_eq!(published.change, SessionFileChange::Appended);
+        assert_eq!(std::fs::read_to_string(target).unwrap(), "first\nsecond\n");
+    }
+
+    #[test]
+    fn session_file_sync_recovers_append_after_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.jsonl");
+        let target = dir.path().join("target.jsonl");
+        std::fs::write(&source, "first\n").unwrap();
+        copy_session_file_atomically(&source, &target).unwrap();
+
+        let mut source_file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&source)
+            .unwrap();
+        source_file.write_all(b"second\n").unwrap();
+        drop(source_file);
+
+        let published = synchronize_session_file(&source, &target, None).unwrap();
+
+        assert_eq!(published.change, SessionFileChange::Appended);
+        assert_eq!(std::fs::read_to_string(target).unwrap(), "first\nsecond\n");
+    }
+
+    #[test]
+    fn session_file_sync_accepts_identical_migrated_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.jsonl");
+        let target = dir.path().join("target.jsonl");
+        std::fs::write(&source, "portable\n").unwrap();
+        copy_session_file_atomically(&source, &target).unwrap();
+        let target_file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&target)
+            .unwrap();
+        target_file
+            .set_times(
+                std::fs::FileTimes::new()
+                    .set_modified(std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(1)),
+            )
+            .unwrap();
+
+        let published = synchronize_session_file(&source, &target, None).unwrap();
+
+        assert_eq!(published.change, SessionFileChange::Unchanged);
+        assert_eq!(
+            std::fs::metadata(target).unwrap().modified().unwrap(),
+            std::fs::metadata(source).unwrap().modified().unwrap()
+        );
+    }
+
+    #[test]
+    fn session_file_sync_verifies_cold_start_metadata_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.jsonl");
+        let target = dir.path().join("target.jsonl");
+        std::fs::write(&source, "source\n").unwrap();
+        std::fs::write(&target, "target\n").unwrap();
+        let source_modified = std::fs::metadata(&source).unwrap().modified().unwrap();
+        let target_file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&target)
+            .unwrap();
+        target_file
+            .set_times(std::fs::FileTimes::new().set_modified(source_modified))
+            .unwrap();
+
+        let published = synchronize_session_file(&source, &target, None).unwrap();
+
+        assert_eq!(published.change, SessionFileChange::Replaced);
+        assert_eq!(std::fs::read_to_string(target).unwrap(), "source\n");
+    }
+
+    #[test]
+    fn session_file_sync_replaces_same_length_rewrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.jsonl");
+        let target = dir.path().join("target.jsonl");
+        std::fs::write(&source, "before\n").unwrap();
+        copy_session_file_atomically(&source, &target).unwrap();
+        std::fs::write(&source, "after!\n").unwrap();
+
+        let published = synchronize_session_file(&source, &target, None).unwrap();
+
+        assert_eq!(published.change, SessionFileChange::Replaced);
+        assert_eq!(std::fs::read_to_string(target).unwrap(), "after!\n");
+    }
+
+    #[test]
+    fn session_file_sync_replaces_truncated_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.jsonl");
+        let target = dir.path().join("target.jsonl");
+        std::fs::write(&source, "first\nsecond\n").unwrap();
+        copy_session_file_atomically(&source, &target).unwrap();
+        std::fs::write(&source, "first\n").unwrap();
+
+        let published = synchronize_session_file(&source, &target, None).unwrap();
+
+        assert_eq!(published.change, SessionFileChange::Replaced);
+        assert_eq!(std::fs::read_to_string(target).unwrap(), "first\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn session_file_sync_replaces_target_symlink_without_following_it() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.jsonl");
+        let target = dir.path().join("target.jsonl");
+        let victim = dir.path().join("victim.jsonl");
+        std::fs::write(&source, "first\nsecond\n").unwrap();
+        std::fs::write(&victim, "first\n").unwrap();
+        symlink(&victim, &target).unwrap();
+
+        let published = synchronize_session_file(&source, &target, None).unwrap();
+
+        assert_eq!(published.change, SessionFileChange::Replaced);
+        assert_eq!(std::fs::read_to_string(&victim).unwrap(), "first\n");
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "first\nsecond\n");
+        assert!(!std::fs::symlink_metadata(target)
+            .unwrap()
+            .file_type()
+            .is_symlink());
     }
 
     #[test]
@@ -478,5 +1050,42 @@ mod tests {
         assert!(error
             .to_string()
             .contains("`--interval-ms` must be greater than 0"));
+    }
+
+    #[test]
+    fn export_wait_wakes_before_reconciliation_timeout() {
+        let (sender, receiver) = sync_channel(1);
+        sender.send(WatchSignal::Changed).unwrap();
+
+        let wait = wait_for_export_cycle(&receiver, Duration::from_secs(2));
+
+        assert_eq!(wait, ExportWait::Changed);
+    }
+
+    #[test]
+    fn export_watcher_reports_source_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let wakeup = start_export_wakeup(dir.path()).unwrap();
+
+        std::fs::write(dir.path().join("session.jsonl"), "event\n").unwrap();
+        let wait = wait_for_export_cycle(&wakeup.receiver, Duration::from_secs(5));
+
+        assert_eq!(wait, ExportWait::Changed);
+    }
+
+    #[test]
+    fn export_wait_distinguishes_timeout_and_disconnection() {
+        let (_sender, receiver) = sync_channel(1);
+        assert_eq!(
+            wait_for_export_cycle(&receiver, Duration::from_millis(1)),
+            ExportWait::ReconcileTimeout
+        );
+
+        let (sender, receiver) = sync_channel(1);
+        drop(sender);
+        assert_eq!(
+            wait_for_export_cycle(&receiver, Duration::from_secs(1)),
+            ExportWait::WatcherDisconnected
+        );
     }
 }


### PR DESCRIPTION
## 1. Context & Motivation (Context)
- **Issue:** Fixes the correctness and write-amplification failure mode in `codex export --watch`.
- **Problem:** The exporter treated filesystem metadata as sufficient identity and recopied full JSONL snapshots on every polling cycle. mtime drift across filesystems could also trigger unnecessary rewrites, while watcher loss could leave the projection stale.
- **Trade-offs:** Process-local `len + mtime` observations keep the hot path cheap; portable identity is `len + SHA-256(content)` and excludes inode, device, path, and timestamp metadata. Stable files avoid writes entirely. Appends up to 8 MiB are copied incrementally, using a 64 KiB guard on the hot path and full prefix verification on cold or metadata-drift paths. This uses bounded memory and occasional hashing to reduce storage churn.

## 2. Implementation Details (Implementation)
- Added stable-file detection, cold-start content verification, atomic replacement for rewrites, truncation, and prefix divergence, plus incremental append for growing JSONL sessions.
- Added bounded watcher wakeups with debounce, periodic reconciliation, and polling fallback after watcher initialization failure or disconnection.
- Added symlink and dangling-temp protections, and stale checkpoint cleanup.
- Updated English and Chinese CLI documentation and help text.
- **Migration identity:** The content fingerprint is deterministic across Windows, Linux, and macOS and independent of filesystem-specific metadata, enabling future multi-platform migration semantics, including the direction discussed around PRs #70 and #71.
- **Scope note:** This remains a read-only JSONL projection. It does not claim reply routing, exactly-once delivery, session ownership, offline command replay, or a bidirectional mobile control plane.

## 3. Testing Strategies (Validation)
- [x] Added regression tests for stable rounds, hot and cold append, mtime drift, metadata collision, same-length rewrite, truncate, stale checkpoints, symlink targets, dangling temp symlinks, watcher wakeup, timeout, and disconnect.
- [x] Ran `cargo fmt --all -- --check`.
- [x] Ran `cargo clippy --workspace --all-targets --locked -- -D warnings`.
- [x] Ran `cargo test --workspace --locked` (512 passed).
- [x] Ran `cargo build --release --locked`.
- **Benchmark:** On `/dev/shm`, a steady 128 MiB file for 3 seconds at 100 ms produced baseline `wchar_delta=2376`, `syscw_delta=24`; the candidate produced `wchar_delta=0`, `syscw_delta=0`, with equivalent approximately 3.8 MiB RSS. For 20 x 4 KiB appends to a 64 MiB file, the baseline created 31 additional inodes; the candidate kept the same inode and wrote only the 81,920 appended bytes.

The branch was fetched and rebased on upstream `main` before submission. The docs-site dependency install could not be validated in this environment because the configured registry reported no matching `magic-string@^1.0.0`; source changes are limited to the existing docs files and the repository CI docs job remains the final authority.
