### PR TITLE
chore(renovate): auto-merge patch and minor dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "dependencyDashboard": true,
+  "platformAutomerge": true,
   "packageRules": [
     {
       "matchManagers": ["cargo"],
@@ -14,6 +15,10 @@
     {
       "matchFileNames": ["docs-site/**", "editors/vscode/**"],
       "labels": ["dependencies", "js"]
+    },
+    {
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
## What

- Enable `platformAutomerge` so Renovate delegates merging to GitHub's native auto-merge instead of merging itself.
- Auto-merge `patch` and `minor` dependency updates; `major` updates still require manual review.

## Why

Low-risk dependency updates no longer need a manual merge. Branch protection on `main` is split into two rulesets so the exception stays narrow:

- `main: required CI` — CI matrix, MSRV, and Dependency audit. The Renovate app is **not** in this ruleset's bypass list, so CI is always enforced, including on its own PRs.
- `main: required review` — one approving review, with the Renovate app in the bypass list (`pull_request` mode), so its auto-merge does not wait for a human review while a human-authored PR still does.

The previous classic-branch-protection review requirement was removed because it has no bypass mechanism and would block platform auto-merge.
