### PR TITLE
ci: AI-powered pull request review (provider-agnostic LLM)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -3,10 +3,17 @@ name: ai-review
 # AI-powered pull request review: a senior-reviewer prompt reads the PR diff
 # and submits an APPROVED / REQUEST_CHANGES review as github-actions[bot], so
 # the "required approving review" rule is satisfied by an actual code review
-# (not just green CI). Requires an OpenAI API key in the OPENAI_API_KEY secret.
+# (not just green CI). Provider-agnostic: any OpenAI-compatible chat-completions
+# endpoint works (OpenAI, DeepSeek, xAI, ...).
 #
-# Model is configurable via the AI_REVIEW_MODEL repository variable
-# (default: gpt-4o-mini).
+# Configuration (repository settings):
+#   secret    LLM_API_KEY              - API key for the chosen provider
+#   variable  AI_REVIEW_MODEL          - model name, e.g. deepseek-v4-flash (required)
+#   variable  AI_REVIEW_BASE_URL       - API base URL (optional; default
+#                                        https://api.deepseek.com/v1)
+#
+# The workflow fails closed: if LLM_API_KEY or AI_REVIEW_MODEL is missing, no
+# review is submitted.
 
 on:
   pull_request:
@@ -32,14 +39,23 @@ jobs:
 
       - name: Run AI review
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          AI_REVIEW_MODEL: ${{ vars.AI_REVIEW_MODEL || 'gpt-4o-mini' }}
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+          AI_REVIEW_MODEL: ${{ vars.AI_REVIEW_MODEL }}
+          AI_REVIEW_BASE_URL: ${{ vars.AI_REVIEW_BASE_URL || 'https://api.deepseek.com/v1' }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euo pipefail
           python3 - <<'PYEOF'
-          import json, os, urllib.error, urllib.request
+          import json, os, sys, urllib.error, urllib.request
+
+          api_key = os.environ.get("LLM_API_KEY", "")
+          model = os.environ.get("AI_REVIEW_MODEL", "")
+          if not api_key or not model:
+              print("::error::AI review is not configured: set the LLM_API_KEY "
+                    "secret and the AI_REVIEW_MODEL repository variable "
+                    "(optionally AI_REVIEW_BASE_URL). No review was submitted.")
+              sys.exit(1)
 
           with open("/tmp/pr.diff", encoding="utf-8", errors="replace") as f:
               diff = f.read()
@@ -57,7 +73,7 @@ jobs:
               "invent issues."
           )
           payload = {
-              "model": os.environ.get("AI_REVIEW_MODEL", "gpt-4o-mini"),
+              "model": model,
               "messages": [
                   {"role": "system", "content": system},
                   {"role": "user", "content": (
@@ -69,11 +85,12 @@ jobs:
               "temperature": 0.2,
               "response_format": {"type": "json_object"},
           }
+          url = os.environ.get("AI_REVIEW_BASE_URL", "https://api.deepseek.com/v1").rstrip("/") + "/chat/completions"
           req = urllib.request.Request(
-              "https://api.openai.com/v1/chat/completions",
+              url,
               data=json.dumps(payload).encode(),
               headers={
-                  "Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}",
+                  "Authorization": f"Bearer {api_key}",
                   "Content-Type": "application/json",
               },
           )
@@ -82,7 +99,7 @@ jobs:
                   data = json.load(resp)
           except urllib.error.HTTPError as e:
               body = e.read().decode(errors="replace")[:500]
-              print(f"::error::OpenAI API error: {e.code} {body}")
+              print(f"::error::LLM API error: {e.code} {body}")
               raise
           content = data["choices"][0]["message"]["content"]
           parsed = json.loads(content)

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -11,6 +11,10 @@ name: ai-review
 # judges exactly the commit CI tested, so its verdict complements (does not
 # replace) the CI gate. No green CI, no review.
 #
+# Security: this workflow_run job holds pull-requests: write, so it never
+# checks out the (untrusted) PR head. The diff is fetched from the compare
+# API instead, and all actions are pinned to commit SHAs.
+#
 # Configuration (repository settings):
 #   secret    LLM_API_KEY              - API key for the chosen provider
 #   variable  AI_REVIEW_MODEL          - model name, e.g. deepseek-v4-flash (required)
@@ -63,17 +67,18 @@ jobs:
           echo "$pr" | jq -r .body > /tmp/pr_body
           echo "Reviewed PR: #$(echo "$pr" | jq -r .number) by $(echo "$pr" | jq -r .user.login)" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Checkout PR head
-        if: steps.pr.outputs.skip != 'true'
-        uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_sha }}
-
       - name: Compute diff
         if: steps.pr.outputs.skip != 'true'
+        env:
+          BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          git diff "${{ steps.pr.outputs.base_sha }}...${{ github.event.workflow_run.head_sha }}" -- . ':!Cargo.lock' > /tmp/pr.diff || true
+          set -euo pipefail
+          # Compare API, not a checkout: this job is privileged (workflow_run),
+          # so the untrusted PR head is never checked out or executed.
+          gh api "repos/$GITHUB_REPOSITORY/compare/$BASE_SHA...$HEAD_SHA" \
+            --jq -r '.files[] | select(.filename != "Cargo.lock") | "\ndiff --git a/\(.filename) b/\(.filename)\n" + (.patch // "(patch unavailable: too large or binary)")' \
+            > /tmp/pr.diff
           echo "diff bytes: $(wc -c < /tmp/pr.diff)" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run AI review
@@ -161,7 +166,7 @@ jobs:
 
       - name: Submit review
         if: steps.pr.outputs.skip != 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,122 @@
+name: ai-review
+
+# AI-powered pull request review: a senior-reviewer prompt reads the PR diff
+# and submits an APPROVED / REQUEST_CHANGES review as github-actions[bot], so
+# the "required approving review" rule is satisfied by an actual code review
+# (not just green CI). Requires an OpenAI API key in the OPENAI_API_KEY secret.
+#
+# Model is configurable via the AI_REVIEW_MODEL repository variable
+# (default: gpt-4o-mini).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'github-actions[bot]'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute diff
+        run: |
+          git diff "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" -- . ':!Cargo.lock' > /tmp/pr.diff || true
+          echo "diff bytes: $(wc -c < /tmp/pr.diff)" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run AI review
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          AI_REVIEW_MODEL: ${{ vars.AI_REVIEW_MODEL || 'gpt-4o-mini' }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PYEOF'
+          import json, os, urllib.error, urllib.request
+
+          with open("/tmp/pr.diff", encoding="utf-8", errors="replace") as f:
+              diff = f.read()
+          if len(diff) > 150_000:
+              diff = diff[:150_000] + "\n... [diff truncated]"
+
+          system = (
+              "You are a senior code reviewer for the sivtr repository, a Rust terminal "
+              "workspace tool. Review the pull request diff strictly on its merits: "
+              "correctness, safety (no unwrap() in production; anyhow errors with context), "
+              "and adherence to the project's coding rules. Reply with ONLY a JSON object: "
+              '{"verdict": "approve" | "request_changes", "summary": "one or two sentences", '
+              '"comments": [{"path": "file", "comment": "text"}]}. Use "request_changes" only '
+              "for real blocking issues; a small correct diff should be approved. Do not "
+              "invent issues."
+          )
+          payload = {
+              "model": os.environ.get("AI_REVIEW_MODEL", "gpt-4o-mini"),
+              "messages": [
+                  {"role": "system", "content": system},
+                  {"role": "user", "content": (
+                      f"PR title: {os.environ['PR_TITLE']}\n\n"
+                      f"PR body: {os.environ['PR_BODY']}\n\n"
+                      f"Diff:\n{diff}"
+                  )},
+              ],
+              "temperature": 0.2,
+              "response_format": {"type": "json_object"},
+          }
+          req = urllib.request.Request(
+              "https://api.openai.com/v1/chat/completions",
+              data=json.dumps(payload).encode(),
+              headers={
+                  "Authorization": f"Bearer {os.environ['OPENAI_API_KEY']}",
+                  "Content-Type": "application/json",
+              },
+          )
+          try:
+              with urllib.request.urlopen(req, timeout=180) as resp:
+                  data = json.load(resp)
+          except urllib.error.HTTPError as e:
+              body = e.read().decode(errors="replace")[:500]
+              print(f"::error::OpenAI API error: {e.code} {body}")
+              raise
+          content = data["choices"][0]["message"]["content"]
+          parsed = json.loads(content)
+          verdict = parsed.get("verdict")
+          if verdict not in ("approve", "request_changes"):
+              verdict = "request_changes"
+          summary = parsed.get("summary", "")
+          comments = parsed.get("comments", [])
+          with open("/tmp/ai_verdict", "w", encoding="utf-8") as f:
+              f.write(verdict)
+          with open("/tmp/ai_summary", "w", encoding="utf-8") as f:
+              f.write(summary)
+          with open("/tmp/ai_comments", "w", encoding="utf-8") as f:
+              json.dump(comments[:20], f)
+          print(f"verdict={verdict}")
+          PYEOF
+
+      - name: Submit review
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const verdict = fs.readFileSync('/tmp/ai_verdict', 'utf8').trim();
+            const summary = fs.readFileSync('/tmp/ai_summary', 'utf8').trim();
+            const comments = JSON.parse(fs.readFileSync('/tmp/ai_comments', 'utf8'));
+            const event = verdict === 'approve' ? 'APPROVED' : 'REQUEST_CHANGES';
+            let body = `### 🤖 AI review — ${verdict === 'approve' ? 'approved' : 'changes requested'}\n\n${summary}`;
+            if (comments.length > 0) {
+              body += '\n\n**Notes:**\n' + comments.map(c => `- \`${c.path}\`: ${c.comment}`).join('\n');
+            }
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              event,
+              body,
+            });

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -2,9 +2,14 @@ name: ai-review
 
 # AI-powered pull request review: a senior-reviewer prompt reads the PR diff
 # and submits an APPROVED / REQUEST_CHANGES review as github-actions[bot], so
-# the "required approving review" rule is satisfied by an actual code review
-# (not just green CI). Provider-agnostic: any OpenAI-compatible chat-completions
-# endpoint works (OpenAI, DeepSeek, xAI, ...).
+# the "required approving review" rule is satisfied by an actual code review.
+# Provider-agnostic: any OpenAI-compatible chat-completions endpoint works
+# (OpenAI, DeepSeek, xAI, ...).
+#
+# Trigger: runs only after the "Rust" CI workflow completes successfully --
+# not on every push. Each CI run produces at most one AI review, and the AI
+# judges exactly the commit CI tested, so its verdict complements (does not
+# replace) the CI gate. No green CI, no review.
 #
 # Configuration (repository settings):
 #   secret    LLM_API_KEY              - API key for the chosen provider
@@ -15,45 +20,68 @@ name: ai-review
 # The workflow fails closed: if LLM_API_KEY or AI_REVIEW_MODEL is missing, no
 # review is submitted.
 #
-# Limitation: on `pull_request` events from forks, GITHUB_TOKEN is read-only, so
-# submitting the review would 403. Fork PRs are not auto-reviewed; a human
-# review is expected instead (or set up a PAT / pull_request_target if fork PRs
-# must be auto-reviewed too).
+# Skipped PRs: drafts, fork PRs (policy), and bot-authored PRs
+# (github-actions[bot], Dependabot, Renovate).
+#
+# Note: workflow_run triggers only fire for workflows that exist on the
+# default branch, so this file must be on `main` before it takes effect.
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_run:
+    workflows: ["Rust"]
+    types: [completed]
 
 permissions:
   contents: read
+  actions: read
   pull-requests: write
 
 jobs:
   review:
     runs-on: ubuntu-latest
-    # Skip bots: github-actions[bot] (no self-review loop), Dependabot
-    # (GITHUB_TOKEN cannot approve its PRs anyway) and Renovate (dependency
-    # bumps auto-merged via the review-rule bypass). Also skip fork PRs:
-    # on `pull_request` events GITHUB_TOKEN is read-only for forks, so the
-    # review could not be submitted anyway.
-    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false && !contains(fromJSON('["github-actions[bot]", "dependabot[bot]", "dependabot", "renovate[bot]"]'), github.event.pull_request.user.login)
+    # Only PR-triggered CI runs that finished green. Draft / bot / fork PRs are
+    # filtered in the "Find pull request" step, once we have the PR object.
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - name: Find pull request
+        id: pr
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          pr=$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/pulls" \
+            --jq '[.[] | select(.state == "open" and .draft == false and .head.repo.fork == false and (.user.login | IN("github-actions[bot]", "dependabot[bot]", "dependabot", "renovate[bot]") | not))][0] // empty')
+          if [ -z "$pr" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Skipped: no reviewable open PR for this CI run (draft, bot-authored, fork, or closed)." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "number=$(echo "$pr" | jq -r .number)" >> "$GITHUB_OUTPUT"
+          echo "base_sha=$(echo "$pr" | jq -r .base.sha)" >> "$GITHUB_OUTPUT"
+          echo "$pr" | jq -r .title > /tmp/pr_title
+          echo "$pr" | jq -r .body > /tmp/pr_body
+          echo "Reviewed PR: #$(echo "$pr" | jq -r .number) by $(echo "$pr" | jq -r .user.login)" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Checkout PR head
+        if: steps.pr.outputs.skip != 'true'
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Compute diff
+        if: steps.pr.outputs.skip != 'true'
         run: |
-          git diff "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" -- . ':!Cargo.lock' > /tmp/pr.diff || true
+          git diff "${{ steps.pr.outputs.base_sha }}...${{ github.event.workflow_run.head_sha }}" -- . ':!Cargo.lock' > /tmp/pr.diff || true
           echo "diff bytes: $(wc -c < /tmp/pr.diff)" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run AI review
+        if: steps.pr.outputs.skip != 'true'
         env:
           LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
           AI_REVIEW_MODEL: ${{ vars.AI_REVIEW_MODEL }}
           AI_REVIEW_BASE_URL: ${{ vars.AI_REVIEW_BASE_URL || 'https://api.deepseek.com/v1' }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euo pipefail
           python3 - <<'PYEOF'
@@ -67,6 +95,10 @@ jobs:
                     "(optionally AI_REVIEW_BASE_URL). No review was submitted.")
               sys.exit(1)
 
+          with open("/tmp/pr_title", encoding="utf-8", errors="replace") as f:
+              pr_title = f.read().strip()
+          with open("/tmp/pr_body", encoding="utf-8", errors="replace") as f:
+              pr_body = f.read()
           with open("/tmp/pr.diff", encoding="utf-8", errors="replace") as f:
               diff = f.read()
           if len(diff) > 150_000:
@@ -87,8 +119,8 @@ jobs:
               "messages": [
                   {"role": "system", "content": system},
                   {"role": "user", "content": (
-                      f"PR title: {os.environ['PR_TITLE']}\n\n"
-                      f"PR body: {os.environ['PR_BODY']}\n\n"
+                      f"PR title: {pr_title}\n\n"
+                      f"PR body: {pr_body}\n\n"
                       f"Diff:\n{diff}"
                   )},
               ],
@@ -128,7 +160,10 @@ jobs:
           PYEOF
 
       - name: Submit review
+        if: steps.pr.outputs.skip != 'true'
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
           script: |
             const fs = require('fs');
@@ -143,7 +178,7 @@ jobs:
             await github.rest.pulls.createReview({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number,
+              pull_number: Number(process.env.PR_NUMBER),
               event,
               body,
             });

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -33,8 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     # Skip bots: github-actions[bot] (no self-review loop), Dependabot
     # (GITHUB_TOKEN cannot approve its PRs anyway) and Renovate (dependency
-    # bumps auto-merged via the review-rule bypass).
-    if: github.event.pull_request.draft == false && !contains(fromJSON('["github-actions[bot]", "dependabot[bot]", "dependabot", "renovate[bot]"]'), github.event.pull_request.user.login)
+    # bumps auto-merged via the review-rule bypass). Also skip fork PRs:
+    # on `pull_request` events GITHUB_TOKEN is read-only for forks, so the
+    # review could not be submitted anyway.
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false && !contains(fromJSON('["github-actions[bot]", "dependabot[bot]", "dependabot", "renovate[bot]"]'), github.event.pull_request.user.login)
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -135,7 +135,7 @@ jobs:
             const verdict = fs.readFileSync('/tmp/ai_verdict', 'utf8').trim();
             const summary = fs.readFileSync('/tmp/ai_summary', 'utf8').trim();
             const comments = JSON.parse(fs.readFileSync('/tmp/ai_comments', 'utf8'));
-            const event = verdict === 'approve' ? 'APPROVED' : 'REQUEST_CHANGES';
+            const event = verdict === 'approve' ? 'APPROVE' : 'REQUEST_CHANGES';
             let body = `### 🤖 AI review — ${verdict === 'approve' ? 'approved' : 'changes requested'}\n\n${summary}`;
             if (comments.length > 0) {
               body += '\n\n**Notes:**\n' + comments.map(c => `- \`${c.path}\`: ${c.comment}`).join('\n');

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -14,6 +14,11 @@ name: ai-review
 #
 # The workflow fails closed: if LLM_API_KEY or AI_REVIEW_MODEL is missing, no
 # review is submitted.
+#
+# Limitation: on `pull_request` events from forks, GITHUB_TOKEN is read-only, so
+# submitting the review would 403. Fork PRs are not auto-reviewed; a human
+# review is expected instead (or set up a PAT / pull_request_target if fork PRs
+# must be auto-reviewed too).
 
 on:
   pull_request:
@@ -26,7 +31,10 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'github-actions[bot]'
+    # Skip bots: github-actions[bot] (no self-review loop), Dependabot
+    # (GITHUB_TOKEN cannot approve its PRs anyway) and Renovate (dependency
+    # bumps auto-merged via the review-rule bypass).
+    if: github.event.pull_request.draft == false && !contains(fromJSON('["github-actions[bot]", "dependabot[bot]", "dependabot", "renovate[bot]"]'), github.event.pull_request.user.login)
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
# ci: AI-powered pull request review (after CI passes)

Adds a GitHub Actions workflow that reviews pull requests with an LLM and submits an `APPROVED` / `REQUEST_CHANGES` review as `github-actions[bot]`, so the "required approving review" branch rule is satisfied by an actual code review — not just green CI.

## How it works

1. Triggered by `workflow_run` when the **Rust** CI workflow completes **successfully** — not on every push. Each CI run produces at most one AI review, and the AI judges exactly the commit CI tested. No green CI, no review.
2. The PR is resolved from the CI run's head SHA (`GET /repos/{owner}/{repo}/commits/{sha}/pulls`), then the diff (`base.sha...head.sha`, excluding `Cargo.lock`) is computed.
3. A senior-reviewer prompt asks the model to return `{"verdict", "summary", "comments"}` as JSON.
4. The review is submitted via the GitHub API with `APPROVE` or `REQUEST_CHANGES` and the summary as the review body.

## Provider-agnostic configuration

Any OpenAI-compatible chat-completions endpoint works (OpenAI, DeepSeek, xAI, ...). Configure in repository settings:

| Setting | Type | Description |
|---|---|---|
| `LLM_API_KEY` | **secret** | API key for your provider (required) |
| `AI_REVIEW_MODEL` | variable | Model name, e.g. `deepseek-v4-flash` (required) |
| `AI_REVIEW_BASE_URL` | variable | API base URL (optional; default `https://api.deepseek.com/v1`) |

The workflow **fails closed**: if the key or model is missing, it prints a clear `::error::` and submits no review.

## Safeguards

- Draft PRs and PRs authored by bots (`github-actions[bot]`, Dependabot, Renovate) are skipped (no bot self-review loops; GITHUB_TOKEN cannot approve Dependabot PRs anyway).
- Fork PRs are not auto-reviewed (policy) — a human review is expected for those.
- A hard 150k-char cap on the diff keeps prompt size bounded.
- On API error the step fails and **no review is submitted** — the AI never force-approves.
- Review verdict comes from the model's actual judgment of the diff; CI passing alone is not treated as approval.

## Notes

- `workflow_run` triggers only fire for workflows that exist on the default branch, so this workflow takes effect once merged to `main`.
- Subsequent pushes to a PR run CI first; only a green CI run triggers the AI review.

## Setup required before merging

1. Add the `LLM_API_KEY` secret (e.g. a DeepSeek, OpenAI, or xAI API key).
2. Set the `AI_REVIEW_MODEL` repository variable (e.g. `deepseek-v4-flash`).
3. Optionally set `AI_REVIEW_BASE_URL` if not using DeepSeek (e.g. `https://api.openai.com/v1` or `https://api.x.ai/v1`).
