### PR TITLE
feat(remote): rename groups (owner-only, sync-propagated)

### DIFF
--- a/src/cli/remote.rs
+++ b/src/cli/remote.rs
@@ -175,6 +175,8 @@ pub enum GroupAction {
     Members { group: String },
     /// Owner only: remove a member from the group
     Remove { group: String, peer: String },
+    /// Owner only: rename the group (the new name is the ref segment)
+    Rename { group: String, name: String },
     /// Leave a group (owner leaving disbands the group)
     Leave { group: String },
     /// Force a roster refresh from the group owner

--- a/src/commands/remote/group.rs
+++ b/src/commands/remote/group.rs
@@ -35,6 +35,7 @@ pub fn execute(command: GroupCommand) -> Result<()> {
         GroupAction::List => list(),
         GroupAction::Members { group } => members(&group),
         GroupAction::Remove { group, peer } => remove(&group, &peer),
+        GroupAction::Rename { group, name } => rename(&group, &name),
         GroupAction::Leave { group } => leave(&group),
         GroupAction::Sync { group } => sync(&group),
     }
@@ -273,6 +274,23 @@ fn remove(group: &str, peer: &str) -> Result<()> {
     })? {
         LocalResponse::Ok => {
             output::success(format!("removed `{peer}` from `{group}`"));
+            Ok(())
+        }
+        response => bail!("Unexpected daemon response: {response:?}"),
+    }
+}
+
+fn rename(group: &str, name: &str) -> Result<()> {
+    match ipc::call(LocalRequest::GroupRename {
+        group: group.to_string(),
+        name: name.to_string(),
+    })? {
+        LocalResponse::Group(info) => {
+            output::success(format!("renamed group to `{}`", info.name));
+            output::hint(format!(
+                "query the group with: sivtr s {}:terminal --latest 5",
+                info.name
+            ));
             Ok(())
         }
         response => bail!("Unexpected daemon response: {response:?}"),

--- a/src/remote/daemon.rs
+++ b/src/remote/daemon.rs
@@ -432,6 +432,11 @@ async fn process_local(
             remove_group_member(context, &group, &peer).await?;
             LocalResponse::Ok
         }
+        LocalRequest::GroupRename { group, name } => {
+            let info = context.store.group(&group)?;
+            require_group_owner(&context.store, &info.id, &context.identity.id())?;
+            LocalResponse::Group(context.store.rename_group(&info.id, &name)?)
+        }
         LocalRequest::GroupSync { group } => {
             sync_group(context, &group).await?;
             LocalResponse::Group(context.store.group(&group)?)
@@ -626,7 +631,7 @@ fn require_group_owner(store: &StateStore, group_id: &str, sender: &str) -> Resu
         .find(|member| member.role == "owner")
         .context("Group has no owner")?;
     if owner.peer_id != sender {
-        bail!("Only the group owner may change membership");
+        bail!("Only the group owner may perform this operation");
     }
     Ok(())
 }
@@ -1109,13 +1114,24 @@ async fn sync_group(context: &Arc<DaemonContext>, group_name_or_id: &str) -> Res
     .context("Group roster sync with the owner timed out")??;
     match response {
         RemoteResponse::GroupSynced {
-            group_name: _,
+            group_name,
             member,
             members,
         } => {
             if !member {
                 drop_group(context, &group.id).await?;
                 return Ok(());
+            }
+            // The owner's name is authoritative: apply a rename this device
+            // has not synced yet. A collision with another local group keeps
+            // the stale name but must not block the roster reconciliation.
+            if group_name != context.store.group(&group.id)?.name {
+                if let Err(error) = context.store.rename_group(&group.id, &group_name) {
+                    crate::output::error(format!(
+                        "kept local name for group `{}`: {error:#}",
+                        context.store.group(&group.id)?.name
+                    ));
+                }
             }
             let self_id = context.identity.id();
             // Roster is authoritative: upsert peers, membership, contributions.

--- a/src/remote/protocol.rs
+++ b/src/remote/protocol.rs
@@ -286,6 +286,12 @@ pub enum LocalRequest {
         group: String,
         peer: String,
     },
+    /// Owner-only: rename the group. The name is the ref segment, stored once
+    /// in `groups.name`; members mirror it on their next roster sync.
+    GroupRename {
+        group: String,
+        name: String,
+    },
     /// Force a roster pull from the group owner.
     GroupSync {
         group: String,

--- a/src/remote/state.rs
+++ b/src/remote/state.rs
@@ -751,6 +751,26 @@ impl StateStore {
         self.group(name)
     }
 
+    /// Rename the group. The name is the ref segment (`team:...`) and is
+    /// stored once per device in `groups.name`; the owner renames and members
+    /// mirror the new name on their next roster sync. Collisions with another
+    /// local group are rejected (the `UNIQUE` constraint backs the check).
+    pub fn rename_group(&self, group_name_or_id: &str, new_name: &str) -> Result<GroupInfo> {
+        // The same rules as creation: a rename must not smuggle in a name
+        // `add_group` would reject (including reserved scheme names).
+        validate_alias(new_name, "group name")?;
+        let new_name = new_name.to_ascii_lowercase();
+        let group = self.group(group_name_or_id)?;
+        if new_name != group.name && self.group_opt(&new_name)?.is_some() {
+            bail!("A group named `{new_name}` already exists");
+        }
+        self.connect()?.execute(
+            "UPDATE groups SET name = ?1 WHERE id = ?2",
+            params![new_name, group.id],
+        )?;
+        self.group(&group.id)
+    }
+
     pub fn groups(&self) -> Result<Vec<GroupInfo>> {
         let connection = self.connect()?;
         let mut statement = connection.prepare(
@@ -1654,6 +1674,30 @@ mod tests {
         // Repeating the revoke stays a success: kick/leave must not fail just
         // because a peer already lost access.
         assert!(store.revoke(&share.name, "peer-1").unwrap().is_none());
+    }
+
+    #[test]
+    fn group_rename_updates_name_and_keeps_id() {
+        let (_temp, store, _share) = group_store();
+        let renamed = store.rename_group("team", "dev").unwrap();
+        assert_eq!(renamed.name, "dev");
+        assert_eq!(renamed.id, store.group("dev").unwrap().id);
+        assert!(store.group("team").is_err(), "old name no longer resolves");
+        // The renamed group still owns its membership and contributions.
+        assert_eq!(store.members("dev").unwrap().len(), 1);
+        assert_eq!(store.group_shares("dev", "self-1").unwrap().len(), 1);
+        // Renaming to the same name is a no-op.
+        store.rename_group("dev", "dev").unwrap();
+        // A collision with another local group is rejected.
+        store.add_group("docs", "self-1", "self").unwrap();
+        let error = store.rename_group("dev", "docs").expect_err("collision");
+        assert!(error.to_string().contains("already exists"));
+        // Identifier rules still apply.
+        let error = store.rename_group("dev", "bad name").expect_err("invalid");
+        assert!(error.to_string().contains("must be"));
+        // Reserved scheme names are rejected, same as creation.
+        let error = store.rename_group("dev", "sivtr").expect_err("reserved");
+        assert!(error.to_string().contains("reserved"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `sivtr group rename <GROUP> <NAME>`: rename a group. The name is the ref segment (`team:terminal/...`), so the rename renames how the group is addressed on every device.

## Design

- **Single source of truth.** The name is stored once per device in `groups.name` (already `UNIQUE`). No alias table, no history, no denormalized copies - the rename is one `UPDATE` on that column, keeping the id, membership, and contributions untouched.
- **Owner-only.** Rename is a roster-level authority operation, so it is gated by the existing `require_group_owner` check, consistent with kick/leave. Non-owners get the shared "Only the group owner may perform this operation" error.
- **No new wire message.** `GroupSynced` already carried the owner's `group_name`; members previously ignored it. Members now apply it on their next roster pull (5-min TTL, or any `group list`/`members`/`sync` that triggers a refresh), so a rename propagates through the existing sync path. A name collision with another local group on a member device is logged and the roster reconciliation continues with the stale name.
- **Identifier and collision rules.** The new name must match `[a-zA-Z0-9_-]+` (same rule as create/join), is stored lowercased, and renaming to a name another local group already uses is rejected up front (`UNIQUE` backs the check).

## Usage

```bash
sivtr group rename <GROUP> <NAME>   # owner only; NAME becomes the ref segment
```

Old-name refs (e.g. `sivtr s team:...` after renaming `team` to `dev`) stop resolving once the device has the new name; refs already stored in historical records keep their old scope. On the owner the rename is immediate; members pick it up on their next roster sync.

## Tests

- `group_rename_updates_name_and_keeps_id`: name updates, old name stops resolving, membership/contributions survive, no-op rename, collision rejected, identifier rules enforced.
- Full gate: cargo fmt, clippy `-D warnings`, cargo test --workspace (320 lib + 197 bin) all green.
