### PR TITLE
feat(agents): add Gemini CLI, Goose, and Qwen Code providers

### DIFF
--- a/crates/sivtr-core/src/agents/gemini.rs
+++ b/crates/sivtr-core/src/agents/gemini.rs
@@ -1,0 +1,395 @@
+//! Gemini CLI (Google) agent sessions.
+//!
+//! Layout (`GEMINI_HOME`, default `~/.gemini`):
+//! ```text
+//! tmp/<project-id>/chats/
+//!   session-<timestamp>-<id8>.jsonl   ← current JSONL format
+//!   session-<timestamp>-<id8>.json    ← legacy single-record format
+//! ```
+//! The project-id is a hash of the working directory; the CLI keeps the
+//! id→path mapping in `projects.json`, which is not always present, so
+//! sessions without a mapping are listed as unbound (kept for every
+//! workspace, same as sessions that carry no cwd metadata).
+//!
+//! JSONL records: the first line is a header `{sessionId, projectHash,
+//! startTime, lastUpdated, summary?}`; message lines are `{id, type:
+//! user|gemini|info|error|warning, timestamp, content, thoughts?,
+//! toolCalls?, model?}` plus `$set` metadata updates and `$rewindTo`
+//! markers. The legacy `.json` form is a single object with the header
+//! fields and an inline `messages` array.
+
+use crate::agents::{
+    extract_content_text, list_chat_recording_sessions, pretty_json_value, push_block,
+    push_parts_blocks, push_tool_block, AgentBlockKind, AgentProvider, AgentSession,
+    AgentSessionInfo, AgentSessionMeta, AgentSessionProvider,
+};
+use anyhow::{Context, Result};
+use serde_json::Value;
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+const PROVIDER_NAME: &str = "Gemini";
+
+/// Upper bound on the header + first messages read for listing metadata.
+const META_READ_LIMIT: usize = 64 * 1024;
+/// Lines scanned for the first user message when no summary exists.
+const META_SCAN_LINES: usize = 30;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GeminiProvider;
+
+impl AgentSessionProvider for GeminiProvider {
+    fn provider(&self) -> AgentProvider {
+        AgentProvider::Gemini
+    }
+
+    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+        list_chat_recording_sessions(PROVIDER_NAME, &gemini_tmp_dir(), cwd, parse_session_meta)
+    }
+
+    fn parse_session_file(&self, path: &Path) -> Result<AgentSession> {
+        let text = fs::read_to_string(path)
+            .with_context(|| format!("Failed to read Gemini session: {}", path.display()))?;
+
+        // Legacy files are a single JSON object (possibly pretty-printed);
+        // current files are JSONL with one record per line.
+        if let Ok(value) = serde_json::from_str::<Value>(&text) {
+            if is_legacy_record(&value) {
+                return parse_legacy_session(path, &value);
+            }
+        }
+
+        let mut session = AgentSession {
+            path: path.to_path_buf(),
+            id: None,
+            cwd: None,
+            title: None,
+            blocks: Vec::new(),
+        };
+        for line in text.lines() {
+            if let Ok(value) = serde_json::from_str::<Value>(line) {
+                apply_event(&mut session, &value);
+            }
+        }
+        Ok(session)
+    }
+}
+
+pub fn gemini_home() -> PathBuf {
+    if let Ok(path) = std::env::var("GEMINI_HOME") {
+        if !path.trim().is_empty() {
+            return PathBuf::from(path);
+        }
+    }
+
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".gemini")
+}
+
+fn gemini_tmp_dir() -> PathBuf {
+    gemini_home().join("tmp")
+}
+
+fn is_legacy_record(value: &Value) -> bool {
+    value.get("sessionId").is_some() && value.get("messages").is_some()
+}
+
+fn parse_session_meta(path: &Path) -> Result<AgentSessionMeta> {
+    let head = read_head(path)?;
+    let mut meta = AgentSessionMeta::default();
+    let mut first_user_text: Option<String> = None;
+
+    if let Ok(value) = serde_json::from_str::<Value>(&head) {
+        if is_legacy_record(&value) {
+            update_meta(&mut meta, &value, &mut first_user_text);
+            meta.fallback_title(first_user_text.as_deref());
+            return Ok(meta);
+        }
+    }
+
+    for line in head.lines().take(META_SCAN_LINES) {
+        if let Ok(value) = serde_json::from_str::<Value>(line) {
+            update_meta(&mut meta, &value, &mut first_user_text);
+        }
+    }
+    meta.fallback_title(first_user_text.as_deref());
+    Ok(meta)
+}
+
+fn read_head(path: &Path) -> Result<String> {
+    let file = fs::File::open(path)
+        .with_context(|| format!("Failed to read Gemini session: {}", path.display()))?;
+    let mut buf = Vec::new();
+    file.take(META_READ_LIMIT as u64)
+        .read_to_end(&mut buf)
+        .with_context(|| format!("Failed to read Gemini session: {}", path.display()))?;
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
+fn update_meta(meta: &mut AgentSessionMeta, value: &Value, first_user_text: &mut Option<String>) {
+    if value.get("id").is_some() {
+        // Message records: track the first user text as a title fallback.
+        if first_user_text.is_none() && value.get("type").and_then(Value::as_str) == Some("user") {
+            let text = dialogue_text(value.get("content").unwrap_or(&Value::Null));
+            if !text.trim().is_empty() {
+                *first_user_text = Some(text);
+            }
+        }
+        return;
+    }
+
+    if meta.id.is_none() {
+        meta.id = value
+            .get("sessionId")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+    }
+    if meta.title.is_none() {
+        meta.title = value
+            .get("summary")
+            .and_then(Value::as_str)
+            .filter(|summary| !summary.trim().is_empty())
+            .map(str::to_string);
+    }
+}
+
+/// Visible text from a Gemini content value, excluding thought parts.
+fn dialogue_text(content: &Value) -> String {
+    match content {
+        Value::String(text) => text.clone(),
+        Value::Array(items) => items
+            .iter()
+            .filter_map(|item| {
+                if item.get("thought").and_then(Value::as_bool) == Some(true) {
+                    return None;
+                }
+                item.get("text").and_then(Value::as_str)
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n"),
+        _ => String::new(),
+    }
+}
+
+fn parse_legacy_session(path: &Path, value: &Value) -> Result<AgentSession> {
+    let mut session = AgentSession {
+        path: path.to_path_buf(),
+        id: value
+            .get("sessionId")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        cwd: None,
+        title: value
+            .get("summary")
+            .and_then(Value::as_str)
+            .filter(|summary| !summary.trim().is_empty())
+            .map(str::to_string),
+        blocks: Vec::new(),
+    };
+
+    if let Some(messages) = value.get("messages").and_then(Value::as_array) {
+        for message in messages {
+            apply_event(&mut session, message);
+        }
+    }
+    Ok(session)
+}
+
+fn apply_event(session: &mut AgentSession, value: &Value) {
+    if value.get("id").is_none() {
+        // Header line or metadata update; messages always carry an id.
+        if session.id.is_none() {
+            session.id = value
+                .get("sessionId")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+        }
+        if session.title.is_none() {
+            let summary = value
+                .get("$set")
+                .and_then(|set| set.get("summary"))
+                .or_else(|| value.get("summary"));
+            session.title = summary
+                .and_then(Value::as_str)
+                .filter(|summary| !summary.trim().is_empty())
+                .map(str::to_string);
+        }
+        return;
+    }
+
+    let Some(message_type) = value.get("type").and_then(Value::as_str) else {
+        return;
+    };
+    let timestamp = value
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let content = value.get("content").unwrap_or(&Value::Null);
+
+    match message_type {
+        "user" | "info" | "error" | "warning" => {
+            push_parts_blocks(session, AgentBlockKind::User, timestamp, content);
+        }
+        "gemini" => {
+            if let Some(thoughts) = value.get("thoughts").and_then(Value::as_array) {
+                for thought in thoughts {
+                    let text = thought
+                        .get("description")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default();
+                    push_block(
+                        session,
+                        AgentBlockKind::Thinking,
+                        timestamp.clone(),
+                        None,
+                        text,
+                    );
+                }
+            }
+            push_parts_blocks(
+                session,
+                AgentBlockKind::Assistant,
+                timestamp.clone(),
+                content,
+            );
+            if let Some(calls) = value.get("toolCalls").and_then(Value::as_array) {
+                for call in calls {
+                    apply_tool_call(session, timestamp.clone(), call);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn apply_tool_call(session: &mut AgentSession, timestamp: Option<String>, call: &Value) {
+    let id = call.get("id").and_then(Value::as_str).map(str::to_string);
+    let name = call.get("name").and_then(Value::as_str).map(str::to_string);
+    let args = call.get("args").unwrap_or(&Value::Null);
+    push_tool_block(
+        session,
+        AgentBlockKind::ToolCall,
+        timestamp.clone(),
+        id.clone(),
+        name,
+        pretty_json_value(args),
+    );
+
+    if let Some(result) = call.get("result") {
+        push_tool_block(
+            session,
+            AgentBlockKind::ToolOutput,
+            timestamp,
+            id,
+            None,
+            extract_content_text(result),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::AgentSessionProvider;
+    use std::time::{Duration, UNIX_EPOCH};
+
+    fn touch(path: &Path, epoch_secs: u64) {
+        fs::File::options()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_modified(UNIX_EPOCH + Duration::from_secs(epoch_secs))
+            .unwrap();
+    }
+
+    #[test]
+    fn parses_current_jsonl_format() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session-2026-01-25T15-10-130c64ed.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"sessionId":"abc-123","projectHash":"h1","startTime":"2026-01-25T15:10:52Z","lastUpdated":"2026-01-25T15:11:09Z"}
+{"id":"m1","timestamp":"2026-01-25T15:10:52Z","type":"user","content":"hello"}
+{"id":"m2","timestamp":"2026-01-25T15:11:09Z","type":"gemini","content":[{"text":"hi"}],"thoughts":[{"subject":"s","description":"thinking here","timestamp":"2026-01-25T15:11:00Z"}],"toolCalls":[{"id":"t1","name":"bash","args":{"command":"ls"},"result":{"text":"file.txt"}}]}
+{"$set":{"summary":"summarized"}}
+"#,
+        )
+        .unwrap();
+
+        let session = GeminiProvider.parse_session_file(&path).unwrap();
+
+        assert_eq!(session.id.as_deref(), Some("abc-123"));
+        assert_eq!(session.blocks.len(), 5);
+        assert_eq!(session.blocks[0].kind, AgentBlockKind::User);
+        assert_eq!(session.blocks[0].text, "hello");
+        assert_eq!(session.blocks[1].kind, AgentBlockKind::Thinking);
+        assert_eq!(session.blocks[1].text, "thinking here");
+        assert_eq!(session.blocks[2].kind, AgentBlockKind::Assistant);
+        assert_eq!(session.blocks[2].text, "hi");
+        assert_eq!(session.blocks[3].kind, AgentBlockKind::ToolCall);
+        assert_eq!(session.blocks[3].label.as_deref(), Some("bash"));
+        assert_eq!(session.blocks[3].call_id.as_deref(), Some("t1"));
+        assert!(session.blocks[3].text.contains("ls"));
+        assert_eq!(session.blocks[4].kind, AgentBlockKind::ToolOutput);
+        assert_eq!(session.blocks[4].text, "file.txt");
+    }
+
+    #[test]
+    fn parses_legacy_single_json_format() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session-2026-01-25T15-10-130c64ed.json");
+        std::fs::write(
+            &path,
+            r#"{
+  "sessionId": "legacy-1",
+  "projectHash": "h2",
+  "startTime": "2026-01-25T15:10:52Z",
+  "lastUpdated": "2026-01-25T15:11:09Z",
+  "messages": [
+    {"id": "m1", "timestamp": "2026-01-25T15:10:52Z", "type": "user", "content": "hello legacy"},
+    {"id": "m2", "timestamp": "2026-01-25T15:11:09Z", "type": "gemini", "content": "hi"}
+  ]
+}
+"#,
+        )
+        .unwrap();
+
+        let session = GeminiProvider.parse_session_file(&path).unwrap();
+
+        assert_eq!(session.id.as_deref(), Some("legacy-1"));
+        assert_eq!(session.blocks.len(), 2);
+        assert_eq!(session.blocks[0].kind, AgentBlockKind::User);
+        assert_eq!(session.blocks[0].text, "hello legacy");
+        assert_eq!(session.blocks[1].kind, AgentBlockKind::Assistant);
+        assert_eq!(session.blocks[1].text, "hi");
+    }
+
+    #[test]
+    fn lists_chat_recording_sessions() {
+        let _guard = crate::test_env_lock();
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("GEMINI_HOME", dir.path());
+
+        let chats = dir.path().join("tmp").join("hash1").join("chats");
+        std::fs::create_dir_all(&chats).unwrap();
+        let newer = chats.join("session-2026-01-25T15-10-130c64ed.jsonl");
+        let older = chats.join("session-2026-01-20T10-00-abc12345.jsonl");
+        let nested = chats.join("parent").join("sub.jsonl");
+        std::fs::create_dir_all(chats.join("parent")).unwrap();
+        std::fs::write(&newer, r#"{"sessionId":"n1","projectHash":"h","startTime":"2026-01-25T15:10:52Z","lastUpdated":"2026-01-25T15:11:09Z"}"#).unwrap();
+        std::fs::write(&older, r#"{"sessionId":"o1","projectHash":"h","startTime":"2026-01-20T10:00:00Z","lastUpdated":"2026-01-20T10:01:00Z"}"#).unwrap();
+        std::fs::write(&nested, r#"{"sessionId":"sub","projectHash":"h","startTime":"2026-01-25T15:12:00Z","lastUpdated":"2026-01-25T15:12:01Z"}"#).unwrap();
+        touch(&newer, 1_800_000_000);
+        touch(&older, 1_700_000_000);
+        touch(&nested, 1_800_000_001);
+
+        let sessions = GeminiProvider.list_recent_sessions(None).unwrap();
+
+        // Subagent files nested under chats/<parent>/ are skipped.
+        assert_eq!(sessions.len(), 2);
+        assert_eq!(sessions[0].id.as_deref(), Some("n1"));
+        assert_eq!(sessions[1].id.as_deref(), Some("o1"));
+    }
+}

--- a/crates/sivtr-core/src/agents/goose.rs
+++ b/crates/sivtr-core/src/agents/goose.rs
@@ -1,0 +1,384 @@
+//! Goose (Block) agent sessions.
+//!
+//! Store (Goose >= 1.0): a single SQLite database.
+//! ```text
+//! <data-dir>/sessions/sessions.db    tables: sessions + messages
+//! ```
+//! The data dir follows `etcetera`'s app layout for `Block/goose`:
+//! Windows `%APPDATA%\Block\goose\data`, Unix `~/.local/share/Block/goose/data`.
+//! `GOOSE_PATH_ROOT` (absolute) overrides the root; sessions then live under
+//! `<root>/data/sessions/`.
+//!
+//! `sessions` holds `id`, `working_dir`, `name`, timestamps; `messages`
+//! holds `role` (`user`/`assistant`), `content_json` (a JSON array of
+//! `{type: text|thinking|toolRequest|toolResponse|…}` blocks) and
+//! `created_timestamp` (epoch seconds or millis).
+
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+
+use crate::agents::{
+    extract_content_text, filter_sessions_by_workspace, open_readonly_db, pretty_json_value,
+    push_block, push_tool_block, system_time_from_unix_secs, AgentBlockKind, AgentProvider,
+    AgentSession, AgentSessionInfo, AgentSessionProvider,
+};
+
+const SESSION_PATH_PREFIX: &str = "goose-session-";
+const SESSION_PATH_SUFFIX: &str = ".sqlite";
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GooseProvider;
+
+impl AgentSessionProvider for GooseProvider {
+    fn provider(&self) -> AgentProvider {
+        AgentProvider::Goose
+    }
+
+    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+        let db_path = goose_db_path();
+        if !db_path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let conn = open_readonly_db(&db_path)?;
+        let mut stmt = conn.prepare(
+            "select id, working_dir, name, coalesce(cast(strftime('%s', updated_at) as integer), 0) \
+             from sessions order by updated_at desc, id desc",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?,
+            ))
+        })?;
+
+        let mut sessions = Vec::new();
+        for row in rows {
+            let (id, working_dir, name, updated_secs) = row?;
+            sessions.push(AgentSessionInfo {
+                modified: system_time_from_unix_secs(updated_secs as f64),
+                path: goose_session_path(&id),
+                id: Some(id),
+                cwd: Some(working_dir).filter(|value| !value.trim().is_empty()),
+                title: Some(name).filter(|name| !name.trim().is_empty()),
+            });
+        }
+
+        Ok(filter_sessions_by_workspace(sessions, cwd))
+    }
+
+    fn parse_session_file(&self, path: &Path) -> Result<AgentSession> {
+        let session_id = session_id_from_path(path).with_context(|| {
+            format!(
+                "Goose session path `{}` does not contain a session id",
+                path.display()
+            )
+        })?;
+        parse_session_by_id(&session_id)
+    }
+
+    fn find_session_by_id(&self, id: &str) -> Result<Option<PathBuf>> {
+        let db_path = goose_db_path();
+        if !db_path.exists() {
+            return Ok(None);
+        }
+
+        let conn = open_readonly_db(&db_path)?;
+        let exact = conn
+            .query_row(
+                "select id from sessions where id = ?1",
+                params![id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        if let Some(id) = exact {
+            return Ok(Some(goose_session_path(&id)));
+        }
+
+        let prefix = format!("{id}%");
+        let prefix_match = conn
+            .query_row(
+                "select id from sessions where id like ?1 order by updated_at desc limit 1",
+                params![prefix],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        Ok(prefix_match.map(|id| goose_session_path(&id)))
+    }
+}
+
+pub fn goose_db_path() -> PathBuf {
+    if let Some(root) = goose_path_root() {
+        return root.join("data").join("sessions").join("sessions.db");
+    }
+
+    dirs::data_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("Block")
+        .join("goose")
+        .join("data")
+        .join("sessions")
+        .join("sessions.db")
+}
+
+fn goose_path_root() -> Option<PathBuf> {
+    std::env::var_os("GOOSE_PATH_ROOT")
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+}
+
+fn goose_session_path(id: &str) -> PathBuf {
+    PathBuf::from(format!("{SESSION_PATH_PREFIX}{id}{SESSION_PATH_SUFFIX}"))
+}
+
+fn session_id_from_path(path: &Path) -> Option<String> {
+    let name = path.file_name()?.to_str()?;
+    name.strip_prefix(SESSION_PATH_PREFIX)?
+        .strip_suffix(SESSION_PATH_SUFFIX)
+        .map(str::to_string)
+}
+
+fn parse_session_by_id(session_id: &str) -> Result<AgentSession> {
+    let db_path = goose_db_path();
+    if !db_path.exists() {
+        anyhow::bail!("Goose database {} does not exist", db_path.display());
+    }
+
+    let conn = open_readonly_db(&db_path)?;
+    let meta = conn
+        .query_row(
+            "select id, working_dir, name from sessions where id = ?1",
+            params![session_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .optional()?
+        .with_context(|| format!("Goose session `{session_id}` was not found"))?;
+
+    let mut session = AgentSession {
+        path: goose_session_path(&meta.0),
+        id: Some(meta.0),
+        cwd: Some(meta.1).filter(|value| !value.trim().is_empty()),
+        title: Some(meta.2).filter(|name| !name.trim().is_empty()),
+        blocks: Vec::new(),
+    };
+
+    apply_message_rows(&conn, session_id, &mut session)?;
+    Ok(session)
+}
+
+fn apply_message_rows(
+    conn: &Connection,
+    session_id: &str,
+    session: &mut AgentSession,
+) -> Result<()> {
+    let mut stmt = conn.prepare(
+        "select role, content_json, created_timestamp from messages \
+         where session_id = ?1 order by created_timestamp, id",
+    )?;
+    let rows = stmt.query_map(params![session_id], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, i64>(2)?,
+        ))
+    })?;
+
+    for row in rows {
+        let (role, content_json, created) = row?;
+        let timestamp = Some(created.to_string());
+        let content = match serde_json::from_str::<Value>(&content_json) {
+            Ok(content) => content,
+            Err(error) => {
+                eprintln!(
+                    "warning: failed to parse Goose message content for session {}: {error}",
+                    session_id
+                );
+                continue;
+            }
+        };
+        apply_content(session, &role, timestamp, &content);
+    }
+    Ok(())
+}
+
+fn apply_content(
+    session: &mut AgentSession,
+    role: &str,
+    timestamp: Option<String>,
+    content: &Value,
+) {
+    let dialogue_kind = match role {
+        "user" => AgentBlockKind::User,
+        "assistant" => AgentBlockKind::Assistant,
+        _ => return,
+    };
+
+    let Some(items) = content.as_array() else {
+        return;
+    };
+    for item in items {
+        match item.get("type").and_then(Value::as_str) {
+            Some("text") => push_block(
+                session,
+                dialogue_kind,
+                timestamp.clone(),
+                None,
+                extract_content_text(item),
+            ),
+            Some("thinking") => {
+                let thinking = item
+                    .get("thinking")
+                    .map(extract_content_text)
+                    .filter(|text| !text.trim().is_empty())
+                    .unwrap_or_else(|| extract_content_text(item));
+                push_block(
+                    session,
+                    AgentBlockKind::Thinking,
+                    timestamp.clone(),
+                    None,
+                    thinking,
+                );
+            }
+            Some("toolRequest") => {
+                let id = item.get("id").and_then(Value::as_str).map(str::to_string);
+                let tool_call = item.get("toolCall").unwrap_or(&Value::Null);
+                let name = tool_call
+                    .get("value")
+                    .and_then(|value| value.get("name"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                let args = tool_call
+                    .get("value")
+                    .and_then(|value| value.get("arguments"))
+                    .unwrap_or(&Value::Null);
+                push_tool_block(
+                    session,
+                    AgentBlockKind::ToolCall,
+                    timestamp.clone(),
+                    id,
+                    name,
+                    pretty_json_value(args),
+                );
+            }
+            Some("toolResponse") => {
+                let id = item.get("id").and_then(Value::as_str).map(str::to_string);
+                let result = item
+                    .get("toolResult")
+                    .and_then(|result| result.get("value"))
+                    .unwrap_or(&Value::Null);
+                let text = result
+                    .get("content")
+                    .map(extract_content_text)
+                    .filter(|text| !text.trim().is_empty())
+                    .unwrap_or_else(|| pretty_json_value(result));
+                push_tool_block(
+                    session,
+                    AgentBlockKind::ToolOutput,
+                    timestamp.clone(),
+                    id,
+                    None,
+                    text,
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::AgentSessionProvider;
+    use rusqlite::Connection;
+
+    fn seed_db(db_path: &Path) {
+        std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+        let conn = Connection::open(db_path).unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL DEFAULT '',
+                description TEXT NOT NULL DEFAULT '',
+                session_type TEXT NOT NULL DEFAULT 'user',
+                working_dir TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                message_id TEXT,
+                session_id TEXT NOT NULL REFERENCES sessions(id),
+                role TEXT NOT NULL,
+                content_json TEXT NOT NULL,
+                created_timestamp INTEGER NOT NULL,
+                timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            );
+            INSERT INTO sessions (id, name, working_dir) VALUES ('s1', 'goose session', 'D:\repo');
+            INSERT INTO messages (message_id, session_id, role, content_json, created_timestamp) VALUES
+                ('m1', 's1', 'user', '[{"type":"text","text":"hello"}]', 1700000000),
+                ('m2', 's1', 'assistant', '[{"type":"thinking","thinking":"hidden","signature":""},{"type":"text","text":"hi"}]', 1700000001),
+                ('m3', 's1', 'assistant', '[{"type":"toolRequest","id":"t1","toolCall":{"status":"success","value":{"name":"bash","arguments":{"command":"ls"}}}}]', 1700000002),
+                ('m4', 's1', 'assistant', '[{"type":"toolResponse","id":"t1","toolResult":{"status":"success","value":{"content":[{"type":"text","text":"file.txt"}]}}}]', 1700000003),
+                ('m5', 's1', 'assistant', '[{"type":"text","text":"done"}]', 1700000004);
+            "#,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn parses_goose_sqlite_session() {
+        let dir = tempfile::tempdir().unwrap();
+        seed_db(&dir.path().join("data").join("sessions").join("sessions.db"));
+
+        let _guard = crate::test_env_lock();
+        std::env::set_var("GOOSE_PATH_ROOT", dir.path());
+        let path = goose_session_path("s1");
+        let session = GooseProvider.parse_session_file(&path).unwrap();
+
+        assert_eq!(session.id.as_deref(), Some("s1"));
+        assert_eq!(session.cwd.as_deref(), Some("D:\\repo"));
+        assert_eq!(session.title.as_deref(), Some("goose session"));
+        assert_eq!(session.blocks.len(), 6);
+        assert_eq!(session.blocks[0].kind, AgentBlockKind::User);
+        assert_eq!(session.blocks[0].text, "hello");
+        assert_eq!(session.blocks[1].kind, AgentBlockKind::Thinking);
+        assert_eq!(session.blocks[1].text, "hidden");
+        assert_eq!(session.blocks[2].kind, AgentBlockKind::Assistant);
+        assert_eq!(session.blocks[2].text, "hi");
+        assert_eq!(session.blocks[3].kind, AgentBlockKind::ToolCall);
+        assert_eq!(session.blocks[3].label.as_deref(), Some("bash"));
+        assert_eq!(session.blocks[3].call_id.as_deref(), Some("t1"));
+        assert!(session.blocks[3].text.contains("ls"));
+        assert_eq!(session.blocks[4].kind, AgentBlockKind::ToolOutput);
+        assert_eq!(session.blocks[4].call_id.as_deref(), Some("t1"));
+        assert_eq!(session.blocks[4].text, "file.txt");
+        assert_eq!(session.blocks[5].kind, AgentBlockKind::Assistant);
+        assert_eq!(session.blocks[5].text, "done");
+    }
+
+    #[test]
+    fn lists_goose_sessions() {
+        let dir = tempfile::tempdir().unwrap();
+        seed_db(&dir.path().join("data").join("sessions").join("sessions.db"));
+
+        let _guard = crate::test_env_lock();
+        std::env::set_var("GOOSE_PATH_ROOT", dir.path());
+
+        let sessions = GooseProvider.list_recent_sessions(None).unwrap();
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].id.as_deref(), Some("s1"));
+        assert_eq!(sessions[0].cwd.as_deref(), Some("D:\\repo"));
+    }
+}

--- a/crates/sivtr-core/src/agents/goose.rs
+++ b/crates/sivtr-core/src/agents/goose.rs
@@ -5,9 +5,8 @@
 //! <data-dir>/sessions/sessions.db    tables: sessions + messages
 //! ```
 //! The data dir follows `etcetera`'s app layout for `Block/goose`:
-//! Windows `%APPDATA%\Block\goose\data`, macOS
-//! `~/Library/Application Support/Block/goose/data`, Linux
-//! `~/.local/share/goose/data` (XDG uses the app name only).
+//! Windows `%APPDATA%\Block\goose\data`; macOS and Linux use
+//! `$XDG_DATA_HOME/goose` (default `~/.local/share/goose`).
 //! `GOOSE_PATH_ROOT` (absolute) overrides the root; sessions then live under
 //! `<root>/data/sessions/`.
 //!
@@ -126,24 +125,24 @@ pub fn goose_db_path() -> PathBuf {
             .join("data")
             .join("sessions")
             .join("sessions.db")
-    } else if cfg!(target_os = "macos") {
-        dirs::home_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join("Library")
-            .join("Application Support")
-            .join("Block")
-            .join("goose")
-            .join("data")
-            .join("sessions")
-            .join("sessions.db")
     } else {
-        dirs::data_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
+        xdg_data_dir()
             .join("goose")
-            .join("data")
             .join("sessions")
             .join("sessions.db")
     }
+}
+
+fn xdg_data_dir() -> PathBuf {
+    std::env::var_os("XDG_DATA_HOME")
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .unwrap_or_else(|| {
+            dirs::home_dir()
+                .unwrap_or_else(|| PathBuf::from("."))
+                .join(".local")
+                .join("share")
+        })
 }
 
 fn goose_path_root() -> Option<PathBuf> {
@@ -321,6 +320,32 @@ mod tests {
     use super::*;
     use crate::agents::AgentSessionProvider;
     use rusqlite::Connection;
+
+    #[cfg(not(windows))]
+    #[test]
+    fn uses_xdg_data_home_for_default_db_path() {
+        let _guard = crate::test_env_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let data_home = dir.path().join("data");
+        let previous_root = std::env::var_os("GOOSE_PATH_ROOT");
+        let previous_data_home = std::env::var_os("XDG_DATA_HOME");
+        std::env::remove_var("GOOSE_PATH_ROOT");
+        std::env::set_var("XDG_DATA_HOME", &data_home);
+
+        assert_eq!(
+            goose_db_path(),
+            data_home.join("goose").join("sessions").join("sessions.db")
+        );
+
+        match previous_root {
+            Some(value) => std::env::set_var("GOOSE_PATH_ROOT", value),
+            None => std::env::remove_var("GOOSE_PATH_ROOT"),
+        }
+        match previous_data_home {
+            Some(value) => std::env::set_var("XDG_DATA_HOME", value),
+            None => std::env::remove_var("XDG_DATA_HOME"),
+        }
+    }
 
     fn seed_db(db_path: &Path) {
         std::fs::create_dir_all(db_path.parent().unwrap()).unwrap();

--- a/crates/sivtr-core/src/agents/goose.rs
+++ b/crates/sivtr-core/src/agents/goose.rs
@@ -5,7 +5,9 @@
 //! <data-dir>/sessions/sessions.db    tables: sessions + messages
 //! ```
 //! The data dir follows `etcetera`'s app layout for `Block/goose`:
-//! Windows `%APPDATA%\Block\goose\data`, Unix `~/.local/share/Block/goose/data`.
+//! Windows `%APPDATA%\Block\goose\data`, macOS
+//! `~/Library/Application Support/Block/goose/data`, Linux
+//! `~/.local/share/goose/data` (XDG uses the app name only).
 //! `GOOSE_PATH_ROOT` (absolute) overrides the root; sessions then live under
 //! `<root>/data/sessions/`.
 //!
@@ -116,13 +118,32 @@ pub fn goose_db_path() -> PathBuf {
         return root.join("data").join("sessions").join("sessions.db");
     }
 
-    dirs::data_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join("Block")
-        .join("goose")
-        .join("data")
-        .join("sessions")
-        .join("sessions.db")
+    if cfg!(windows) {
+        dirs::data_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("Block")
+            .join("goose")
+            .join("data")
+            .join("sessions")
+            .join("sessions.db")
+    } else if cfg!(target_os = "macos") {
+        dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("Library")
+            .join("Application Support")
+            .join("Block")
+            .join("goose")
+            .join("data")
+            .join("sessions")
+            .join("sessions.db")
+    } else {
+        dirs::data_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("goose")
+            .join("data")
+            .join("sessions")
+            .join("sessions.db")
+    }
 }
 
 fn goose_path_root() -> Option<PathBuf> {

--- a/crates/sivtr-core/src/agents/jsonl.rs
+++ b/crates/sivtr-core/src/agents/jsonl.rs
@@ -42,12 +42,43 @@ pub fn list_recent_jsonl_sessions(
     cwd: Option<&Path>,
     parse_meta: impl Fn(&Path) -> Result<AgentSessionMeta>,
 ) -> Result<Vec<AgentSessionInfo>> {
+    collect_recent_sessions(provider, root, cwd, jsonl_files(root)?, parse_meta)
+}
+
+/// Walk a chat-recording tmp root: `<tmp>/<project>*/chats/*.json[l]`.
+///
+/// Shared by Gemini CLI and Qwen Code, which both store one session per
+/// file directly under a per-project `chats/` directory inside `tmp/`.
+/// Subagent files nested one level deeper under `chats/<parent>/` are
+/// skipped, matching what each tool's own session picker shows.
+pub fn list_chat_recording_sessions(
+    provider: &str,
+    tmp_root: &Path,
+    cwd: Option<&Path>,
+    parse_meta: impl Fn(&Path) -> Result<AgentSessionMeta>,
+) -> Result<Vec<AgentSessionInfo>> {
+    collect_recent_sessions(
+        provider,
+        tmp_root,
+        cwd,
+        chat_recording_files(tmp_root)?,
+        parse_meta,
+    )
+}
+
+fn collect_recent_sessions(
+    provider: &str,
+    root: &Path,
+    cwd: Option<&Path>,
+    files: Vec<PathBuf>,
+    parse_meta: impl Fn(&Path) -> Result<AgentSessionMeta>,
+) -> Result<Vec<AgentSessionInfo>> {
     let wanted = cwd.map(WorkspaceMatchTarget::new);
     let mut cache = load_listing_cache(provider, root);
     let mut dirty = false;
     let mut sessions = Vec::new();
 
-    for path in jsonl_files(root)? {
+    for path in files {
         let Some(stamp) = crate::cache::file_stamp(&path) else {
             // Unstampable file (e.g. racing delete): parse without caching.
             match parse_meta(&path) {
@@ -116,6 +147,36 @@ pub fn list_recent_jsonl_sessions(
     sessions.sort_by_key(|session| session.modified);
     sessions.reverse();
     Ok(sessions)
+}
+
+fn chat_recording_files(tmp_root: &Path) -> Result<Vec<PathBuf>> {
+    if !tmp_root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut files = Vec::new();
+    for project in
+        fs::read_dir(tmp_root).with_context(|| format!("Failed to read {}", tmp_root.display()))?
+    {
+        let chats = project?.path().join("chats");
+        if !chats.is_dir() {
+            continue;
+        }
+        for entry in
+            fs::read_dir(&chats).with_context(|| format!("Failed to read {}", chats.display()))?
+        {
+            let path = entry?.path();
+            let is_chat_file = path.is_file()
+                && path
+                    .extension()
+                    .and_then(|ext| ext.to_str())
+                    .is_some_and(|ext| ext == "json" || ext == "jsonl");
+            if is_chat_file {
+                files.push(path);
+            }
+        }
+    }
+    Ok(files)
 }
 
 fn push_session(

--- a/crates/sivtr-core/src/agents/mod.rs
+++ b/crates/sivtr-core/src/agents/mod.rs
@@ -8,6 +8,8 @@
 pub mod claude;
 pub mod codex;
 pub mod cursor;
+pub mod gemini;
+pub mod goose;
 pub mod grok;
 pub mod hermes;
 pub mod jsonl;
@@ -16,9 +18,13 @@ pub mod openclaw;
 pub mod opencode;
 pub mod pi;
 pub mod qoder;
+pub mod qwen;
 pub mod sqlite;
 
-pub use jsonl::{jsonl_files, list_recent_jsonl_sessions, parse_jsonl_meta, parse_jsonl_session};
+pub use jsonl::{
+    jsonl_files, list_chat_recording_sessions, list_recent_jsonl_sessions, parse_jsonl_meta,
+    parse_jsonl_session,
+};
 pub use model::*;
 pub use sqlite::{open_readonly_db, system_time_from_millis, system_time_from_unix_secs};
 
@@ -105,6 +111,30 @@ const AGENT_PROVIDER_SPECS: &[AgentProviderSpec] = &[
         current_session_id_env: None,
         factory: qoder_provider,
     },
+    AgentProviderSpec {
+        provider: AgentProvider::Gemini,
+        name: "Gemini",
+        command_name: "gemini",
+        current_transcript_env: None,
+        current_session_id_env: None,
+        factory: gemini_provider,
+    },
+    AgentProviderSpec {
+        provider: AgentProvider::Goose,
+        name: "Goose",
+        command_name: "goose",
+        current_transcript_env: None,
+        current_session_id_env: None,
+        factory: goose_provider,
+    },
+    AgentProviderSpec {
+        provider: AgentProvider::Qwen,
+        name: "Qwen",
+        command_name: "qwen",
+        current_transcript_env: None,
+        current_session_id_env: None,
+        factory: qwen_provider,
+    },
 ];
 
 fn codex_provider() -> Box<dyn AgentSessionProvider> {
@@ -141,6 +171,18 @@ fn pi_provider() -> Box<dyn AgentSessionProvider> {
 
 fn qoder_provider() -> Box<dyn AgentSessionProvider> {
     Box::new(crate::agents::qoder::QoderProvider)
+}
+
+fn gemini_provider() -> Box<dyn AgentSessionProvider> {
+    Box::new(crate::agents::gemini::GeminiProvider)
+}
+
+fn goose_provider() -> Box<dyn AgentSessionProvider> {
+    Box::new(crate::agents::goose::GooseProvider)
+}
+
+fn qwen_provider() -> Box<dyn AgentSessionProvider> {
+    Box::new(crate::agents::qwen::QwenProvider)
 }
 
 impl AgentProvider {

--- a/crates/sivtr-core/src/agents/model.rs
+++ b/crates/sivtr-core/src/agents/model.rs
@@ -12,12 +12,15 @@ pub enum AgentProvider {
     Claude,
     Codex,
     Cursor,
+    Gemini,
+    Goose,
     Grok,
     Hermes,
     OpenClaw,
     OpenCode,
     Pi,
     Qoder,
+    Qwen,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -136,6 +139,21 @@ impl AgentSessionMeta {
         }
     }
 
+    /// Fall back to the first line of the first user message as the title
+    /// when no explicit title (summary / user-set name) was captured.
+    pub fn fallback_title(&mut self, first_user_text: Option<&str>) {
+        if self.title.is_some() {
+            return;
+        }
+        let Some(text) = first_user_text else {
+            return;
+        };
+        let title = text.lines().next().unwrap_or(text).trim();
+        if !title.is_empty() {
+            self.title = Some(title.to_string());
+        }
+    }
+
     pub(crate) fn cwd_candidates(&self) -> impl Iterator<Item = &str> {
         self.cwd_history.iter().map(String::as_str).chain(
             self.cwd
@@ -242,6 +260,76 @@ pub fn push_tool_block(
             text,
         });
     }
+}
+
+/// Push Gemini-API-style content parts as blocks: `text` parts become the
+/// given dialogue kind, `thought` parts become `Thinking`, and
+/// `functionCall` / `functionResponse` parts become `ToolCall` / `ToolOutput`.
+///
+/// Shared by the Gemini CLI and Qwen Code providers, whose transcripts both
+/// store content as Gemini API `Part` objects. Plain string content is pushed
+/// as a single block of `kind`.
+pub fn push_parts_blocks(
+    session: &mut AgentSession,
+    kind: AgentBlockKind,
+    timestamp: Option<String>,
+    content: &Value,
+) {
+    match content {
+        Value::String(text) => push_block(session, kind, timestamp, None, text),
+        Value::Array(items) => {
+            for item in items {
+                if item.get("thought").and_then(Value::as_bool) == Some(true) {
+                    push_block(
+                        session,
+                        AgentBlockKind::Thinking,
+                        timestamp.clone(),
+                        None,
+                        extract_content_text(item),
+                    );
+                } else if let Some(call) = item.get("functionCall") {
+                    push_tool_block(
+                        session,
+                        AgentBlockKind::ToolCall,
+                        timestamp.clone(),
+                        part_id(item, call),
+                        call.get("name").and_then(Value::as_str).map(str::to_string),
+                        pretty_json_value(call.get("args").unwrap_or(&Value::Null)),
+                    );
+                } else if let Some(response) = item.get("functionResponse") {
+                    let body = response.get("response").unwrap_or(&Value::Null);
+                    let text = extract_content_text(body);
+                    push_tool_block(
+                        session,
+                        AgentBlockKind::ToolOutput,
+                        timestamp.clone(),
+                        part_id(item, response),
+                        response
+                            .get("name")
+                            .and_then(Value::as_str)
+                            .map(str::to_string),
+                        text,
+                    );
+                } else {
+                    push_block(
+                        session,
+                        kind,
+                        timestamp.clone(),
+                        None,
+                        extract_content_text(item),
+                    );
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn part_id(item: &Value, nested: &Value) -> Option<String> {
+    item.get("id")
+        .and_then(Value::as_str)
+        .or_else(|| nested.get("id").and_then(Value::as_str))
+        .map(str::to_string)
 }
 
 pub fn extract_content_text(content: &Value) -> String {

--- a/crates/sivtr-core/src/agents/qwen.rs
+++ b/crates/sivtr-core/src/agents/qwen.rs
@@ -1,0 +1,275 @@
+//! Qwen Code (Alibaba) agent sessions.
+//!
+//! Layout (`QWEN_HOME`, default `~/.qwen`):
+//! ```text
+//! tmp/<project-hash>/chats/<session-id>.jsonl
+//! ```
+//! One JSONL file per session. The first line is a header
+//! `{id, workspaceRootPath, name?, ...}`; following lines are chat records:
+//! `{uuid, sessionId, type: user|assistant|tool_result|system, subtype?,
+//! cwd, timestamp, message?: {role, parts}, toolCallResult?, model?}`.
+//! Every record carries the session id and working directory, so the header
+//! is only a convenience — the parser reads them from whichever record
+//! appears first.
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use std::fs;
+use std::io::BufRead;
+use std::path::{Path, PathBuf};
+
+use crate::agents::{
+    list_chat_recording_sessions, parse_jsonl_session, pretty_json_value, push_parts_blocks,
+    push_tool_block, AgentBlockKind, AgentProvider, AgentSession, AgentSessionInfo,
+    AgentSessionMeta, AgentSessionProvider,
+};
+
+const PROVIDER_NAME: &str = "Qwen";
+
+/// Lines scanned for listing metadata (header + first messages).
+const META_SCAN_LINES: usize = 40;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct QwenProvider;
+
+impl AgentSessionProvider for QwenProvider {
+    fn provider(&self) -> AgentProvider {
+        AgentProvider::Qwen
+    }
+
+    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+        list_chat_recording_sessions(PROVIDER_NAME, &qwen_tmp_dir(), cwd, parse_session_meta)
+    }
+
+    fn parse_session_file(&self, path: &Path) -> Result<AgentSession> {
+        parse_jsonl_session(path, PROVIDER_NAME, apply_event)
+    }
+}
+
+pub fn qwen_home() -> PathBuf {
+    if let Ok(path) = std::env::var("QWEN_HOME") {
+        if !path.trim().is_empty() {
+            return PathBuf::from(path);
+        }
+    }
+
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".qwen")
+}
+
+fn qwen_tmp_dir() -> PathBuf {
+    qwen_home().join("tmp")
+}
+
+fn parse_session_meta(path: &Path) -> Result<AgentSessionMeta> {
+    let file = fs::File::open(path)
+        .with_context(|| format!("Failed to read Qwen session: {}", path.display()))?;
+    let reader = std::io::BufReader::new(file);
+
+    let mut meta = AgentSessionMeta::default();
+    let mut first_user_text: Option<String> = None;
+
+    for line in reader.lines().take(META_SCAN_LINES) {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Ok(value) = serde_json::from_str::<Value>(&line) {
+            update_meta(&mut meta, &value, &mut first_user_text);
+        }
+    }
+    meta.fallback_title(first_user_text.as_deref());
+    Ok(meta)
+}
+
+fn update_meta(meta: &mut AgentSessionMeta, value: &Value, first_user_text: &mut Option<String>) {
+    let record_type = value.get("type").and_then(Value::as_str);
+    let (id, cwd, title) = extract_identity(value);
+
+    if meta.id.is_none() {
+        meta.id = id;
+    }
+    if meta.cwd.is_none() {
+        if let Some(cwd) = cwd {
+            meta.add_cwd(cwd);
+        }
+    }
+    if meta.title.is_none() {
+        meta.title = title;
+    }
+    if first_user_text.is_none() && record_type == Some("user") {
+        let text = extract_record_text(value);
+        if !text.trim().is_empty() {
+            *first_user_text = Some(text);
+        }
+    }
+}
+
+/// Expand a leading `~` in portable workspace paths to the home directory.
+fn expand_home(path: &str) -> String {
+    let Some(rest) = path.strip_prefix('~') else {
+        return path.to_string();
+    };
+    let home = dirs::home_dir().unwrap_or_default();
+    format!("{}{}", home.display(), rest)
+}
+
+/// Session id, cwd and user-set name from a header or chat record.
+fn extract_identity(value: &Value) -> (Option<String>, Option<String>, Option<String>) {
+    let id = value
+        .get("sessionId")
+        .or_else(|| value.get("id"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let cwd = value
+        .get("cwd")
+        .or_else(|| value.get("workspaceRootPath"))
+        .and_then(Value::as_str)
+        .map(expand_home)
+        .filter(|cwd| !cwd.trim().is_empty());
+    let title = value
+        .get("name")
+        .and_then(Value::as_str)
+        .filter(|name| !name.trim().is_empty())
+        .map(str::to_string);
+    (id, cwd, title)
+}
+
+fn apply_event(session: &mut AgentSession, value: &Value) {
+    let (id, cwd, title) = extract_identity(value);
+    if session.id.is_none() {
+        session.id = id;
+    }
+    if session.cwd.is_none() {
+        session.cwd = cwd;
+    }
+    if session.title.is_none() {
+        session.title = title;
+    }
+
+    let Some(record_type) = value.get("type").and_then(Value::as_str) else {
+        return;
+    };
+    let timestamp = value
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let message = value.get("message").unwrap_or(&Value::Null);
+    let parts = message.get("parts").unwrap_or(&Value::Null);
+
+    match record_type {
+        "user" => push_parts_blocks(session, AgentBlockKind::User, timestamp, parts),
+        "assistant" => {
+            push_parts_blocks(session, AgentBlockKind::Assistant, timestamp.clone(), parts);
+            if let Some(result) = value.get("toolCallResult") {
+                push_tool_block(
+                    session,
+                    AgentBlockKind::ToolOutput,
+                    timestamp,
+                    result
+                        .get("callId")
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                    result
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                    pretty_json_value(result),
+                );
+            }
+        }
+        "tool_result" => {
+            let label = value
+                .get("toolCallResult")
+                .and_then(|result| result.get("name"))
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            push_tool_block(
+                session,
+                AgentBlockKind::ToolOutput,
+                timestamp,
+                None,
+                label,
+                extract_record_text(value),
+            );
+        }
+        "system" => {}
+        _ => {}
+    }
+}
+
+/// Visible text from a Qwen record's `message` content (text parts only).
+fn extract_record_text(value: &Value) -> String {
+    value
+        .get("message")
+        .and_then(|message| message.get("parts"))
+        .map(extract_parts_text)
+        .unwrap_or_default()
+}
+
+fn extract_parts_text(parts: &Value) -> String {
+    match parts {
+        Value::String(text) => text.clone(),
+        Value::Array(items) => items
+            .iter()
+            .filter_map(|item| {
+                if item.get("thought").and_then(Value::as_bool) == Some(true) {
+                    return None;
+                }
+                item.get("text").and_then(Value::as_str)
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n"),
+        _ => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::AgentSessionProvider;
+
+    #[test]
+    fn parses_qwen_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir
+            .path()
+            .join("9f8e7d6c-5b4a-4321-9abc-def012345678.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"id":"9f8e7d6c-5b4a-4321-9abc-def012345678","workspaceRootPath":"D:\\repo","createdAt":1779265000000}
+{"uuid":"r1","sessionId":"9f8e7d6c-5b4a-4321-9abc-def012345678","type":"user","cwd":"D:\\repo","timestamp":"2026-05-20T00:00:01Z","message":{"role":"user","parts":[{"text":"hello"}]}}
+{"uuid":"r2","sessionId":"9f8e7d6c-5b4a-4321-9abc-def012345678","type":"assistant","cwd":"D:\\repo","timestamp":"2026-05-20T00:00:02Z","message":{"role":"model","parts":[{"thought":true,"text":"hidden"},{"text":"thinking out loud"}]}}
+{"uuid":"r3","sessionId":"9f8e7d6c-5b4a-4321-9abc-def012345678","type":"assistant","cwd":"D:\\repo","timestamp":"2026-05-20T00:00:03Z","message":{"role":"model","parts":[{"functionCall":{"name":"bash","args":{"command":"echo hi"}}}]}}
+{"uuid":"r4","sessionId":"9f8e7d6c-5b4a-4321-9abc-def012345678","type":"tool_result","cwd":"D:\\repo","timestamp":"2026-05-20T00:00:04Z","message":{"role":"tool","parts":[{"text":"hi"}]},"toolCallResult":{"name":"bash","status":"success"}}
+{"uuid":"r5","sessionId":"9f8e7d6c-5b4a-4321-9abc-def012345678","type":"system","subtype":"chat_compression","cwd":"D:\\repo","timestamp":"2026-05-20T00:00:05Z"}
+{"uuid":"r6","sessionId":"9f8e7d6c-5b4a-4321-9abc-def012345678","type":"assistant","cwd":"D:\\repo","timestamp":"2026-05-20T00:00:06Z","message":{"role":"model","parts":[{"text":"done"}]}}
+"#,
+        )
+        .unwrap();
+
+        let session = QwenProvider.parse_session_file(&path).unwrap();
+
+        assert_eq!(
+            session.id.as_deref(),
+            Some("9f8e7d6c-5b4a-4321-9abc-def012345678")
+        );
+        assert_eq!(session.cwd.as_deref(), Some("D:\\repo"));
+        assert_eq!(session.blocks.len(), 6);
+        assert_eq!(session.blocks[0].kind, AgentBlockKind::User);
+        assert_eq!(session.blocks[0].text, "hello");
+        assert_eq!(session.blocks[1].kind, AgentBlockKind::Thinking);
+        assert_eq!(session.blocks[1].text, "hidden");
+        assert_eq!(session.blocks[2].kind, AgentBlockKind::Assistant);
+        assert_eq!(session.blocks[2].text, "thinking out loud");
+        assert_eq!(session.blocks[3].kind, AgentBlockKind::ToolCall);
+        assert_eq!(session.blocks[3].label.as_deref(), Some("bash"));
+        assert!(session.blocks[3].text.contains("echo hi"));
+        assert_eq!(session.blocks[4].kind, AgentBlockKind::ToolOutput);
+        assert_eq!(session.blocks[4].text, "hi");
+        assert_eq!(session.blocks[4].label.as_deref(), Some("bash"));
+        assert_eq!(session.blocks[5].kind, AgentBlockKind::Assistant);
+        assert_eq!(session.blocks[5].text, "done");
+    }
+}

--- a/src/commands/system/mcp.rs
+++ b/src/commands/system/mcp.rs
@@ -391,18 +391,8 @@ fn print_config(target: AgentProvider) {
         McpConfigKind::Toml => {
             println!("{}", toml_mcp_snippet());
         }
-        McpConfigKind::Yaml { key, .. } => {
-            let mut root = serde_yaml::Mapping::new();
-            let mut servers = serde_yaml::Mapping::new();
-            servers.insert(
-                serde_yaml::Value::String(SERVER_NAME.to_string()),
-                hermes_entry(),
-            );
-            root.insert(
-                serde_yaml::Value::String(key.to_string()),
-                serde_yaml::Value::Mapping(servers),
-            );
-            println!("{}", serde_yaml::to_string(&root).unwrap_or_default());
+        McpConfigKind::Yaml { key, entry } => {
+            println!("{}", yaml_config_snippet(key, entry()));
         }
         McpConfigKind::JsonNested {
             outer,
@@ -422,6 +412,17 @@ fn print_config(target: AgentProvider) {
             );
         }
     }
+}
+
+fn yaml_config_snippet(key: &str, entry: serde_yaml::Value) -> String {
+    let mut root = serde_yaml::Mapping::new();
+    let mut servers = serde_yaml::Mapping::new();
+    servers.insert(serde_yaml::Value::String(SERVER_NAME.to_string()), entry);
+    root.insert(
+        serde_yaml::Value::String(key.to_string()),
+        serde_yaml::Value::Mapping(servers),
+    );
+    serde_yaml::to_string(&root).unwrap_or_default()
 }
 
 fn install_json(path: PathBuf, key: &str, entry: Value, provider: AgentProvider) -> Result<()> {
@@ -1095,5 +1096,17 @@ mod tests {
         let out = serde_yaml::to_string(&root).unwrap();
         assert!(out.contains("mcp_servers:"));
         assert!(!out.contains("sivtr"));
+    }
+
+    #[test]
+    fn prints_provider_specific_yaml_config() {
+        let goose = yaml_config_snippet("extensions", goose_entry());
+        assert!(goose.contains("enabled: true"));
+        assert!(goose.contains("type: stdio"));
+        assert!(goose.contains("cmd: sivtr"));
+        assert!(!goose.contains("command: sivtr"));
+
+        let hermes = yaml_config_snippet("mcp_servers", hermes_entry());
+        assert!(hermes.contains("command: sivtr"));
     }
 }

--- a/src/commands/system/mcp.rs
+++ b/src/commands/system/mcp.rs
@@ -900,8 +900,8 @@ fn qwen_host_present() -> bool {
 
 /// Goose loads MCP servers from `config.yaml` under `extensions:` (the
 /// ExtensionConfig shape written by `goose configure`). Paths follow
-/// etcetera's app layout for `Block/goose` (Windows/macOS) or plain
-/// `goose` (XDG on Linux).
+/// etcetera's app layout for `Block/goose` on Windows or plain `goose`
+/// under XDG config on macOS and Linux.
 fn goose_config_path() -> PathBuf {
     if cfg!(windows) {
         dirs::data_dir()
@@ -910,19 +910,8 @@ fn goose_config_path() -> PathBuf {
             .join("goose")
             .join("config")
             .join("config.yaml")
-    } else if cfg!(target_os = "macos") {
-        dirs::home_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join("Library")
-            .join("Application Support")
-            .join("Block")
-            .join("goose")
-            .join("config.yaml")
     } else {
-        dirs::config_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join("goose")
-            .join("config.yaml")
+        node_config_dir().join("goose").join("config.yaml")
     }
 }
 
@@ -1023,6 +1012,25 @@ fn write_text(path: &Path, text: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(not(windows))]
+    #[test]
+    fn goose_config_uses_xdg_config_home() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_home = dir.path().join("config");
+        let previous = std::env::var_os("XDG_CONFIG_HOME");
+        std::env::set_var("XDG_CONFIG_HOME", &config_home);
+
+        assert_eq!(
+            goose_config_path(),
+            config_home.join("goose").join("config.yaml")
+        );
+
+        match previous {
+            Some(value) => std::env::set_var("XDG_CONFIG_HOME", value),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
+    }
 
     #[test]
     fn resolves_default_named_and_all_targets() {

--- a/src/commands/system/mcp.rs
+++ b/src/commands/system/mcp.rs
@@ -134,6 +134,36 @@ const MCP_HOSTS: &[McpHostSpec] = &[
         config_path: |_loc| qoder_config_path(),
         host_present: qoder_host_present,
     },
+    McpHostSpec {
+        provider: AgentProvider::Gemini,
+        location: McpLocationSupport::GlobalOnly,
+        kind: McpConfigKind::Json {
+            key: "mcpServers",
+            entry: pi_entry,
+        },
+        config_path: |_loc| gemini_config_path(),
+        host_present: gemini_host_present,
+    },
+    McpHostSpec {
+        provider: AgentProvider::Qwen,
+        location: McpLocationSupport::GlobalOnly,
+        kind: McpConfigKind::Json {
+            key: "mcpServers",
+            entry: pi_entry,
+        },
+        config_path: |_loc| qwen_config_path(),
+        host_present: qwen_host_present,
+    },
+    McpHostSpec {
+        provider: AgentProvider::Goose,
+        location: McpLocationSupport::GlobalOrLocal,
+        kind: McpConfigKind::Json {
+            key: "mcpServers",
+            entry: pi_entry,
+        },
+        config_path: goose_config_path,
+        host_present: goose_host_present,
+    },
 ];
 
 fn mcp_host(provider: AgentProvider) -> &'static McpHostSpec {
@@ -840,6 +870,43 @@ fn qoder_config_path() -> PathBuf {
 
 fn qoder_host_present() -> bool {
     qoder_config_path().exists() || sivtr_core::agents::qoder::qoder_home().exists()
+}
+
+/// Gemini CLI reads MCP servers from `settings.json` (`mcpServers` key).
+fn gemini_config_path() -> PathBuf {
+    sivtr_core::agents::gemini::gemini_home().join("settings.json")
+}
+
+fn gemini_host_present() -> bool {
+    gemini_config_path().exists() || sivtr_core::agents::gemini::gemini_home().exists()
+}
+
+/// Qwen Code reads MCP servers from `settings.json` (`mcpServers` key).
+fn qwen_config_path() -> PathBuf {
+    sivtr_core::agents::qwen::qwen_home().join("settings.json")
+}
+
+fn qwen_host_present() -> bool {
+    qwen_config_path().exists() || sivtr_core::agents::qwen::qwen_home().exists()
+}
+
+/// Goose loads MCP servers from `.mcp.json` plugin manifests, discovered
+/// under `<root>/.agents/plugins/<name>/` (project or user scope).
+fn goose_config_path(location: McpLocation) -> PathBuf {
+    let root = match location {
+        McpLocation::Global => dirs::home_dir().unwrap_or_else(|| PathBuf::from(".")),
+        McpLocation::Local => env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+    };
+    root.join(".agents")
+        .join("plugins")
+        .join("sivtr")
+        .join(".mcp.json")
+}
+
+fn goose_host_present() -> bool {
+    let config_dir = dirs::config_dir().is_some_and(|dir| dir.join("goose").exists());
+    let agents_dir = dirs::home_dir().is_some_and(|home| home.join(".agents").exists());
+    config_dir || agents_dir || sivtr_core::agents::goose::goose_db_path().exists()
 }
 
 fn hermes_host_present() -> bool {

--- a/src/commands/system/mcp.rs
+++ b/src/commands/system/mcp.rs
@@ -34,7 +34,10 @@ enum McpConfigKind {
     /// TOML section: `[mcp_servers.sivtr]`
     Toml,
     /// YAML mapping: `<key>:\n  sivtr: ...`
-    Yaml { key: &'static str },
+    Yaml {
+        key: &'static str,
+        entry: fn() -> serde_yaml::Value,
+    },
     /// Nested JSON: `{ "<outer>": { "<inner>": { "sivtr": ... } } }`
     JsonNested {
         outer: &'static str,
@@ -110,7 +113,10 @@ const MCP_HOSTS: &[McpHostSpec] = &[
     McpHostSpec {
         provider: AgentProvider::Hermes,
         location: McpLocationSupport::GlobalOnly,
-        kind: McpConfigKind::Yaml { key: "mcp_servers" },
+        kind: McpConfigKind::Yaml {
+            key: "mcp_servers",
+            entry: hermes_entry,
+        },
         config_path: |_loc| hermes_config_path(),
         host_present: hermes_host_present,
     },
@@ -156,12 +162,12 @@ const MCP_HOSTS: &[McpHostSpec] = &[
     },
     McpHostSpec {
         provider: AgentProvider::Goose,
-        location: McpLocationSupport::GlobalOrLocal,
-        kind: McpConfigKind::Json {
-            key: "mcpServers",
-            entry: pi_entry,
+        location: McpLocationSupport::GlobalOnly,
+        kind: McpConfigKind::Yaml {
+            key: "extensions",
+            entry: goose_entry,
         },
-        config_path: goose_config_path,
+        config_path: |_loc| goose_config_path(),
         host_present: goose_host_present,
     },
 ];
@@ -234,7 +240,7 @@ fn install_target(target: AgentProvider, location: McpLocation) -> Result<()> {
     match host.kind {
         McpConfigKind::Json { key, entry } => install_json(path, key, entry(), target),
         McpConfigKind::Toml => install_toml(path, target),
-        McpConfigKind::Yaml { key } => install_yaml(path, key, target),
+        McpConfigKind::Yaml { key, entry } => install_yaml(path, key, entry(), target),
         McpConfigKind::JsonNested {
             outer,
             inner,
@@ -250,7 +256,7 @@ fn uninstall_target(target: AgentProvider, location: McpLocation) -> Result<()> 
     match host.kind {
         McpConfigKind::Json { key, .. } => uninstall_json(path, key, target),
         McpConfigKind::Toml => uninstall_toml(path, target),
-        McpConfigKind::Yaml { key } => uninstall_yaml(path, key, target),
+        McpConfigKind::Yaml { key, .. } => uninstall_yaml(path, key, target),
         McpConfigKind::JsonNested { outer, inner, .. } => {
             uninstall_json_nested(path, outer, inner, target)
         }
@@ -358,7 +364,7 @@ fn config_has_server(host: &McpHostSpec, location: McpLocation) -> bool {
     match host.kind {
         McpConfigKind::Json { key, .. } => json_has_server(&path, key),
         McpConfigKind::Toml => toml_has_server(&path),
-        McpConfigKind::Yaml { key } => yaml_has_server(&path, key),
+        McpConfigKind::Yaml { key, .. } => yaml_has_server(&path, key),
         McpConfigKind::JsonNested { outer, inner, .. } => {
             json_nested_has_server(&path, outer, inner)
         }
@@ -385,7 +391,7 @@ fn print_config(target: AgentProvider) {
         McpConfigKind::Toml => {
             println!("{}", toml_mcp_snippet());
         }
-        McpConfigKind::Yaml { key } => {
+        McpConfigKind::Yaml { key, .. } => {
             let mut root = serde_yaml::Mapping::new();
             let mut servers = serde_yaml::Mapping::new();
             servers.insert(
@@ -503,7 +509,12 @@ fn remove_toml_mcp_block(text: &mut String) -> bool {
     true
 }
 
-fn install_yaml(path: PathBuf, key: &str, provider: AgentProvider) -> Result<()> {
+fn install_yaml(
+    path: PathBuf,
+    key: &str,
+    entry: serde_yaml::Value,
+    provider: AgentProvider,
+) -> Result<()> {
     let mut root: serde_yaml::Value = if path.exists() {
         let text = fs::read_to_string(&path)
             .with_context(|| format!("Failed to read {}", path.display()))?;
@@ -518,10 +529,7 @@ fn install_yaml(path: PathBuf, key: &str, provider: AgentProvider) -> Result<()>
     };
 
     let servers = ensure_yaml_mapping(&mut root, key)?;
-    servers.insert(
-        serde_yaml::Value::String(SERVER_NAME.to_string()),
-        hermes_entry(),
-    );
+    servers.insert(serde_yaml::Value::String(SERVER_NAME.to_string()), entry);
 
     let text = serde_yaml::to_string(&root)?;
     write_text(&path, &text)?;
@@ -890,23 +898,71 @@ fn qwen_host_present() -> bool {
     qwen_config_path().exists() || sivtr_core::agents::qwen::qwen_home().exists()
 }
 
-/// Goose loads MCP servers from `.mcp.json` plugin manifests, discovered
-/// under `<root>/.agents/plugins/<name>/` (project or user scope).
-fn goose_config_path(location: McpLocation) -> PathBuf {
-    let root = match location {
-        McpLocation::Global => dirs::home_dir().unwrap_or_else(|| PathBuf::from(".")),
-        McpLocation::Local => env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-    };
-    root.join(".agents")
-        .join("plugins")
-        .join("sivtr")
-        .join(".mcp.json")
+/// Goose loads MCP servers from `config.yaml` under `extensions:` (the
+/// ExtensionConfig shape written by `goose configure`). Paths follow
+/// etcetera's app layout for `Block/goose` (Windows/macOS) or plain
+/// `goose` (XDG on Linux).
+fn goose_config_path() -> PathBuf {
+    if cfg!(windows) {
+        dirs::data_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("Block")
+            .join("goose")
+            .join("config")
+            .join("config.yaml")
+    } else if cfg!(target_os = "macos") {
+        dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("Library")
+            .join("Application Support")
+            .join("Block")
+            .join("goose")
+            .join("config.yaml")
+    } else {
+        dirs::config_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("goose")
+            .join("config.yaml")
+    }
+}
+
+/// Goose extension entry (`extensions.sivtr`) in the ExtensionConfig schema:
+/// `{enabled, type: stdio, name, cmd, args, envs}`.
+fn goose_entry() -> serde_yaml::Value {
+    let mut entry = serde_yaml::Mapping::new();
+    entry.insert(
+        serde_yaml::Value::String("enabled".to_string()),
+        serde_yaml::Value::Bool(true),
+    );
+    entry.insert(
+        serde_yaml::Value::String("type".to_string()),
+        serde_yaml::Value::String("stdio".to_string()),
+    );
+    entry.insert(
+        serde_yaml::Value::String("name".to_string()),
+        serde_yaml::Value::String(SERVER_NAME.to_string()),
+    );
+    entry.insert(
+        serde_yaml::Value::String("cmd".to_string()),
+        serde_yaml::Value::String("sivtr".to_string()),
+    );
+    let args = serde_yaml::Sequence::from([
+        serde_yaml::Value::String("mcp".to_string()),
+        serde_yaml::Value::String("serve".to_string()),
+    ]);
+    entry.insert(
+        serde_yaml::Value::String("args".to_string()),
+        serde_yaml::Value::Sequence(args),
+    );
+    entry.insert(
+        serde_yaml::Value::String("envs".to_string()),
+        serde_yaml::Value::Mapping(Default::default()),
+    );
+    serde_yaml::Value::Mapping(entry)
 }
 
 fn goose_host_present() -> bool {
-    let config_dir = dirs::config_dir().is_some_and(|dir| dir.join("goose").exists());
-    let agents_dir = dirs::home_dir().is_some_and(|home| home.join(".agents").exists());
-    config_dir || agents_dir || sivtr_core::agents::goose::goose_db_path().exists()
+    goose_config_path().exists() || sivtr_core::agents::goose::goose_db_path().exists()
 }
 
 fn hermes_host_present() -> bool {

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -61,6 +61,9 @@ pub(crate) fn provider_color(provider: AgentProvider) -> Color {
         AgentProvider::Grok => Color::Rgb(244, 114, 182),  // pink-400
         AgentProvider::Pi => Color::Rgb(74, 222, 128),     // green-400
         AgentProvider::Qoder => Color::Rgb(34, 211, 238),  // cyan-400
+        AgentProvider::Gemini => Color::Rgb(96, 165, 250), // blue-400
+        AgentProvider::Goose => Color::Rgb(251, 191, 36),  // amber-400
+        AgentProvider::Qwen => Color::Rgb(232, 121, 249),  // fuchsia-400
     }
 }
 

--- a/src/tui/workspace/model.rs
+++ b/src/tui/workspace/model.rs
@@ -40,6 +40,9 @@ impl WorkspaceSourceKind {
             Self::Agent(AgentProvider::Grok) => "grk",
             Self::Agent(AgentProvider::Pi) => "pi",
             Self::Agent(AgentProvider::Qoder) => "qdr",
+            Self::Agent(AgentProvider::Gemini) => "gmi",
+            Self::Agent(AgentProvider::Goose) => "gse",
+            Self::Agent(AgentProvider::Qwen) => "qwn",
         }
     }
 


### PR DESCRIPTION
## Purpose

Add three new agent providers to the registry: **Gemini CLI**, **Goose**, and **Qwen Code**. Each is a `jsonl`-based parser plus registry wiring (provider variants, provider specs, TUI colors/badges, and MCP host registrations — Gemini/Qwen `settings.json` mcpServers, Goose `config.yaml` extensions with per-OS paths).

Independent of the group/origin stack (#70-#102): only touches `agents/`, `commands/system/mcp.rs`, and TUI provider colors, so it bases directly on `main` and can merge on its own.

## Main changes

- `agents/gemini.rs`, `agents/goose.rs`, `agents/qwen.rs` — new `AgentProvider` parsers.
- `agents/jsonl.rs` — shared jsonl parsing gains what the new formats need.
- `agents/mod.rs` / `agents/model.rs` — registry wiring and provider metadata.
- `commands/system/mcp.rs` — MCP host registration for the three CLIs.
- TUI provider colors/badges for the new providers.

## Validation

- cargo test --workspace: 326 CLI + 212 core tests pass.
- cargo clippy --workspace --all-targets -- -D warnings and cargo fmt --all -- --check clean.
- Cherry-picked from the provider branch onto `main` (the touched files are unchanged between the group stack and main, so the commits apply cleanly).
