### PR TITLE
feat(mcp): interactive install host picker, idle-exit default

### DIFF
--- a/crates/sivtr-core/src/config/mod.rs
+++ b/crates/sivtr-core/src/config/mod.rs
@@ -83,12 +83,13 @@ pub struct HotkeyConfig {
 
 /// MCP stdio server settings (shared by every agent host registration —
 /// hosts all run plain `sivtr mcp serve`, behavior is configured here once).
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct McpConfig {
-    /// Seconds of no tool calls after which the stdio MCP server exits (0 =
-    /// stay alive until the host closes stdin). Hosts respawn the server on
-    /// the next tool use, so an idle server never lingers.
+    /// Seconds of no tool calls after which the stdio MCP server exits.
+    /// Default 60 (idle exit on); set 0 to keep the server alive until the
+    /// host closes stdin. Hosts respawn the server on the next tool use, so
+    /// an idle server never lingers.
     pub idle_exit_secs: u64,
 }
 
@@ -116,6 +117,12 @@ impl Default for HotkeyConfig {
         Self {
             chord: "alt+y".to_string(),
         }
+    }
+}
+
+impl Default for McpConfig {
+    fn default() -> Self {
+        Self { idle_exit_secs: 60 }
     }
 }
 
@@ -239,6 +246,6 @@ mod tests {
 
         assert!(toml.contains("[mcp]"));
         assert!(toml.contains("idle_exit_secs = 60"));
-        assert_eq!(SivtrConfig::default().mcp.idle_exit_secs, 0);
+        assert_eq!(SivtrConfig::default().mcp.idle_exit_secs, 60);
     }
 }

--- a/docs-site/src/content/docs/reference/cli.md
+++ b/docs-site/src/content/docs/reference/cli.md
@@ -568,7 +568,7 @@ sivtr mcp serve
 sivtr mcp serve --idle-exit 60
 ```
 
-`--idle-exit <SECS>` makes the server exit after that many seconds with no tool calls; the host respawns it on the next tool use, so an idle server never lingers (each agent session otherwise keeps one alive until it exits). `0` / absent = stay alive until the host closes stdin. The same value can be set globally with the `[mcp] idle_exit_secs` config key; the CLI flag wins over the config.
+`--idle-exit <SECS>` makes the server exit after that many seconds with no tool calls; the host respawns it on the next tool use, so an idle server never lingers (each agent session otherwise keeps one alive until it exits). `0` = stay alive until the host closes stdin. The same value can be set globally with the `[mcp] idle_exit_secs` config key, which defaults to `60` (idle exit on; set `0` to disable); the CLI flag wins over the config.
 
 Tools:
 

--- a/docs-site/src/content/docs/zh-cn/reference/cli.md
+++ b/docs-site/src/content/docs/zh-cn/reference/cli.md
@@ -566,7 +566,7 @@ sivtr mcp serve
 sivtr mcp serve --idle-exit 60
 ```
 
-`--idle-exit <SECS>` 让 server 在连续多少秒没有 tool call 后退出；host 会在下次使用工具时重新拉起，空闲 server 因此不会常驻（否则每个 agent session 会各保留一个直到退出）。`0` / 缺省 = 直到 host 关闭 stdin 才退出。也可以用全局配置键 `[mcp] idle_exit_secs` 设置同样的值；CLI flag 优先于配置。
+`--idle-exit <SECS>` 让 server 在连续多少秒没有 tool call 后退出；host 会在下次使用工具时重新拉起，空闲 server 因此不会常驻（否则每个 agent session 会各保留一个直到退出）。`0` = 直到 host 关闭 stdin 才退出。也可以用全局配置键 `[mcp] idle_exit_secs` 设置同样的值，默认 `60`（默认开启；设为 `0` 关闭）；CLI flag 优先于配置。
 
 工具：
 

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -29,7 +29,8 @@ pub struct McpServeArgs {
     /// Exit the server process after this many seconds with no tool calls.
     /// The host respawns the server on the next tool use, so an idle server
     /// never lingers (each agent session otherwise keeps one alive until it
-    /// exits). 0 / absent = stay alive until the host closes stdin.
+    /// exits). 0 = stay alive until the host closes stdin. Absent = the
+    /// `[mcp] idle_exit_secs` config value (default 60; 0 disables).
     #[arg(long, value_name = "SECS")]
     pub idle_exit: Option<u64>,
 }

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -11,7 +11,7 @@ pub enum McpAction {
     /// Run the read-only MCP server on stdio
     Serve(McpServeArgs),
 
-    /// Install sivtr MCP into agent hosts
+    /// Install sivtr MCP into agent hosts (interactively picks hosts when -p is omitted)
     Install(McpInstallArgs),
 
     /// Remove sivtr MCP from agent hosts
@@ -38,7 +38,7 @@ pub struct McpServeArgs {
 pub struct McpInstallArgs {
     /// Provider host(s) to inject (comma-separated or repeated).
     /// Use registered command names, or `all`.
-    /// Default: detect installed hosts.
+    /// Omit to pick hosts interactively; with -y, installs to detected hosts.
     #[arg(
         short = 'p',
         long = "provider",
@@ -51,7 +51,7 @@ pub struct McpInstallArgs {
     #[arg(short = 'l', long = "location", value_enum, default_value_t = McpLocation::Global)]
     pub location: McpLocation,
 
-    /// Non-interactive defaults
+    /// Non-interactive: skip the host picker and install to detected hosts
     #[arg(short = 'y', long = "yes")]
     pub yes: bool,
 }

--- a/src/commands/system/mcp.rs
+++ b/src/commands/system/mcp.rs
@@ -190,8 +190,9 @@ pub fn execute(command: McpCommand) -> Result<()> {
         McpAction::Serve(args) => {
             // Idle-exit precedence: CLI `--idle-exit` overrides the unified
             // `[mcp] idle_exit_secs` config, which all host registrations
-            // share (hosts run plain `sivtr mcp serve`).
-            let idle_secs = args.idle_exit.or_else(|| {
+            // share (hosts run plain `sivtr mcp serve`). Both accept 0 to
+            // mean "never exit on idle"; the config default is 60.
+            let idle_secs = args.idle_exit.filter(|&secs| secs > 0).or_else(|| {
                 SivtrConfig::load()
                     .ok()
                     .map(|config| config.mcp.idle_exit_secs)

--- a/src/commands/system/mcp.rs
+++ b/src/commands/system/mcp.rs
@@ -188,16 +188,11 @@ fn mcp_host(provider: AgentProvider) -> &'static McpHostSpec {
 pub fn execute(command: McpCommand) -> Result<()> {
     match command.action {
         McpAction::Serve(args) => {
-            // Idle-exit precedence: CLI `--idle-exit` overrides the unified
-            // `[mcp] idle_exit_secs` config, which all host registrations
-            // share (hosts run plain `sivtr mcp serve`). Both accept 0 to
-            // mean "never exit on idle"; the config default is 60.
-            let idle_secs = args.idle_exit.filter(|&secs| secs > 0).or_else(|| {
-                SivtrConfig::load()
-                    .ok()
-                    .map(|config| config.mcp.idle_exit_secs)
-                    .filter(|&secs| secs > 0)
-            });
+            // CLI `--idle-exit` wins over `[mcp] idle_exit_secs`. 0 = never.
+            let idle_secs = resolve_idle_exit_secs(
+                args.idle_exit,
+                SivtrConfig::load().ok().map(|c| c.mcp.idle_exit_secs),
+            );
             let runtime = tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
                 .build()?;
@@ -211,6 +206,10 @@ pub fn execute(command: McpCommand) -> Result<()> {
             Ok(())
         }
     }
+}
+
+fn resolve_idle_exit_secs(cli: Option<u64>, config: Option<u64>) -> Option<u64> {
+    cli.or(config).filter(|&secs| secs > 0)
 }
 
 pub fn install(args: &McpInstallArgs) -> Result<()> {
@@ -1144,5 +1143,13 @@ mod tests {
 
         let hermes = yaml_config_snippet("mcp_servers", hermes_entry());
         assert!(hermes.contains("command: sivtr"));
+    }
+
+    #[test]
+    fn resolve_idle_exit_secs_cli_zero_wins_over_config() {
+        assert_eq!(resolve_idle_exit_secs(Some(0), Some(60)), None);
+        assert_eq!(resolve_idle_exit_secs(Some(30), Some(60)), Some(30));
+        assert_eq!(resolve_idle_exit_secs(None, Some(60)), Some(60));
+        assert_eq!(resolve_idle_exit_secs(None, Some(0)), None);
     }
 }

--- a/src/commands/system/mcp.rs
+++ b/src/commands/system/mcp.rs
@@ -9,6 +9,7 @@ use sivtr_core::ai::AgentProvider;
 use sivtr_core::config::SivtrConfig;
 
 use crate::cli::{McpAction, McpCommand, McpInstallArgs, McpLocation};
+use crate::commands::interactive;
 use crate::mcp;
 use crate::output;
 
@@ -212,14 +213,48 @@ pub fn execute(command: McpCommand) -> Result<()> {
 }
 
 pub fn install(args: &McpInstallArgs) -> Result<()> {
-    let targets = resolve_targets(&args.providers)?;
+    // No explicit `-p` and no `-y`: let the user pick hosts interactively.
+    // Falls back to detected hosts when stdin is not a TTY.
+    let targets = if args.providers.is_empty() && !args.yes {
+        pick_targets()?
+    } else {
+        resolve_targets(&args.providers)?
+    };
     if targets.is_empty() {
-        bail!("no install targets resolved");
+        bail!("no install targets selected; pass -p with host names, or -p all");
     }
     for target in targets {
         install_target(target, args.location)?;
     }
     Ok(())
+}
+
+/// Interactive host multi-select, mirroring `npx skills`: all MCP-capable
+/// hosts listed, detected ones pre-checked. Returns `Ok(defaults)` when not
+/// interactive, so `doctor --fix` / `setup` (which pass `yes: true`) never
+/// prompt and CI pipes keep the old auto-detect behavior.
+fn pick_targets() -> Result<Vec<AgentProvider>> {
+    let detected = detect_targets();
+    let labels: Vec<String> = MCP_HOSTS
+        .iter()
+        .map(|host| {
+            format!(
+                "{} ({})",
+                host.provider.name(),
+                host.provider.command_name()
+            )
+        })
+        .collect();
+    let defaults: Vec<usize> = detected
+        .iter()
+        .filter_map(|target| MCP_HOSTS.iter().position(|host| host.provider == *target))
+        .collect();
+    let picked = interactive::multi_select(
+        "Install sivtr MCP into which agent hosts?",
+        &labels,
+        &defaults,
+    )?;
+    Ok(picked.into_iter().map(|i| MCP_HOSTS[i].provider).collect())
 }
 
 fn uninstall(args: &McpInstallArgs) -> Result<()> {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -148,17 +148,17 @@ pub async fn serve_stdio(idle_exit: Option<Duration>) -> anyhow::Result<()> {
         return Ok(());
     };
 
-    // Idle-exit watchdog: exit 0 once no tool call has completed for `idle`
-    // seconds (and none is in flight). The clock only starts after the first
-    // tool call — "exit after use" — so a freshly spawned server that the host
-    // is still initializing is never killed. MCP stdio hosts respawn the
-    // server on the next tool use, so an idle server never lingers.
+    // Standard idle-exit: the clock starts at spawn, so any server that stays
+    // idle for `idle` is killed — whether or not a tool was ever called —
+    // and unused servers never linger. Every tool call resets the clock.
+    // MCP stdio hosts respawn the server on the next tool use.
     //
     // This uses a hard `process::exit`: returning instead would drop the tokio
     // runtime, whose shutdown joins the blocking pool — and the stdio reader
     // thread is parked on the still-open stdin pipe, so the drop hangs until
     // the host closes stdin. Exiting directly is safe here: no tool call is in
     // flight (BUSY gate) and the last response was flushed seconds ago.
+    LAST_ACTIVITY_MS.store(now_ms(), Ordering::Relaxed);
     let wait = service.waiting();
     tokio::pin!(wait);
     let mut ticker = tokio::time::interval(Duration::from_millis(500));
@@ -170,8 +170,7 @@ pub async fn serve_stdio(idle_exit: Option<Duration>) -> anyhow::Result<()> {
                 return Ok(());
             }
             _ = ticker.tick() => {
-                if HAS_ACTIVITY.load(Ordering::Relaxed)
-                    && !BUSY.load(Ordering::Relaxed)
+                if !BUSY.load(Ordering::Relaxed)
                     && idle_elapsed() >= idle.as_millis() as u64
                 {
                     std::process::exit(0);
@@ -181,13 +180,9 @@ pub async fn serve_stdio(idle_exit: Option<Duration>) -> anyhow::Result<()> {
     }
 }
 
-/// Milliseconds since the last completed tool call (0 before any call).
+/// Milliseconds since the last completed tool call or server start.
 fn idle_elapsed() -> u64 {
-    let last = LAST_ACTIVITY_MS.load(Ordering::Relaxed);
-    if last == 0 {
-        return u64::MAX;
-    }
-    now_ms().saturating_sub(last)
+    now_ms().saturating_sub(LAST_ACTIVITY_MS.load(Ordering::Relaxed))
 }
 
 fn now_ms() -> u64 {
@@ -197,12 +192,11 @@ fn now_ms() -> u64 {
         .unwrap_or(0)
 }
 
-/// Last completed tool call, in epoch milliseconds.
+/// Last completed tool call or server start (the idle clock base), in epoch
+/// milliseconds.
 static LAST_ACTIVITY_MS: AtomicU64 = AtomicU64::new(0);
 /// A tool call is currently executing; the watchdog must not exit mid-call.
 static BUSY: AtomicBool = AtomicBool::new(false);
-/// Whether any tool call has ever completed (the idle clock starts then).
-static HAS_ACTIVITY: AtomicBool = AtomicBool::new(false);
 
 /// Marks activity at the start of a tool call and again when it completes.
 /// Dropped on every exit path, including errors.
@@ -210,7 +204,6 @@ struct ActivityGuard;
 
 impl ActivityGuard {
     fn begin() -> Self {
-        HAS_ACTIVITY.store(true, Ordering::Relaxed);
         BUSY.store(true, Ordering::Relaxed);
         LAST_ACTIVITY_MS.store(now_ms(), Ordering::Relaxed);
         Self


### PR DESCRIPTION
## Purpose

Make `sivtr mcp install` interactive (npx-skills style) so users can pick which agent hosts to configure, and default the stdio MCP server to exit after 60s of idle so each agent session does not keep a server alive until exit.

## Changes

- `mcp install` with no `-p` / `-y` now shows an interactive multi-select of all MCP-capable hosts, pre-checked to detected ones. Falls back to detected hosts when stdin is not a TTY, so `doctor --fix` / `setup` / CI pipes keep the old non-interactive behavior.
- `--yes` gains its intended meaning: skip the picker and install to detected hosts.
- Stdio MCP server exits after 60s with no tool calls by default; `[mcp] idle_exit_secs` config overrides, `--idle-exit 0` disables. Hosts respawn the server on the next tool use.

## Validation

- `cargo fmt --all -- --check` passes
- `cargo clippy --workspace --all-targets -- -D warnings` passes
- `cargo test --workspace mcp` passes (13 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP servers now automatically exit after 60 seconds of inactivity by default.
  * Idle timeout can be configured globally or through the CLI; setting it to `0` disables the timeout.
  * MCP installation offers interactive host selection when no provider is specified.

* **Bug Fixes**
  * Idle timeout now starts at server launch and resets correctly after tool activity.
  * CLI settings take precedence over global configuration.

* **Documentation**
  * Updated CLI help and reference documentation in English and Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->