### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/Ariestar/sivtr/security/code-scanning/5](https://github.com/Ariestar/sivtr/security/code-scanning/5)

Add an explicit workflow-level `permissions` block at the top level of `.github/workflows/rust.yml`, directly under `on:` (or another top-level key), with the minimum needed permission:
- `contents: read`

This is the best single fix because:
- It addresses all jobs (`ci`, `audit`, `msrv`, `docs`, `vscode`) at once without changing job behavior.
- It satisfies `actions/checkout` requirements.
- It preserves current functionality while enforcing least privilege and making permissions explicit/documented.

No imports, methods, or dependencies are needed (YAML workflow config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
