### PR TITLE
feat(agents): add Qoder-CN provider, align Qoder MCP config

### DIFF
--- a/crates/sivtr-core/src/agents/mod.rs
+++ b/crates/sivtr-core/src/agents/mod.rs
@@ -112,6 +112,14 @@ const AGENT_PROVIDER_SPECS: &[AgentProviderSpec] = &[
         factory: qoder_provider,
     },
     AgentProviderSpec {
+        provider: AgentProvider::QoderCn,
+        name: "Qoder-CN",
+        command_name: "qoder-cn",
+        current_transcript_env: None,
+        current_session_id_env: None,
+        factory: qoder_cn_provider,
+    },
+    AgentProviderSpec {
         provider: AgentProvider::Gemini,
         name: "Gemini",
         command_name: "gemini",
@@ -171,6 +179,10 @@ fn pi_provider() -> Box<dyn AgentSessionProvider> {
 
 fn qoder_provider() -> Box<dyn AgentSessionProvider> {
     Box::new(crate::agents::qoder::QoderProvider)
+}
+
+fn qoder_cn_provider() -> Box<dyn AgentSessionProvider> {
+    Box::new(crate::agents::qoder::QoderCnProvider)
 }
 
 fn gemini_provider() -> Box<dyn AgentSessionProvider> {

--- a/crates/sivtr-core/src/agents/model.rs
+++ b/crates/sivtr-core/src/agents/model.rs
@@ -20,6 +20,7 @@ pub enum AgentProvider {
     OpenCode,
     Pi,
     Qoder,
+    QoderCn,
     Qwen,
 }
 

--- a/crates/sivtr-core/src/agents/qoder.rs
+++ b/crates/sivtr-core/src/agents/qoder.rs
@@ -11,9 +11,10 @@ use crate::agents::{
 
 const PROVIDER_NAME: &str = "Qoder";
 
-/// Qoder CLI sessions.
+/// Qoder CLI sessions (global channel, `qodercli`).
 ///
-/// Layout (`QODER_HOME`, default `~/.qoder`):
+/// The global CLI shares its home with the Qoder IDE, so one provider covers
+/// both. Layout (default `~/.qoder`):
 /// ```text
 /// projects/<cwd-slug>/<session-uuid>.jsonl
 /// ```
@@ -21,55 +22,20 @@ const PROVIDER_NAME: &str = "Qoder";
 #[derive(Debug, Clone, Copy, Default)]
 pub struct QoderProvider;
 
+/// Qoder CLI CN sessions (`qoderclicn`).
+///
+/// Same JSONL schema as the global CLI, separate home (default `~/.qoder-cn`);
+/// only the home directory differs.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct QoderCnProvider;
+
 impl AgentSessionProvider for QoderProvider {
     fn provider(&self) -> AgentProvider {
         AgentProvider::Qoder
     }
 
     fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
-        let root = qoder_projects_dir();
-        if !root.exists() {
-            return Ok(Vec::new());
-        }
-
-        let mut sessions = Vec::new();
-        for bucket in fs::read_dir(&root)
-            .with_context(|| format!("Failed to read Qoder projects dir {}", root.display()))?
-        {
-            let bucket = bucket?;
-            let bucket_path = bucket.path();
-            if !bucket_path.is_dir() {
-                continue;
-            }
-            for entry in fs::read_dir(&bucket_path)
-                .with_context(|| format!("Failed to read Qoder bucket {}", bucket_path.display()))?
-            {
-                let entry = entry?;
-                let path = entry.path();
-                if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
-                    continue;
-                }
-                match parse_session_meta(&path) {
-                    Ok(meta) => {
-                        let modified = fs::metadata(&path)
-                            .and_then(|m| m.modified())
-                            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-                        sessions.push(AgentSessionInfo {
-                            path,
-                            id: meta.id,
-                            cwd: meta.cwd,
-                            title: meta.title,
-                            modified,
-                        });
-                    }
-                    Err(_) => continue,
-                }
-            }
-        }
-
-        sessions.sort_by_key(|s| s.modified);
-        sessions.reverse();
-        Ok(filter_sessions_by_workspace(sessions, cwd))
+        list_recent_sessions_in(&qoder_projects_dir(), cwd)
     }
 
     fn parse_session_file(&self, path: &Path) -> Result<AgentSession> {
@@ -77,17 +43,85 @@ impl AgentSessionProvider for QoderProvider {
     }
 }
 
-pub fn qoder_home() -> PathBuf {
-    if let Ok(path) = std::env::var("QODER_HOME") {
-        return PathBuf::from(path);
+impl AgentSessionProvider for QoderCnProvider {
+    fn provider(&self) -> AgentProvider {
+        AgentProvider::QoderCn
     }
+
+    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+        list_recent_sessions_in(&qoder_cn_projects_dir(), cwd)
+    }
+
+    fn parse_session_file(&self, path: &Path) -> Result<AgentSession> {
+        parse_jsonl_session(path, PROVIDER_NAME, apply_event)
+    }
+}
+
+/// Scan `projects/<cwd-slug>/<session>.jsonl` under `root`, newest first.
+/// Shared by the global and CN Qoder providers; only `root` differs.
+fn list_recent_sessions_in(root: &Path, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut sessions = Vec::new();
+    for bucket in fs::read_dir(root)
+        .with_context(|| format!("Failed to read Qoder projects dir {}", root.display()))?
+    {
+        let bucket = bucket?;
+        let bucket_path = bucket.path();
+        if !bucket_path.is_dir() {
+            continue;
+        }
+        for entry in fs::read_dir(&bucket_path)
+            .with_context(|| format!("Failed to read Qoder bucket {}", bucket_path.display()))?
+        {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                continue;
+            }
+            match parse_session_meta(&path) {
+                Ok(meta) => {
+                    let modified = fs::metadata(&path)
+                        .and_then(|m| m.modified())
+                        .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+                    sessions.push(AgentSessionInfo {
+                        path,
+                        id: meta.id,
+                        cwd: meta.cwd,
+                        title: meta.title,
+                        modified,
+                    });
+                }
+                Err(_) => continue,
+            }
+        }
+    }
+
+    sessions.sort_by_key(|s| s.modified);
+    sessions.reverse();
+    Ok(filter_sessions_by_workspace(sessions, cwd))
+}
+
+pub fn qoder_home() -> PathBuf {
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".qoder")
 }
 
+pub fn qoder_cn_home() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".qoder-cn")
+}
+
 fn qoder_projects_dir() -> PathBuf {
     qoder_home().join("projects")
+}
+
+fn qoder_cn_projects_dir() -> PathBuf {
+    qoder_cn_home().join("projects")
 }
 
 fn parse_session_meta(path: &Path) -> Result<AgentSessionMeta> {
@@ -246,7 +280,7 @@ fn push_content_blocks(
 
 #[cfg(test)]
 mod tests {
-    use super::QoderProvider;
+    use super::{QoderCnProvider, QoderProvider};
     use crate::agents::{format_blocks, AgentBlockKind, AgentSessionProvider};
 
     #[test]
@@ -317,5 +351,26 @@ mod tests {
         let session = QoderProvider.parse_session_file(&path).unwrap();
 
         assert_eq!(session.cwd.as_deref(), Some("D:\\Coding\\sivtr"));
+    }
+
+    #[test]
+    fn cn_provider_parses_identical_schema() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"type":"workspace-directories","sessionId":"cn-1","directories":["D:\\repo"]}
+{"type":"user","sessionId":"cn-1","cwd":"D:\\repo","timestamp":"2026-07-01T00:00:00Z","message":{"role":"user","content":"hello"}}
+{"type":"assistant","sessionId":"cn-1","cwd":"D:\\repo","timestamp":"2026-07-01T00:00:01Z","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}
+"#,
+        )
+        .unwrap();
+
+        let session = QoderCnProvider.parse_session_file(&path).unwrap();
+
+        assert_eq!(session.id.as_deref(), Some("cn-1"));
+        assert_eq!(session.cwd.as_deref(), Some("D:\\repo"));
+        assert_eq!(session.blocks.len(), 2);
+        assert_eq!(format_blocks(&session.blocks), "hello\n\ndone");
     }
 }

--- a/src/commands/system/mcp.rs
+++ b/src/commands/system/mcp.rs
@@ -141,6 +141,16 @@ const MCP_HOSTS: &[McpHostSpec] = &[
         host_present: qoder_host_present,
     },
     McpHostSpec {
+        provider: AgentProvider::QoderCn,
+        location: McpLocationSupport::GlobalOnly,
+        kind: McpConfigKind::Json {
+            key: "mcpServers",
+            entry: claude_cursor_entry,
+        },
+        config_path: |_loc| qoder_cn_config_path(),
+        host_present: qoder_cn_host_present,
+    },
+    McpHostSpec {
         provider: AgentProvider::Gemini,
         location: McpLocationSupport::GlobalOnly,
         kind: McpConfigKind::Json {
@@ -874,11 +884,19 @@ fn pi_host_present() -> bool {
 }
 
 fn qoder_config_path() -> PathBuf {
-    sivtr_core::agents::qoder::qoder_home().join("mcp.json")
+    sivtr_core::agents::qoder::qoder_home().join("settings.json")
 }
 
 fn qoder_host_present() -> bool {
     qoder_config_path().exists() || sivtr_core::agents::qoder::qoder_home().exists()
+}
+
+fn qoder_cn_config_path() -> PathBuf {
+    sivtr_core::agents::qoder::qoder_cn_home().join("settings.json")
+}
+
+fn qoder_cn_host_present() -> bool {
+    qoder_cn_config_path().exists() || sivtr_core::agents::qoder::qoder_cn_home().exists()
 }
 
 /// Gemini CLI reads MCP servers from `settings.json` (`mcpServers` key).

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -61,6 +61,7 @@ pub(crate) fn provider_color(provider: AgentProvider) -> Color {
         AgentProvider::Grok => Color::Rgb(244, 114, 182),  // pink-400
         AgentProvider::Pi => Color::Rgb(74, 222, 128),     // green-400
         AgentProvider::Qoder => Color::Rgb(34, 211, 238),  // cyan-400
+        AgentProvider::QoderCn => Color::Rgb(125, 211, 252), // sky-300
         AgentProvider::Gemini => Color::Rgb(96, 165, 250), // blue-400
         AgentProvider::Goose => Color::Rgb(251, 191, 36),  // amber-400
         AgentProvider::Qwen => Color::Rgb(232, 121, 249),  // fuchsia-400

--- a/src/tui/workspace/model.rs
+++ b/src/tui/workspace/model.rs
@@ -40,6 +40,7 @@ impl WorkspaceSourceKind {
             Self::Agent(AgentProvider::Grok) => "grk",
             Self::Agent(AgentProvider::Pi) => "pi",
             Self::Agent(AgentProvider::Qoder) => "qdr",
+            Self::Agent(AgentProvider::QoderCn) => "qcn",
             Self::Agent(AgentProvider::Gemini) => "gmi",
             Self::Agent(AgentProvider::Goose) => "gse",
             Self::Agent(AgentProvider::Qwen) => "qwn",


### PR DESCRIPTION
## Purpose

Adds a **Qoder-CN** agent provider (the `qoderclicn` CLI) with its own home directory (`~/.qoder-cn`), and aligns the existing Qoder MCP host with the shared CLI/IDE home.

## Changes

- **`sivtr-core`**: new `AgentProvider::QoderCn` variant registered as `qoder-cn`; `QoderCnProvider` reuses the existing Qoder JSONL parser through a shared `list_recent_sessions_in` scanner (only the home dir differs).
- **`src/commands/system/mcp.rs`**: Qoder MCP servers are now read from `settings.json` (`mcpServers` key) instead of `mcp.json`; registers a Qoder-CN MCP host (global, `settings.json`).
- **TUI**: Qoder-CN color (sky-300) and workspace scope abbreviation `qcn`.

## Behavior notes

- `qoder_home()` no longer honors the `QODER_HOME` env override — the Qoder CLI home is fixed at `~/.qoder` (shared with the Qoder IDE).

## Validation

- `cargo check --workspace` passes.
- `cargo test -p sivtr-core agents::qoder`: 4/4 pass, including a new `cn_provider_parses_identical_schema` test.

## Risks

- The `mcp.json` → `settings.json` switch changes where `sivtr mcp` reads Qoder's MCP config; users with a `mcp.json`-only setup will need to migrate.