### PR TITLE
feat(codex): parse custom tool call items with labels

### DIFF
--- a/crates/sivtr-core/src/agents/codex.rs
+++ b/crates/sivtr-core/src/agents/codex.rs
@@ -1,13 +1,13 @@
 use anyhow::Result;
 use serde_json::Value;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use crate::agents::{
     extract_content_text, jsonl_files, list_recent_jsonl_sessions, normalize_path_for_match,
     parse_jsonl_meta, parse_jsonl_session, pretty_json_string, pretty_json_value, push_block,
-    AgentBlockKind, AgentProvider, AgentSession, AgentSessionInfo, AgentSessionMeta,
-    AgentSessionProvider,
+    push_tool_block, AgentBlockKind, AgentProvider, AgentSession, AgentSessionInfo,
+    AgentSessionMeta, AgentSessionProvider,
 };
 use crate::config::SivtrConfig;
 
@@ -46,6 +46,7 @@ impl AgentSessionProvider for CodexProvider {
     fn parse_session_file(&self, path: &Path) -> Result<AgentSession> {
         let mut saw_response_item = false;
         let mut event_fallback_indices = Vec::new();
+        let mut tool_labels = HashMap::new();
         let mut session = parse_jsonl_session(path, PROVIDER_NAME, |session, value| {
             let timestamp = value
                 .get("timestamp")
@@ -66,7 +67,7 @@ impl AgentSessionProvider for CodexProvider {
                 }
                 Some("response_item") => {
                     saw_response_item = true;
-                    apply_response_item(session, payload, timestamp.clone());
+                    apply_response_item(session, payload, timestamp.clone(), &mut tool_labels);
                 }
                 Some("event_msg") => {
                     let start = session.blocks.len();
@@ -179,7 +180,12 @@ fn parse_session_meta(path: &Path) -> Result<AgentSessionMeta> {
     })
 }
 
-fn apply_response_item(session: &mut AgentSession, payload: &Value, timestamp: Option<String>) {
+fn apply_response_item(
+    session: &mut AgentSession,
+    payload: &Value,
+    timestamp: Option<String>,
+    tool_labels: &mut HashMap<String, String>,
+) {
     match payload.get("type").and_then(Value::as_str) {
         Some("message") => {
             let kind = match payload.get("role").and_then(Value::as_str) {
@@ -201,27 +207,45 @@ fn apply_response_item(session: &mut AgentSession, payload: &Value, timestamp: O
                 clean_codex_message_text(kind, text),
             );
         }
-        Some("function_call") => push_block(
-            session,
-            AgentBlockKind::ToolCall,
-            timestamp,
-            payload
+        Some("function_call" | "custom_tool_call") => {
+            let call_id = payload
+                .get("call_id")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            let label = payload
                 .get("name")
                 .and_then(Value::as_str)
-                .map(str::to_string),
-            extract_tool_call_text(payload),
-        ),
-        Some("function_call_output") => push_block(
-            session,
-            AgentBlockKind::ToolOutput,
-            timestamp,
-            None,
-            payload
-                .get("output")
+                .map(str::to_string);
+            if let (Some(call_id), Some(label)) = (call_id.as_ref(), label.as_ref()) {
+                tool_labels.insert(call_id.clone(), label.clone());
+            }
+            push_tool_block(
+                session,
+                AgentBlockKind::ToolCall,
+                timestamp,
+                call_id,
+                label,
+                extract_tool_call_text(payload),
+            );
+        }
+        Some("function_call_output" | "custom_tool_call_output") => {
+            let call_id = payload
+                .get("call_id")
                 .and_then(Value::as_str)
-                .unwrap_or_default()
-                .to_string(),
-        ),
+                .map(str::to_string);
+            let label = call_id
+                .as_deref()
+                .and_then(|id| tool_labels.get(id))
+                .cloned();
+            push_tool_block(
+                session,
+                AgentBlockKind::ToolOutput,
+                timestamp,
+                call_id,
+                label,
+                extract_tool_output_text(payload),
+            );
+        }
         _ => {}
     }
 }
@@ -276,10 +300,25 @@ fn strip_trailing_oai_memory_citation(text: String) -> String {
 }
 
 fn extract_tool_call_text(payload: &Value) -> String {
-    match payload.get("arguments") {
+    match payload.get("arguments").or_else(|| payload.get("input")) {
         Some(Value::String(arguments)) => pretty_json_string(arguments),
         Some(arguments) => pretty_json_value(arguments),
         None => pretty_json_value(payload),
+    }
+}
+
+fn extract_tool_output_text(payload: &Value) -> String {
+    let Some(output) = payload.get("output") else {
+        return String::new();
+    };
+    if let Some(text) = output.as_str() {
+        return text.to_string();
+    }
+    let text = extract_content_text(output);
+    if text.trim().is_empty() {
+        pretty_json_value(output)
+    } else {
+        text
     }
 }
 
@@ -374,6 +413,35 @@ mod tests {
         assert_eq!(session.blocks[1].kind, AgentBlockKind::ToolCall);
         assert_eq!(session.blocks[2].kind, AgentBlockKind::ToolOutput);
         assert_eq!(session.blocks[3].kind, AgentBlockKind::Assistant);
+    }
+
+    #[test]
+    fn parses_codex_custom_tool_calls_and_outputs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"type":"session_meta","payload":{"id":"abc"}}
+{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}}
+{"type":"response_item","payload":{"type":"custom_tool_call","id":"ctc_1","call_id":"call_1","name":"exec","input":"ls"}}
+{"type":"response_item","payload":{"type":"custom_tool_call_output","id":"ctco_1","call_id":"call_1","output":[{"type":"input_text","text":"file.txt"}]}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}
+"#,
+        )
+        .unwrap();
+
+        let session = CodexProvider.parse_session_file(&path).unwrap();
+
+        assert_eq!(session.blocks.len(), 4);
+        assert_eq!(session.blocks[1].kind, AgentBlockKind::ToolCall);
+        assert_eq!(session.blocks[1].label.as_deref(), Some("exec"));
+        assert_eq!(session.blocks[1].call_id.as_deref(), Some("call_1"));
+        assert_eq!(session.blocks[1].text, "ls");
+        assert_eq!(session.blocks[2].kind, AgentBlockKind::ToolOutput);
+        assert_eq!(session.blocks[2].label.as_deref(), Some("exec"));
+        assert_eq!(session.blocks[2].call_id.as_deref(), Some("call_1"));
+        assert_eq!(session.blocks[2].text, "file.txt");
+        assert!(format_blocks(&session.blocks).contains("<:tool:exec call:>"));
     }
 
     #[test]

--- a/crates/sivtr-core/src/query/mod.rs
+++ b/crates/sivtr-core/src/query/mod.rs
@@ -211,7 +211,7 @@ fn agent_records(
 }
 
 /// Bump when the cached record layout or agent parsing changes.
-const AGENT_CACHE_VERSION: u32 = 5;
+const AGENT_CACHE_VERSION: u32 = 6;
 
 /// On-disk cache entry for one parsed agent session file, keyed by the
 /// session file's (mtime, size). Reading back a stamp-matched blob is an

--- a/src/tui/content/text.rs
+++ b/src/tui/content/text.rs
@@ -30,7 +30,7 @@ fn io_body_text(record: &WorkRecord, reading: bool, input: bool) -> String {
 }
 
 /// Reading: dialogue in order; each adjacent structure run folds into a
-/// per-channel summary at its position (tools / mcp / skills / thinking).
+/// marker-only line at its position, identical markers counting as `xN`.
 fn structured_parts_text(parts: &[&sivtr_core::record::WorkPart]) -> String {
     let mut chunks = Vec::new();
     let mut run: Vec<&sivtr_core::record::WorkPart> = Vec::new();
@@ -79,73 +79,33 @@ fn structure_fold_label(part: &sivtr_core::record::WorkPart) -> String {
         .unwrap_or_else(|| "<:structure:>".to_string())
 }
 
-/// Per-channel summary of a structure run: tools / mcp / skills / thinking.
-/// Tool results are dropped (a call implies its result).
+/// One line of original markers; identical labels become `label xN`.
+/// Tool results are dropped (a call marker implies its result).
 fn collapse_structure_markers(parts: &[&sivtr_core::record::WorkPart]) -> String {
-    use sivtr_core::record::WorkPartKind;
-
-    let mut tools: Vec<(String, usize)> = Vec::new();
-    let mut mcp: Vec<(String, usize)> = Vec::new();
-    let mut skills: Vec<(String, usize)> = Vec::new();
-    let mut thinking = 0usize;
-
+    use sivtr_core::ai::AgentBlockKind;
+    let mut counts: Vec<(String, usize)> = Vec::new();
     for part in parts {
-        match part.kind() {
-            WorkPartKind::ToolCall => {
-                let label = part.label().unwrap_or("tool");
-                match label.strip_prefix("mcp__") {
-                    Some(rest) => bump(&mut mcp, rest.rsplit("__").next().unwrap_or(rest)),
-                    None => bump(&mut tools, label),
-                }
-            }
-            WorkPartKind::Skill => bump(&mut skills, part.label().unwrap_or("skill")),
-            WorkPartKind::Thinking => thinking += 1,
-            _ => {}
+        if part.kind().as_agent_block_kind() == Some(AgentBlockKind::ToolOutput) {
+            continue;
+        }
+        let label = structure_fold_label(part);
+        if let Some((_, count)) = counts.iter_mut().find(|(existing, _)| *existing == label) {
+            *count += 1;
+        } else {
+            counts.push((label, 1));
         }
     }
-
-    let mut lines = Vec::new();
-    if let Some(line) = channel_line("tools", &tools) {
-        lines.push(line);
-    }
-    if let Some(line) = channel_line("mcp", &mcp) {
-        lines.push(line);
-    }
-    if let Some(line) = channel_line("skills", &skills) {
-        lines.push(line);
-    }
-    if thinking > 0 {
-        lines.push(format!("thinking{}", count_suffix(thinking)));
-    }
-    lines.join("\n")
-}
-
-fn bump(counts: &mut Vec<(String, usize)>, name: &str) {
-    if let Some((_, count)) = counts.iter_mut().find(|(existing, _)| existing == name) {
-        *count += 1;
-    } else {
-        counts.push((name.to_string(), 1));
-    }
-}
-
-fn channel_line(label: &str, counts: &[(String, usize)]) -> Option<String> {
-    if counts.is_empty() {
-        return None;
-    }
-    let names = counts
+    counts
         .iter()
-        .map(|(name, count)| format!("{name}{}", count_suffix(*count)))
+        .map(|(label, count)| {
+            if *count == 1 {
+                label.clone()
+            } else {
+                format!("{label} x{count}")
+            }
+        })
         .collect::<Vec<_>>()
-        .join(", ");
-    Some(format!("{label}: {names}"))
-}
-
-fn count_suffix(count: usize) -> String {
-    if count > 1 {
-        format!(" x{count}")
-    } else {
-        String::new()
-    }
+        .join(" ")
 }
 
 pub(crate) fn workspace_content_text(

--- a/src/tui/workspace/tests.rs
+++ b/src/tui/workspace/tests.rs
@@ -200,8 +200,8 @@ fn reading_mode_folds_structure_and_raw_expands() {
         None,
     );
     assert!(reading_io.input.contains("question"));
-    // Fold summarizes tool activity by channel; results are dropped.
-    assert!(reading_io.output.contains("tools: Bash"));
+    // Fold keeps the structural marker so the content renderer can color it.
+    assert!(reading_io.output.contains("<:tool:Bash call:>"));
     assert!(!reading_io.output.contains("result"));
     assert!(reading_io.output.contains("answer"));
     assert!(!reading.contains("cargo test"));
@@ -293,21 +293,21 @@ fn reading_mode_collapses_adjacent_structure_runs() {
         None,
     );
     assert!(reading_io.input.contains("do it"));
-    // Tool calls fold to one channel line in the output half; skills to one in the input half.
+    // Tool calls and skills fold to marker-only lines in their respective halves.
     let tool_fold = reading_io
         .output
         .lines()
-        .find(|line| line.starts_with("tools:"))
+        .find(|line| line.starts_with("<:tool:"))
         .expect("tools channel line");
-    assert!(tool_fold.contains("Bash"));
-    assert!(tool_fold.contains("Read"));
+    assert!(tool_fold.contains("<:tool:Bash call:>"));
+    assert!(tool_fold.contains("<:tool:Read call:>"));
     let skill_fold = reading_io
         .input
         .lines()
-        .find(|line| line.starts_with("skills:"))
+        .find(|line| line.starts_with("<:skill:"))
         .expect("skills channel line");
-    assert!(skill_fold.contains("review"));
-    assert!(skill_fold.contains("deploy"));
+    assert!(skill_fold.contains("<:skill:review:>"));
+    assert!(skill_fold.contains("<:skill:deploy:>"));
     assert!(reading_io.output.contains("done"));
     assert!(!reading.contains("file"));
     assert!(!reading.contains("skill body"));
@@ -366,15 +366,15 @@ fn reading_mode_counts_identical_structure_markers_regardless_of_order() {
         ContentViewMode::Reading,
         None,
     );
-    // Repeated tool names count as xN within the single tools channel line.
-    assert!(reading.contains("tools: Bash x3, Read"));
+    // Repeated tool names count as xN within the single marker line.
+    assert!(reading.contains("<:tool:Bash call:> x3 <:tool:Read call:>"));
     assert!(reading.contains("middle note"));
     assert!(!reading.contains("file"));
     assert!(!reading.contains("pwd"));
     // Single tools line for the section (not split by the dialogue part).
     let fold_hits = reading
         .lines()
-        .filter(|line| line.starts_with("tools:"))
+        .filter(|line| line.starts_with("<:tool:"))
         .count();
     assert_eq!(fold_hits, 1);
 }
@@ -429,7 +429,7 @@ fn reading_mode_keeps_structure_runs_in_call_order() {
     // Fold sits between the assistant chunks, matching the call order.
     let output = &reading_io.output;
     let first_text = output.find("checking first").expect("first assistant text");
-    let fold = output.find("tools: Bash").expect("tool fold line");
+    let fold = output.find("<:tool:Bash call:>").expect("tool fold line");
     let last_text = output.find("all done").expect("last assistant text");
     assert!(first_text < fold);
     assert!(fold < last_text);


### PR DESCRIPTION
Support Codex's `custom_tool_call` / `custom_tool_call_output` response items, which the newer API uses for tool invocations.

## Changes

- **codex.rs**: parse `custom_tool_call` and `custom_tool_call_output`; tool calls and outputs now carry a label (tool name) and are linked by `call_id`
- **text.rs / workspace tests**: content view renders structure runs as marker-only lines (`<:tool:name call:>`) with `xN` counts for identical labels
- **query/mod.rs**: bump `AGENT_CACHE_VERSION` since the parsed block layout changed

## Validation

- `cargo fmt --all -- --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace` ✅ (exit 0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tool-call tracking and output display, including custom tools and structured results.
  * Reading mode now shows tool and skill activity in execution order, with repeated tools summarized by count.

* **Bug Fixes**
  * Improved association between tool calls and their corresponding outputs.
  * Updated session caching to ensure refreshed session data is used.

* **Tests**
  * Added coverage for custom tool calls, output handling, marker ordering, and repeated tool counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->