### PR TITLE
refactor(tui): fold structure blocks to tags in read mode

### DIFF
--- a/src/tui/content/markdown.rs
+++ b/src/tui/content/markdown.rs
@@ -185,16 +185,6 @@ fn markdown_line_parts(line: &str) -> MarkdownLineParts<'_> {
         };
     }
 
-    // Read-mode fold summaries ("tools: Bash x2", "thinking x7").
-    if let Some(style) = fold_summary_style(trimmed) {
-        return MarkdownLineParts {
-            prefix: leading.to_string(),
-            prefix_style: Style::default(),
-            content: trimmed,
-            content_style: style,
-        };
-    }
-
     if let Some(rest) = trimmed.strip_prefix("> ") {
         return MarkdownLineParts {
             prefix: format!("{leading}> "),
@@ -733,29 +723,14 @@ fn agent_heading_style(text: &str) -> Option<Style> {
     Some(Style::default().fg(color).add_modifier(Modifier::BOLD))
 }
 
-/// Style for `<:channel:…:>` structure markers (tools/skills/thinking/mcp)
-/// and read-mode fold summaries: structural content renders in a subdued
-/// gray in every content mode, distinct from the default-foreground body.
+/// Style for `<:channel:…:>` structure markers (tools/skills/thinking/mcp):
+/// structural content renders in a subdued gray, distinct from the
+/// default-foreground body.
 fn structure_marker_style(text: &str) -> Option<Style> {
     if !text.starts_with("<:") {
         return None;
     }
     Some(structural_gray_style())
-}
-
-/// Read-mode fold summaries produced by `collapse_structure_markers`
-/// (content/text.rs): `tools: …`, `mcp: …`, `skills: …`, `thinking xN`.
-fn fold_summary_style(text: &str) -> Option<Style> {
-    let channel = ["tools:", "mcp:", "skills:"]
-        .iter()
-        .any(|prefix| text.starts_with(prefix));
-    let thinking = text.strip_prefix("thinking").is_some_and(|rest| {
-        rest.is_empty()
-            || rest.strip_prefix(" x").is_some_and(|count| {
-                !count.is_empty() && count.chars().all(|ch| ch.is_ascii_digit())
-            })
-    });
-    (channel || thinking).then(structural_gray_style)
 }
 
 fn structural_gray_style() -> Style {
@@ -856,31 +831,6 @@ mod tests {
             lines[5].line.spans[1].style.fg,
             Some(crate::tui::theme::failure())
         ); // Error
-    }
-
-    #[test]
-    fn renders_read_mode_fold_summaries_in_gray() {
-        let lines = render_markdown_window(
-            &[
-                "tools: Bash x2",
-                "mcp: read_file",
-                "skills: sivtr-memory",
-                "thinking",
-                "thinking x7",
-            ],
-            0,
-            5,
-            80,
-        );
-
-        for line in lines {
-            assert_eq!(
-                line.line.spans[0].style.fg,
-                Some(crate::tui::theme::muted()),
-                "fold summary must render gray: {:?}",
-                line.line.spans[0].content
-            );
-        }
     }
 
     #[test]

--- a/src/tui/content/text.rs
+++ b/src/tui/content/text.rs
@@ -29,30 +29,17 @@ fn io_body_text(record: &WorkRecord, reading: bool, input: bool) -> String {
     }
 }
 
-/// Reading: dialogue in order; each adjacent structure run folds into a
-/// per-channel summary at its position (tools / mcp / skills / thinking).
+/// Reading: dialogue in order; each structure part collapses to its
+/// `<:…:>` open-marker tag line (same gray style as raw markers).
 fn structured_parts_text(parts: &[&sivtr_core::record::WorkPart]) -> String {
     let mut chunks = Vec::new();
-    let mut run: Vec<&sivtr_core::record::WorkPart> = Vec::new();
-    let flush = |run: &mut Vec<&sivtr_core::record::WorkPart>, chunks: &mut Vec<String>| {
-        if run.is_empty() {
-            return;
-        }
-        let fold = collapse_structure_markers(run);
-        run.clear();
-        if !fold.is_empty() {
-            chunks.push(fold);
-        }
-    };
     for part in parts {
         if part.kind().is_structure() {
-            run.push(part);
-            continue;
+            chunks.push(structure_fold_label(part));
+        } else {
+            chunks.push(part.text().into_owned());
         }
-        flush(&mut run, &mut chunks);
-        chunks.push(part.text().into_owned());
     }
-    flush(&mut run, &mut chunks);
     chunks.join("\n\n")
 }
 
@@ -77,75 +64,6 @@ fn structure_fold_label(part: &sivtr_core::record::WorkPart) -> String {
         .as_agent_block_kind()
         .and_then(|kind| kind.open_marker(part.label()))
         .unwrap_or_else(|| "<:structure:>".to_string())
-}
-
-/// Per-channel summary of a structure run: tools / mcp / skills / thinking.
-/// Tool results are dropped (a call implies its result).
-fn collapse_structure_markers(parts: &[&sivtr_core::record::WorkPart]) -> String {
-    use sivtr_core::record::WorkPartKind;
-
-    let mut tools: Vec<(String, usize)> = Vec::new();
-    let mut mcp: Vec<(String, usize)> = Vec::new();
-    let mut skills: Vec<(String, usize)> = Vec::new();
-    let mut thinking = 0usize;
-
-    for part in parts {
-        match part.kind() {
-            WorkPartKind::ToolCall => {
-                let label = part.label().unwrap_or("tool");
-                match label.strip_prefix("mcp__") {
-                    Some(rest) => bump(&mut mcp, rest.rsplit("__").next().unwrap_or(rest)),
-                    None => bump(&mut tools, label),
-                }
-            }
-            WorkPartKind::Skill => bump(&mut skills, part.label().unwrap_or("skill")),
-            WorkPartKind::Thinking => thinking += 1,
-            _ => {}
-        }
-    }
-
-    let mut lines = Vec::new();
-    if let Some(line) = channel_line("tools", &tools) {
-        lines.push(line);
-    }
-    if let Some(line) = channel_line("mcp", &mcp) {
-        lines.push(line);
-    }
-    if let Some(line) = channel_line("skills", &skills) {
-        lines.push(line);
-    }
-    if thinking > 0 {
-        lines.push(format!("thinking{}", count_suffix(thinking)));
-    }
-    lines.join("\n")
-}
-
-fn bump(counts: &mut Vec<(String, usize)>, name: &str) {
-    if let Some((_, count)) = counts.iter_mut().find(|(existing, _)| existing == name) {
-        *count += 1;
-    } else {
-        counts.push((name.to_string(), 1));
-    }
-}
-
-fn channel_line(label: &str, counts: &[(String, usize)]) -> Option<String> {
-    if counts.is_empty() {
-        return None;
-    }
-    let names = counts
-        .iter()
-        .map(|(name, count)| format!("{name}{}", count_suffix(*count)))
-        .collect::<Vec<_>>()
-        .join(", ");
-    Some(format!("{label}: {names}"))
-}
-
-fn count_suffix(count: usize) -> String {
-    if count > 1 {
-        format!(" x{count}")
-    } else {
-        String::new()
-    }
 }
 
 pub(crate) fn workspace_content_text(

--- a/src/tui/content/view.rs
+++ b/src/tui/content/view.rs
@@ -25,9 +25,10 @@ impl ContentViewMode {
 
     pub(crate) fn label(self) -> &'static str {
         match self {
-            // Reading = structure folded; Raw = full payloads with <:…:> markers.
-            Self::Raw => "raw/full",
-            Self::Reading => "read/fold",
+            // Read folds structure blocks to their `<:…:>` tags; raw shows
+            // full payloads. Both render tags with the same gray style.
+            Self::Raw => "raw",
+            Self::Reading => "read",
         }
     }
 }

--- a/src/tui/workspace/help.rs
+++ b/src/tui/workspace/help.rs
@@ -194,9 +194,9 @@ pub(crate) fn workspace_help_entries() -> &'static [WorkspaceHelpEntry] {
         },
         WorkspaceHelpEntry {
             key: "r",
-            description: "toggle fold/full content",
+            description: "toggle read/raw content",
             action: WorkspaceHelpAction::ToggleContentMode,
-            footer_label: Some("fold/full"),
+            footer_label: Some("read/raw"),
             footer_panes: CNT,
         },
         WorkspaceHelpEntry {

--- a/src/tui/workspace/tests.rs
+++ b/src/tui/workspace/tests.rs
@@ -200,11 +200,12 @@ fn reading_mode_folds_structure_and_raw_expands() {
         None,
     );
     assert!(reading_io.input.contains("question"));
-    // Fold summarizes tool activity by channel; results are dropped.
-    assert!(reading_io.output.contains("tools: Bash"));
-    assert!(!reading_io.output.contains("result"));
+    // Reading folds each structure part to its tag line; payloads are dropped.
+    assert!(reading_io.output.contains("<:tool:Bash call:>"));
+    assert!(reading_io.output.contains("<:tool:Bash result:>"));
     assert!(reading_io.output.contains("answer"));
     assert!(!reading.contains("cargo test"));
+    assert!(!reading.contains("ok"));
     assert!(!reading.contains("codex/session"));
     assert!(!reading.contains("## User"));
     assert!(!reading.contains("## Input"));
@@ -293,21 +294,13 @@ fn reading_mode_collapses_adjacent_structure_runs() {
         None,
     );
     assert!(reading_io.input.contains("do it"));
-    // Tool calls fold to one channel line in the output half; skills to one in the input half.
-    let tool_fold = reading_io
-        .output
-        .lines()
-        .find(|line| line.starts_with("tools:"))
-        .expect("tools channel line");
-    assert!(tool_fold.contains("Bash"));
-    assert!(tool_fold.contains("Read"));
-    let skill_fold = reading_io
-        .input
-        .lines()
-        .find(|line| line.starts_with("skills:"))
-        .expect("skills channel line");
-    assert!(skill_fold.contains("review"));
-    assert!(skill_fold.contains("deploy"));
+    // Every structure part folds to its own tag line in the reading text.
+    let output = &reading_io.output;
+    assert!(output.contains("<:tool:Bash call:>"));
+    assert!(output.contains("<:tool:Read call:>"));
+    let input = &reading_io.input;
+    assert!(input.contains("<:skill:review:>"));
+    assert!(input.contains("<:skill:deploy:>"));
     assert!(reading_io.output.contains("done"));
     assert!(!reading.contains("file"));
     assert!(!reading.contains("skill body"));
@@ -359,24 +352,27 @@ fn reading_mode_counts_identical_structure_markers_regardless_of_order() {
     ]);
     let dialogue = codex_dialogue(record);
 
-    let reading = workspace_content_text(
+    let reading_io = workspace_content_io_texts(
         std::slice::from_ref(&dialogue),
         &[false],
         0,
         ContentViewMode::Reading,
         None,
     );
-    // Repeated tool names count as xN within the single tools channel line.
-    assert!(reading.contains("tools: Bash x3, Read"));
-    assert!(reading.contains("middle note"));
-    assert!(!reading.contains("file"));
-    assert!(!reading.contains("pwd"));
-    // Single tools line for the section (not split by the dialogue part).
-    let fold_hits = reading
-        .lines()
-        .filter(|line| line.starts_with("tools:"))
-        .count();
-    assert_eq!(fold_hits, 1);
+    // Every structure part keeps its own tag line, in call order.
+    assert!(reading_io.input.contains("middle note"));
+    let output = &reading_io.output;
+    assert!(output.contains("<:tool:Bash call:>"));
+    assert!(output.contains("<:tool:Read call:>"));
+    assert!(!output.contains("file"));
+    assert!(!output.contains("pwd"));
+    assert!(!output.contains("date"));
+    // Tags stay in call order within the output half.
+    let first = output.find("<:tool:Bash call:>").expect("first bash tag");
+    let read = output.find("<:tool:Read call:>").expect("read tag");
+    let second_bash = output.rfind("<:tool:Bash call:>").expect("later bash tag");
+    assert!(first < read);
+    assert!(read < second_bash);
 }
 
 #[test]
@@ -426,25 +422,26 @@ fn reading_mode_keeps_structure_runs_in_call_order() {
         ContentViewMode::Reading,
         None,
     );
-    // Fold sits between the assistant chunks, matching the call order.
+    // Tags sit between the assistant chunks, matching the call order.
     let output = &reading_io.output;
     let first_text = output.find("checking first").expect("first assistant text");
-    let fold = output.find("tools: Bash").expect("tool fold line");
+    let tag = output.find("<:tool:Bash call:>").expect("tool tag");
     let last_text = output.find("all done").expect("last assistant text");
-    assert!(first_text < fold);
-    assert!(fold < last_text);
-    assert!(!output.contains("result"));
+    assert!(first_text < tag);
+    assert!(tag < last_text);
+    // Payloads are dropped: the tag line mentions result, the body never shows.
+    assert!(!output.contains("ok"));
 }
 
 #[test]
 fn content_title_includes_view_mode() {
     assert_eq!(
         content_title(ContentViewMode::Reading, &[false, false], None),
-        "Content (read/fold)"
+        "Content (read)"
     );
     assert_eq!(
         content_title(ContentViewMode::Raw, &[true, false], None),
-        "Content (raw/full): 1 dialogue selected"
+        "Content (raw): 1 dialogue selected"
     );
 }
 
@@ -454,7 +451,7 @@ fn content_title_includes_current_dialogue_ref() {
 
     assert_eq!(
         content_title(ContentViewMode::Reading, &[false], Some(&work_ref)),
-        "Content (read/fold) [codex/session/2]"
+        "Content (read) [codex/session/2]"
     );
 }
 


### PR DESCRIPTION
## Purpose
Read mode now collapses every structure part to its \<:…:>\ tag line (\<:tool:Bash call:>\, \<:thinking:>\, …) instead of a plain channel summary (\	ools: Bash x2\). Raw mode keeps the complete block. Both modes render the tags with the same gray style — read and raw share styling, not content.

## Changes
- \structured_parts_text\ emits each part's open-marker tag instead of channel summaries; \collapse_structure_markers\ and its dead styling are deleted.
- Content labels become \ead\ / \aw\.

## Validation
- \cargo test --workspace\ (332 + 205), clippy \-D warnings\, \cargo fmt --check\ pass; workspace tests rewritten to assert read shows tags only (payloads dropped) and raw shows full blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated reading mode to display each tool and skill structure marker individually and in dialogue order.
  * Preserved non-structure text while omitting structure payloads in reading mode.
  * Simplified content mode labels to “read” and “raw.”
  * Updated help text and workspace titles to reflect the revised terminology.
* **Bug Fixes**
  * Removed outdated fold-summary styling and aggregation behavior in reading mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->