### PR TITLE
feat(tui): color unified-diff lines inside code blocks

### DIFF
--- a/src/tui/content/markdown.rs
+++ b/src/tui/content/markdown.rs
@@ -111,11 +111,11 @@ fn render_code_block(body: &[&str], language: Option<&str>) -> Vec<MarkdownLine>
 }
 
 /// Unified-diff hunk header: `@@ -1,3 +1,4 @@` (an optional section heading
-/// may follow the closing `@@`). Validates the full shape so ordinary code
-/// lines that merely start with `@@` (doc attributes, Lua long strings, …)
-/// do not switch the whole block into diff mode.
+/// may follow the closing `@@`). Strict on shape and column: the header
+/// starts at column 0, the old range is minus-led and the new range
+/// plus-led, and each range carries at most one line-count segment — so
+/// context lines and lookalike code never switch the block into diff mode.
 fn is_diff_hunk_header(line: &str) -> bool {
-    let line = line.trim_start();
     let Some(rest) = line.strip_prefix("@@") else {
         return false;
     };
@@ -125,18 +125,20 @@ fn is_diff_hunk_header(line: &str) -> bool {
     let Some((minus, plus)) = ranges.trim().split_once(' ') else {
         return false;
     };
-    is_hunk_range(minus) && is_hunk_range(plus)
+    minus.strip_prefix('-').is_some_and(hunk_count)
+        && plus.strip_prefix('+').is_some_and(hunk_count)
 }
 
-/// One hunk range (`-1,3`, `+1`, …): a sign followed by comma-joined digits.
-fn is_hunk_range(range: &str) -> bool {
-    let Some(digits) = range.strip_prefix('-').or_else(|| range.strip_prefix('+')) else {
-        return false;
-    };
-    !digits.is_empty()
-        && digits
-            .split(',')
-            .all(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_digit()))
+/// Digits, optionally followed by one `,digits` line count.
+fn hunk_count(digits: &str) -> bool {
+    match digits.split_once(',') {
+        Some((start, count)) => is_digits(start) && is_digits(count),
+        None => is_digits(digits),
+    }
+}
+
+fn is_digits(text: &str) -> bool {
+    !text.is_empty() && text.chars().all(|c| c.is_ascii_digit())
 }
 
 /// Unified-diff file header (`+++ b/file`, `--- a/file`): the marker is
@@ -1209,6 +1211,20 @@ mod tests {
             lines[2].line.spans[1].style.fg,
             Some(crate::tui::theme::code())
         );
+    }
+
+    #[test]
+    fn non_canonical_hunk_headers_do_not_enable_diff_mode() {
+        // A context line, a swapped sign order, and a multi-count range are
+        // all lookalikes, not hunk headers.
+        for header in [" @@ -1 +1 @@", "@@ +1 -1 @@", "@@ -1,2,3 +1 @@"] {
+            let lines = render_markdown_window(&["```", header, "+ not a change", "```"], 0, 3, 80);
+            assert_eq!(
+                lines[2].line.spans[1].style.fg,
+                Some(crate::tui::theme::code()),
+                "header `{header}` must not enable diff mode"
+            );
+        }
     }
 
     #[test]

--- a/src/tui/content/markdown.rs
+++ b/src/tui/content/markdown.rs
@@ -110,29 +110,64 @@ fn render_code_block(body: &[&str], language: Option<&str>) -> Vec<MarkdownLine>
         .collect()
 }
 
-/// Unified-diff hunk header: `@@ -1,3 +1,4 @@`.
+/// Unified-diff hunk header: `@@ -1,3 +1,4 @@` (an optional section heading
+/// may follow the closing `@@`). Validates the full shape so ordinary code
+/// lines that merely start with `@@` (doc attributes, Lua long strings, …)
+/// do not switch the whole block into diff mode.
 fn is_diff_hunk_header(line: &str) -> bool {
-    line.trim_start().starts_with("@@")
+    let line = line.trim_start();
+    let Some(rest) = line.strip_prefix("@@") else {
+        return false;
+    };
+    let Some((ranges, _heading)) = rest.trim_start().split_once("@@") else {
+        return false;
+    };
+    let Some((minus, plus)) = ranges.trim().split_once(' ') else {
+        return false;
+    };
+    is_hunk_range(minus) && is_hunk_range(plus)
+}
+
+/// One hunk range (`-1,3`, `+1`, …): a sign followed by comma-joined digits.
+fn is_hunk_range(range: &str) -> bool {
+    let Some(digits) = range.strip_prefix('-').or_else(|| range.strip_prefix('+')) else {
+        return false;
+    };
+    !digits.is_empty()
+        && digits
+            .split(',')
+            .all(|part| !part.is_empty() && part.chars().all(|c| c.is_ascii_digit()))
+}
+
+/// Unified-diff file header (`+++ b/file`, `--- a/file`): the marker is
+/// followed by a space and a path, so a change line whose content itself
+/// starts with `++`/`--` stays a change line.
+fn is_diff_file_header(line: &str) -> bool {
+    line.strip_prefix("+++")
+        .or_else(|| line.strip_prefix("---"))
+        .and_then(|rest| rest.strip_prefix(' '))
+        .is_some_and(|path| !path.is_empty())
 }
 
 fn code_line_style(line: &str, is_diff: bool) -> Style {
     if !is_diff {
         return code_block_style();
     }
-    let trimmed = line.trim_start();
-    if trimmed.starts_with("@@") {
+    if is_diff_hunk_header(line) {
         Style::default()
             .fg(crate::tui::theme::accent())
             .add_modifier(Modifier::BOLD)
-    } else if trimmed.starts_with("+++") || trimmed.starts_with("---") {
+    } else if is_diff_file_header(line) {
         Style::default()
             .fg(crate::tui::theme::muted())
             .add_modifier(Modifier::BOLD)
-    } else if trimmed.starts_with('+') {
+    } else if line.starts_with('+') {
         Style::default().fg(crate::tui::theme::success())
-    } else if trimmed.starts_with('-') {
+    } else if line.starts_with('-') {
         Style::default().fg(crate::tui::theme::failure())
     } else {
+        // Context lines (leading marker space) and anything else keep the
+        // plain code style; the context space stays in the rendered text.
         code_block_style()
     }
 }
@@ -1155,5 +1190,74 @@ mod tests {
             lines[2].line.spans[1].style.fg,
             Some(crate::tui::theme::code())
         );
+    }
+
+    #[test]
+    fn plain_code_lines_starting_with_at_at_do_not_enable_diff_mode() {
+        // `@@derive` is not a hunk header, so the block stays plain.
+        let lines = render_markdown_window(
+            &["```rust", "@@derive(Clone)", "+ not a change", "```"],
+            0,
+            3,
+            80,
+        );
+        assert_eq!(
+            lines[1].line.spans[1].style.fg,
+            Some(crate::tui::theme::code())
+        );
+        assert_eq!(
+            lines[2].line.spans[1].style.fg,
+            Some(crate::tui::theme::code())
+        );
+    }
+
+    #[test]
+    fn hunk_headers_with_section_headings_still_detect() {
+        let lines = render_markdown_window(&["```", "@@ -1,3 +1,4 @@ fn main()", "```"], 0, 2, 80);
+        assert_eq!(
+            lines[1].line.spans[1].style.fg,
+            Some(crate::tui::theme::accent())
+        );
+    }
+
+    #[test]
+    fn diff_context_lines_with_plus_content_stay_plain() {
+        // The leading context space is preserved: " + x" is context, not an
+        // addition.
+        let lines =
+            render_markdown_window(&["```diff", "@@ -1 +1 @@", " + not added", "```"], 0, 3, 80);
+        assert_eq!(
+            lines[2].line.spans[1].style.fg,
+            Some(crate::tui::theme::code())
+        );
+        assert_eq!(lines[2].line.spans[1].content.as_ref(), " + not added");
+    }
+
+    #[test]
+    fn change_lines_starting_with_triple_pluses_stay_additions() {
+        let lines = render_markdown_window(
+            &["```diff", "@@ -1 +1 @@", "+++added", "--- b/file", "```"],
+            0,
+            4,
+            80,
+        );
+        // "+++added" is added content, not a file header.
+        assert_eq!(
+            lines[2].line.spans[1].style.fg,
+            Some(crate::tui::theme::success())
+        );
+        assert!(!lines[2].line.spans[1]
+            .style
+            .add_modifier
+            .contains(Modifier::BOLD));
+        // "--- b/file" is a file header: muted + bold.
+        assert_eq!(
+            lines[3].line.spans[1].style.fg,
+            Some(crate::tui::theme::muted())
+        );
+        assert!(lines[3].line.spans[1]
+            .style
+            .add_modifier
+            .contains(Modifier::BOLD));
     }
 }

--- a/src/tui/content/markdown.rs
+++ b/src/tui/content/markdown.rs
@@ -51,19 +51,90 @@ struct MarkdownLineParts<'a> {
 }
 
 pub(crate) fn render_markdown_lines(lines: &[&str], width: usize) -> Vec<MarkdownLine> {
-    let mut in_code_block = false;
     let table_rows = aligned_table_rows(lines);
     let mut rendered = Vec::with_capacity(lines.len());
+    let mut idx = 0;
 
-    lines.iter().enumerate().for_each(|(idx, line)| {
+    while idx < lines.len() {
         if let Some(table_rows) = &table_rows[idx] {
             rendered.extend(table_rows.iter().map(render_table_row));
-        } else {
-            rendered.push(render_markdown_line(line, &mut in_code_block, width));
+            idx += 1;
+            continue;
         }
-    });
+        let line = lines[idx];
+        // Fenced code blocks are gathered as one unit so diff-aware coloring
+        // can see the whole block before deciding how to paint its lines.
+        if let Some(language) = code_fence_language(line) {
+            rendered.push(MarkdownLine {
+                line: code_fence_line(language.clone()),
+                kind: MarkdownLineKind::CodeFence,
+                links: Vec::new(),
+            });
+            let mut body = Vec::new();
+            idx += 1;
+            while idx < lines.len() && code_fence_language(lines[idx]).is_none() {
+                body.push(lines[idx]);
+                idx += 1;
+            }
+            rendered.extend(render_code_block(&body, language.as_deref()));
+            if idx < lines.len() {
+                rendered.push(MarkdownLine {
+                    line: code_fence_line(None),
+                    kind: MarkdownLineKind::CodeFence,
+                    links: Vec::new(),
+                });
+                idx += 1;
+            }
+            continue;
+        }
+        rendered.push(render_markdown_line(line, width));
+        idx += 1;
+    }
 
     rendered
+}
+
+/// One fenced block: ` ```rust ` … ` ``` `. Diff-aware when the fence names
+/// `diff` or the body carries a unified-diff hunk header (`@@ …`).
+fn render_code_block(body: &[&str], language: Option<&str>) -> Vec<MarkdownLine> {
+    let is_diff = language == Some("diff") || body.iter().any(|line| is_diff_hunk_header(line));
+    body.iter()
+        .map(|line| MarkdownLine {
+            line: Line::from(vec![
+                Span::styled(CODE_INDENT, code_block_margin_style()),
+                Span::styled(line.to_string(), code_line_style(line, is_diff)),
+            ]),
+            kind: MarkdownLineKind::CodeBlock,
+            links: Vec::new(),
+        })
+        .collect()
+}
+
+/// Unified-diff hunk header: `@@ -1,3 +1,4 @@`.
+fn is_diff_hunk_header(line: &str) -> bool {
+    line.trim_start().starts_with("@@")
+}
+
+fn code_line_style(line: &str, is_diff: bool) -> Style {
+    if !is_diff {
+        return code_block_style();
+    }
+    let trimmed = line.trim_start();
+    if trimmed.starts_with("@@") {
+        Style::default()
+            .fg(crate::tui::theme::accent())
+            .add_modifier(Modifier::BOLD)
+    } else if trimmed.starts_with("+++") || trimmed.starts_with("---") {
+        Style::default()
+            .fg(crate::tui::theme::muted())
+            .add_modifier(Modifier::BOLD)
+    } else if trimmed.starts_with('+') {
+        Style::default().fg(crate::tui::theme::success())
+    } else if trimmed.starts_with('-') {
+        Style::default().fg(crate::tui::theme::failure())
+    } else {
+        code_block_style()
+    }
 }
 
 #[cfg(test)]
@@ -80,28 +151,7 @@ fn render_markdown_window(
         .collect()
 }
 
-fn render_markdown_line(line: &str, in_code_block: &mut bool, width: usize) -> MarkdownLine {
-    if let Some(language) = code_fence_language(line) {
-        let opening = !*in_code_block;
-        *in_code_block = !*in_code_block;
-        return MarkdownLine {
-            line: code_fence_line(opening.then_some(language).flatten()),
-            kind: MarkdownLineKind::CodeFence,
-            links: Vec::new(),
-        };
-    }
-
-    if *in_code_block {
-        return MarkdownLine {
-            line: Line::from(vec![
-                Span::styled(CODE_INDENT, code_block_margin_style()),
-                Span::styled(line.to_string(), code_block_style()),
-            ]),
-            kind: MarkdownLineKind::CodeBlock,
-            links: Vec::new(),
-        };
-    }
-
+fn render_markdown_line(line: &str, width: usize) -> MarkdownLine {
     if is_horizontal_rule(line) {
         return MarkdownLine {
             line: Line::from(Span::styled(
@@ -1032,5 +1082,78 @@ mod tests {
 
         assert_eq!(lines[0].kind, MarkdownLineKind::CodeFence);
         assert_eq!(lines[0].line.spans[0].content.as_ref(), "  sql");
+    }
+
+    #[test]
+    fn renders_diff_fenced_blocks_with_change_colors() {
+        let lines = render_markdown_window(
+            &[
+                "```diff",
+                "@@ -1,3 +1,4 @@",
+                " base",
+                "-removed",
+                "+added",
+                "+++ b/file",
+                "```",
+            ],
+            0,
+            6,
+            80,
+        );
+
+        assert_eq!(lines[0].line.spans[0].content.as_ref(), "  diff");
+        assert_eq!(
+            lines[1].line.spans[1].style.fg,
+            Some(crate::tui::theme::accent())
+        ); // @@ hunk
+        assert_eq!(
+            lines[2].line.spans[1].style.fg,
+            Some(crate::tui::theme::code())
+        ); // context
+        assert_eq!(
+            lines[3].line.spans[1].style.fg,
+            Some(crate::tui::theme::failure())
+        ); // - removed
+        assert_eq!(
+            lines[4].line.spans[1].style.fg,
+            Some(crate::tui::theme::success())
+        ); // + added
+        assert!(lines[5].line.spans[1]
+            .style
+            .add_modifier
+            .contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn auto_detects_unified_diffs_in_plain_fenced_blocks() {
+        let lines = render_markdown_window(&["```", "@@ -1 +1 @@", "-a", "+b", "```"], 0, 5, 80);
+
+        assert_eq!(
+            lines[1].line.spans[1].style.fg,
+            Some(crate::tui::theme::accent())
+        );
+        assert_eq!(
+            lines[2].line.spans[1].style.fg,
+            Some(crate::tui::theme::failure())
+        );
+        assert_eq!(
+            lines[3].line.spans[1].style.fg,
+            Some(crate::tui::theme::success())
+        );
+    }
+
+    #[test]
+    fn non_diff_code_blocks_keep_plain_code_style() {
+        let lines = render_markdown_window(&["```text", "- not a diff", "+ nope", "```"], 0, 3, 80);
+
+        // No hunk header: the block is not a diff, so +/- lines stay code-colored.
+        assert_eq!(
+            lines[1].line.spans[1].style.fg,
+            Some(crate::tui::theme::code())
+        );
+        assert_eq!(
+            lines[2].line.spans[1].style.fg,
+            Some(crate::tui::theme::code())
+        );
     }
 }


### PR DESCRIPTION
## Purpose
Color git-diff code blocks in the read view: \@@\ hunk headers in accent, \+\ additions in success green, \-\ deletions in failure red, file headers bold.

## Changes
- \markdown.rs\ gathers each fenced code block as one unit before painting it.
- A block is treated as a diff when its fence language is \diff\ or its body contains an \@@\ hunk header, so raw tool output pasted as a diff colors up without markup.
- Non-diff code blocks keep the plain code color (regression-tested).

## Validation
- \cargo test --workspace\ (335 + 205), clippy \-D warnings\, \cargo fmt --check\ pass; three new diff-rendering tests.

Stacked on #134.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Markdown rendering for fenced code blocks.
  * Added diff-aware styling for file headers, hunk headers, additions, removals, and context lines.
  * Added automatic recognition of diff-formatted code blocks.

* **Bug Fixes**
  * Preserved code fence and content state to render complete blocks consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->