### PR TITLE
refactor: drop origin aliases and silent fallbacks

### DIFF
--- a/crates/sivtr-core/src/origin.rs
+++ b/crates/sivtr-core/src/origin.rs
@@ -19,11 +19,6 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Major source category.
-///
-/// `#[non_exhaustive]`: adding a category (cloud account, WSL, container, …)
-/// only requires a new variant plus a `label()` arm here; code outside this
-/// crate is forced to handle the wildcard, so nothing downstream breaks.
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum OriginKind {
@@ -66,11 +61,9 @@ pub struct Origin {
 pub enum Reach {
     /// A workspace on this machine: its root directory.
     Local { root: String },
-    /// A mount on another device: which workspace's mount list and which alias.
-    Remote {
-        workspace_key: String,
-        alias: String,
-    },
+    /// A mount on another device: which workspace's mount list.
+    /// The mount alias is [`Origin::name`].
+    Remote { workspace_key: String },
 }
 
 /// One registry entry: the display [`Origin`] plus its [`Reach`].
@@ -109,37 +102,28 @@ impl OriginRegistry {
     /// higher-priority kind wins, matching the lookup order that predated the
     /// registry. Collisions within one kind are an error.
     pub fn resolve(&self, name: &str) -> Result<Option<&Entry>> {
-        let mut matched = self
+        let mut matched: Vec<_> = self
             .entries
             .iter()
             .filter(|entry| entry.origin.name.eq_ignore_ascii_case(name))
-            .collect::<Vec<_>>();
-        if matched.is_empty() {
-            return Ok(None);
+            .collect();
+        match matched.len() {
+            0 => Ok(None),
+            1 => Ok(Some(matched[0])),
+            _ => {
+                // Remote wins a cross-kind collision; same-kind collisions stay
+                // ambiguous.
+                matched.sort_by_key(|entry| matches!(entry.origin.kind, OriginKind::Local));
+                if matched[0].origin.kind == matched[1].origin.kind {
+                    let details: Vec<&str> = matched
+                        .iter()
+                        .map(|entry| entry.origin.detail.as_str())
+                        .collect();
+                    bail!("ambiguous origin `{name}`; matches: {}", details.join(", "));
+                }
+                Ok(Some(matched[0]))
+            }
         }
-        // Remote before local: the higher-priority kind wins a cross-kind
-        // collision; within one kind the name is still ambiguous.
-        matched.sort_by_key(|entry| kind_priority(entry.origin.kind));
-        if matched.len() > 1
-            && kind_priority(matched[0].origin.kind) == kind_priority(matched[1].origin.kind)
-        {
-            let details: Vec<&str> = matched
-                .iter()
-                .map(|entry| entry.origin.detail.as_str())
-                .collect();
-            bail!("ambiguous origin `{name}`; matches: {}", details.join(", "));
-        }
-        Ok(Some(matched[0]))
-    }
-}
-
-/// Resolution priority when a name collides across kinds. A remote mount
-/// wins over a local workspace of the same name — remote lookup ran before
-/// local workspace resolution before the registry existed.
-fn kind_priority(kind: OriginKind) -> u8 {
-    match kind {
-        OriginKind::Remote => 0,
-        OriginKind::Local => 1,
     }
 }
 
@@ -169,7 +153,6 @@ mod tests {
                 },
                 reach: Reach::Remote {
                     workspace_key: "key1".to_string(),
-                    alias: "desk".to_string(),
                 },
             },
         ])
@@ -263,26 +246,19 @@ mod tests {
                 },
                 reach: Reach::Remote {
                     workspace_key: "k1".to_string(),
-                    alias: "proj".to_string(),
                 },
             },
         ]);
         let entry = registry.resolve("proj").expect("resolve").expect("found");
         assert_eq!(entry.origin.kind, OriginKind::Remote);
-        assert!(matches!(
-            &entry.reach,
-            Reach::Remote { alias, .. } if alias == "proj"
-        ));
+        assert!(matches!(&entry.reach, Reach::Remote { workspace_key } if workspace_key == "k1"));
     }
 
     #[test]
     fn resolve_returns_reach_payload_per_kind() {
         let registry = sample();
         let entry = registry.resolve("desk").expect("resolve").expect("found");
-        assert!(matches!(
-            &entry.reach,
-            Reach::Remote { alias, .. } if alias == "desk"
-        ));
+        assert!(matches!(&entry.reach, Reach::Remote { workspace_key } if workspace_key == "key1"));
         let entry = registry.resolve("sivtr").expect("resolve").expect("found");
         assert!(matches!(
             &entry.reach,
@@ -295,16 +271,6 @@ mod tests {
         let registry = sample();
         let names: Vec<_> = registry.all().map(|origin| origin.name.as_str()).collect();
         assert_eq!(names, vec!["sivtr", "desk"]);
-    }
-
-    #[test]
-    fn origin_fields_are_uniform_across_kinds() {
-        // Upper layers read the same four fields no matter the kind.
-        for origin in sample().all() {
-            assert!(!origin.name.is_empty());
-            assert!(!origin.detail.is_empty());
-            assert!(matches!(origin.kind.label(), "local" | "remote"));
-        }
     }
 
     #[test]

--- a/src/commands/memory/copy/mod.rs
+++ b/src/commands/memory/copy/mod.rs
@@ -127,12 +127,8 @@ fn session_source_from_records(records: &[WorkRecord]) -> Option<WorkspaceSource
     // named local aliases (`docs:`) and groups stay on the local style.
     let cwd = std::env::current_dir().ok()?;
     let registry = crate::origins::collect(&cwd).ok()?;
-    let remote = registry
-        .resolve(scope)
-        .ok()
-        .flatten()
-        .is_some_and(|entry| entry.origin.kind == OriginKind::Remote);
-    Some(if remote {
+    let entry = registry.resolve(scope).ok()??;
+    Some(if entry.origin.kind == OriginKind::Remote {
         WorkspaceSource::remote(scope, kind)
     } else {
         WorkspaceSource::local(kind)

--- a/src/commands/memory/workset/source.rs
+++ b/src/commands/memory/workset/source.rs
@@ -56,10 +56,6 @@ impl QuerySource {
             transport: QueryTransport::Remote,
         }
     }
-
-    pub fn is_remote(&self) -> bool {
-        self.transport == QueryTransport::Remote
-    }
 }
 
 /// Per-source outcome from [`query_many`]. Failures never drop other sources.
@@ -117,15 +113,17 @@ pub fn query(source: &str, filter: Filter, cwd: Option<&Path>) -> Result<WorkSet
         return match registry.resolve(&scope)? {
             Some(entry) => match &entry.reach {
                 Reach::Local { root } => run_local(path, Path::new(root), filter),
-                Reach::Remote { workspace_key, alias } => try_remote_timed(
+                Reach::Remote { workspace_key } => try_remote_timed(
                     workspace_key,
-                    alias,
+                    &entry.origin.name,
                     path,
                     filter,
                     &cwd,
                     Duration::from_secs(30),
                 )
-                .with_context(|| format!("remote mount `{alias}` unavailable")),
+                .with_context(|| {
+                    format!("remote mount `{}` unavailable", entry.origin.name)
+                }),
             },
             None => match try_group(&scope, path, filter, &cwd)? {
                 Some(set) => Ok(set),
@@ -163,7 +161,7 @@ pub fn query_many(
 
     let mut remote_idxs = Vec::new();
     for (idx, source) in sources.iter().enumerate() {
-        if source.is_remote() {
+        if source.transport == QueryTransport::Remote {
             remote_idxs.push(idx);
             continue;
         }
@@ -282,11 +280,15 @@ fn query_remote_bounded(
         return query(selector, filter, Some(cwd));
     };
     match &entry.reach {
-        Reach::Remote {
+        Reach::Remote { workspace_key } => try_remote_timed(
             workspace_key,
-            alias,
-        } => try_remote_timed(workspace_key, alias, path, filter, cwd, read_timeout)
-            .with_context(|| format!("remote mount `{alias}` unavailable")),
+            &entry.origin.name,
+            path,
+            filter,
+            cwd,
+            read_timeout,
+        )
+        .with_context(|| format!("remote mount `{}` unavailable", entry.origin.name)),
         _ => query(selector, filter, Some(cwd)),
     }
 }

--- a/src/origins.rs
+++ b/src/origins.rs
@@ -24,7 +24,7 @@ pub fn collect(cwd: &Path) -> Result<OriginRegistry> {
 
     // Register `cwd` when it is a git repo, so the current workspace is part
     // of the registry even before its first capture.
-    let _ = workspace::ensure_workspace_for_dir(cwd);
+    workspace::ensure_workspace_for_dir(cwd)?;
 
     let current_key = workspace::resolve_workspace_for_dir(cwd)?.map(|paths| paths.key);
     for meta in workspace::list_workspaces()? {
@@ -60,7 +60,6 @@ pub fn collect(cwd: &Path) -> Result<OriginRegistry> {
                             },
                             reach: Reach::Remote {
                                 workspace_key: workspace_key.to_string(),
-                                alias: mount.alias,
                             },
                         });
                     }
@@ -104,12 +103,9 @@ pub fn rename(cwd: &Path, name: &str, new_name: &str) -> Result<String> {
             let updated = workspace::rename_workspace(root, &new_name)?;
             Ok(workspace::workspace_alias(&updated))
         }
-        Reach::Remote {
-            workspace_key,
-            alias,
-        } => match ipc::call(LocalRequest::RemoteRename {
+        Reach::Remote { workspace_key } => match ipc::call(LocalRequest::RemoteRename {
             workspace_key: workspace_key.clone(),
-            alias: alias.clone(),
+            alias: entry.origin.name.clone(),
             new_alias: new_name.clone(),
         })? {
             LocalResponse::Mount(mount) => Ok(mount.alias),

--- a/src/pane/sliding.rs
+++ b/src/pane/sliding.rs
@@ -54,6 +54,10 @@ where
         self.store.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.store.len() == 0
+    }
+
     pub fn is_fetching(&self) -> bool {
         self.store.is_fetching()
     }

--- a/src/pane/sliding.rs
+++ b/src/pane/sliding.rs
@@ -54,10 +54,6 @@ where
         self.store.len()
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.store.len() == 0
-    }
-
     pub fn is_fetching(&self) -> bool {
         self.store.is_fetching()
     }

--- a/src/tui/workspace/render.rs
+++ b/src/tui/workspace/render.rs
@@ -329,7 +329,7 @@ fn footer_status_spans(label: &str) -> Vec<Span<'static>> {
 
 /// Compact session row: `· cdx  title…` (origin glyph + short badge + title).
 ///
-/// `·` = local, `↗` = remote (named scope on the source or work_ref). A ` [!]`
+/// `·` = local, `↗` = remote mount. A ` [!]`
 /// suffix marks a session whose body failed to hydrate. The selection dot
 /// (`●` / `○`) is always visible so it survives pane switches.
 fn session_row_line(
@@ -339,11 +339,7 @@ fn session_row_line(
     highlight: Option<&Regex>,
     body_failed: bool,
 ) -> Line<'static> {
-    let remote = choice.source.is_remote()
-        || choice
-            .records
-            .first()
-            .is_some_and(|record| !record.work_ref.is_local());
+    let remote = choice.source.is_remote();
     let check = format!("{} ", selection_dot(selected));
     let origin = theme::origin_glyph(remote);
     let badge = choice.source.badge();


### PR DESCRIPTION
## Purpose
Trim leftover wrappers and silent fallbacks after the origin registry landed.

## Changes
- `Reach::Remote` no longer duplicates `Origin.name`; rename/query use the origin name.
- `resolve` compares kinds directly instead of `kind_priority`.
- Session rows and copy glyphs use the registry only (no `work_ref` / swallow-as-local).
- `collect` propagates `ensure_workspace_for_dir` errors.
- Drop unused `SlidingPane::is_empty` and a vacuous origin test.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p sivtr-core origin`
- `cargo check --workspace --all-targets`

## Risks
- Named-scope copy glyphs now omit a source when registry collect/resolve fails, instead of painting local.