### PR TITLE
perf(browse): fetch session meta at ceiling once

### DIFF
--- a/src/commands/browse/load.rs
+++ b/src/commands/browse/load.rs
@@ -226,56 +226,6 @@ impl SourceLoadPump {
         }
     }
 
-    /// Grow per-source panes until the merged session list covers `viewport`.
-    pub fn ensure_meta_window(
-        &mut self,
-        sources: &[WorkspaceSource],
-        selected: &[bool],
-        states: &mut [SourceLoadState],
-        viewport: Viewport,
-        merged_len: usize,
-    ) {
-        let need_end = viewport.need_end();
-        for (idx, source) in sources.iter().enumerate() {
-            if !selected.get(idx).copied().unwrap_or(false) {
-                continue;
-            }
-            // Per-pane native ensure first.
-            if let Some(need) = states[idx].pane.ensure_meta(viewport) {
-                self.spawn_meta(idx, source, need.gen, need.budget);
-                continue;
-            }
-            // Multi-source: this pane alone may be "covered" while the merged
-            // list is still short — ask for a larger budget explicitly.
-            if merged_len >= need_end {
-                continue;
-            }
-            let store = states[idx].pane.store();
-            if store.list_inflight || states[idx].pane.exhausted() || store.rows.is_empty() {
-                continue;
-            }
-            let deficit = need_end - merged_len;
-            let target = store.rows.len().saturating_add(deficit);
-            let next = Viewport::fetch_budget(target)
-                .max(store.fetch_budget + FETCH_FLOOR)
-                .min(FETCH_CEILING);
-            if next <= store.fetch_budget {
-                let forced = (store.fetch_budget * 2)
-                    .max(store.fetch_budget + FETCH_FLOOR)
-                    .min(FETCH_CEILING);
-                if forced > store.fetch_budget {
-                    if let Some(need) = states[idx].pane.begin_meta_budget(forced) {
-                        self.spawn_meta(idx, source, need.gen, need.budget);
-                    }
-                }
-                continue;
-            }
-            if let Some(need) = states[idx].pane.begin_meta_budget(next) {
-                self.spawn_meta(idx, source, need.gen, need.budget);
-            }
-        }
-    }
-
     pub fn sync_bodies(
         &mut self,
         sources: &[WorkspaceSource],
@@ -638,12 +588,12 @@ impl Pane for SessionColumn {
                     input.viewport,
                 );
             } else {
-                self.pump.ensure_meta_window(
+                self.pump.kick(
                     &self.sources,
                     ctx.selected_sources,
                     &mut self.states,
                     input.viewport,
-                    self.merged_len,
+                    false,
                 );
             }
         }
@@ -656,7 +606,6 @@ impl Pane for SessionColumn {
         );
         self.pump
             .sync_bodies(&self.sources, &mut self.states, &keep);
-        // Update merged length for next multi-source budget decision.
         self.merged_len = ctx.sessions.len();
         true
     }

--- a/src/commands/browse/panes.rs
+++ b/src/commands/browse/panes.rs
@@ -673,7 +673,7 @@ mod tests {
     }
 
     #[test]
-    fn dialogue_meta_grows_with_viewport_not_full_catalog() {
+    fn dialogue_meta_fetches_full_catalog_at_ceiling() {
         let sessions = vec![session_with_n(100, true)];
         let mut pane = DialoguePane::default();
         tick(
@@ -686,8 +686,8 @@ mod tests {
             0,
             &[],
         );
-        assert!(pane.len() < 100);
-        assert!(pane.len() >= 20);
+        assert_eq!(pane.len(), 100);
+        assert!(pane.exhausted());
         tick(
             &mut pane,
             &sessions,
@@ -698,8 +698,7 @@ mod tests {
             45,
             &[],
         );
-        assert!(pane.len() > 40);
-        assert!(pane.len() < 100);
+        assert_eq!(pane.len(), 100);
     }
 
     #[test]

--- a/src/pane/sliding.rs
+++ b/src/pane/sliding.rs
@@ -266,6 +266,7 @@ mod tests {
             },
             false,
             |budget| {
+                assert_eq!(budget, FETCH_CEILING);
                 let end = budget.min(source.len());
                 (source[..end].to_vec(), end >= source.len())
             },
@@ -288,6 +289,7 @@ mod tests {
             },
             true,
             |budget| {
+                assert_eq!(budget, FETCH_CEILING);
                 let end = budget.min(source.len());
                 (source[..end].to_vec(), end >= source.len())
             },

--- a/src/pane/sliding.rs
+++ b/src/pane/sliding.rs
@@ -6,7 +6,7 @@
 use std::collections::HashSet;
 use std::hash::Hash;
 
-use super::store::{SlidingStore, Viewport, WindowRow, FETCH_CEILING, FETCH_FLOOR};
+use super::store::{SlidingStore, Viewport, WindowRow, FETCH_CEILING};
 
 /// Request returned by [`SlidingPane::ensure_meta`] / [`SlidingPane::force_meta`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -76,30 +76,15 @@ where
         if !self.store.needs_meta(viewport) {
             return None;
         }
-        let budget = self.store.next_meta_budget(viewport);
-        Some(self.begin_meta_fetch(budget))
+        Some(self.begin_meta_fetch(FETCH_CEILING))
     }
 
     /// Force a meta refresh (e.g. `R`), even when the viewport is covered.
-    pub fn force_meta(&mut self, viewport: Viewport) -> Option<MetaNeed> {
+    pub fn force_meta(&mut self, _viewport: Viewport) -> Option<MetaNeed> {
         if self.store.list_inflight {
             return None;
         }
-        let budget = self
-            .store
-            .fetch_budget
-            .max(Viewport::fetch_budget(viewport.need_end()))
-            .clamp(FETCH_FLOOR, FETCH_CEILING);
-        Some(self.begin_meta_fetch(budget))
-    }
-
-    /// Explicit budget meta fetch (multi-source pumps that coordinate budgets).
-    pub fn begin_meta_budget(&mut self, budget: usize) -> Option<MetaNeed> {
-        if self.store.list_inflight {
-            return None;
-        }
-        let budget = budget.clamp(FETCH_FLOOR, FETCH_CEILING);
-        Some(self.begin_meta_fetch(budget))
+        Some(self.begin_meta_fetch(FETCH_CEILING))
     }
 
     fn begin_meta_fetch(&mut self, budget: usize) -> MetaNeed {
@@ -271,7 +256,7 @@ mod tests {
     }
 
     #[test]
-    fn ensure_meta_sync_grows_only_to_budget() {
+    fn ensure_meta_sync_asks_ceiling_once() {
         let source: Vec<_> = (0..100u32).map(|i| WindowRow::meta_only(i, "m")).collect();
         let mut pane: SlidingPane<u32, &str, String> = SlidingPane::default();
         let grown = pane.ensure_meta_sync(
@@ -286,11 +271,8 @@ mod tests {
             },
         );
         assert!(grown);
-        // need_end=20 → budget ≥ 12 and typically covers ~60; not the full 100.
-        assert!(pane.len() < 100);
-        assert!(pane.len() >= 20);
-        assert!(!pane.exhausted());
-        // covered → no further growth
+        assert_eq!(pane.len(), 100);
+        assert!(pane.exhausted());
         assert!(!pane.ensure_meta_sync(
             Viewport {
                 first: 0,
@@ -299,7 +281,6 @@ mod tests {
             false,
             |_| panic!("must not fetch when covered"),
         ));
-        // force still refetches
         assert!(pane.ensure_meta_sync(
             Viewport {
                 first: 0,

--- a/src/pane/store.rs
+++ b/src/pane/store.rs
@@ -33,7 +33,6 @@ impl Viewport {
             .saturating_add(prefetch)
             .max(page.saturating_add(prefetch))
     }
-
 }
 
 /// Load phase for a pane store.

--- a/src/pane/store.rs
+++ b/src/pane/store.rs
@@ -34,11 +34,6 @@ impl Viewport {
             .max(page.saturating_add(prefetch))
     }
 
-    /// Batch size for a fetch aiming to cover `target_items` items.
-    pub fn fetch_budget(target_items: usize) -> usize {
-        let raw = target_items.saturating_mul(3).max(FETCH_FLOOR);
-        raw.min(FETCH_CEILING)
-    }
 }
 
 /// Load phase for a pane store.
@@ -146,16 +141,6 @@ where
             return true;
         }
         self.rows.len() < viewport.need_end()
-    }
-
-    /// Budget for the next meta fetch given current coverage + viewport.
-    pub fn next_meta_budget(&self, viewport: Viewport) -> usize {
-        let need = viewport.need_end();
-        let target = need.max(self.rows.len().saturating_add(viewport.visible.max(1)));
-        let budget = Viewport::fetch_budget(target);
-        budget
-            .max(self.fetch_budget.saturating_add(FETCH_FLOOR))
-            .min(FETCH_CEILING)
     }
 
     /// Begin a meta job: Booting if empty, else Ready+inflight (never blank).


### PR DESCRIPTION
## Purpose
Stop ratcheting the session-meta `latest` budget on every scroll step. Each meta job re-runs `query_many` over the source; growing 12 → 2000 re-parses the same source many times.

## Measured
Not a wall-clock bench of `query_many` (that cost is the full source load, independent of `latest`). The change is the fetch count:

- Before: `need_end * 3` plus a +12 ratchet, then a `*2` bump, up to `FETCH_CEILING` (2000). A long scroll issued many meta jobs.
- After: first deficit asks for 2000 once. `ensure_meta_sync_asks_ceiling_once` checks this.

Deleted the unused multi-source `*2` path (`ensure_meta_window`).

## Validation
- pane tests including `ensure_meta_sync_asks_ceiling_once`
- `cargo clippy --workspace --all-targets -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified metadata loading to use a consistent full-capacity fetch.
  * Improved synchronization so a single metadata refresh can load all available source entries.
  * Preserved safeguards that prevent duplicate in-progress metadata requests.

* **Tests**
  * Updated metadata synchronization coverage to reflect the new full-source loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->