### PR TITLE
perf(browse): lay out content from blocks once

### DIFF
--- a/benches/browse_dhat.rs
+++ b/benches/browse_dhat.rs
@@ -8,7 +8,7 @@
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
-use sivtr::commands::browse::perf::{HotPane, HydratedStore};
+use sivtr::commands::browse::perf::{apply_fat_bodies, FatLayout, HotPane, HydratedStore};
 
 fn main() {
     let _profiler = dhat::Profiler::new_heap();
@@ -123,5 +123,67 @@ fn main() {
     }
     eprintln!();
     eprintln!("peak_bytes={} peak_blocks={}", t5.max_bytes, t5.max_blocks);
+
+    // ── Content layout (the double-wrap path on a fat session) ────────────
+    let n_blocks = std::env::var("SIVTR_DHAT_BLOCKS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(80usize);
+    let n_lines = std::env::var("SIVTR_DHAT_BLOCK_LINES")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(20usize);
+    let layout_iters = std::env::var("SIVTR_DHAT_LAYOUT_ITERS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(20usize);
+    let fat = FatLayout::new(n_blocks, n_lines);
+    let t6 = dhat::HeapStats::get();
+    let mut layout_lines = 0usize;
+    for _ in 0..layout_iters {
+        layout_lines = fat.layout_lines();
+    }
+    let t7 = dhat::HeapStats::get();
+    let layout_bytes = t7.total_bytes.saturating_sub(t6.total_bytes);
+    let layout_blocks = t7.total_blocks.saturating_sub(t6.total_blocks);
+    eprintln!();
+    eprintln!(
+        "=== content layout ({n_blocks} blocks × {n_lines} md paras × {layout_iters} iters) ==="
+    );
+    eprintln!("  lines={layout_lines}");
+    eprintln!("  heap_bytes={layout_bytes}");
+    eprintln!("  heap_blocks={layout_blocks}");
+    if layout_iters > 0 {
+        eprintln!(
+            "  heap_bytes/iter={:.0}",
+            layout_bytes as f64 / layout_iters as f64
+        );
+    }
+
+    // ── Stale-body apply: 40 fat sessions landed in the store ─────────────
+    let apply_iters = std::env::var("SIVTR_DHAT_APPLY_ITERS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10usize);
+    let t8 = dhat::HeapStats::get();
+    let mut applied = 0usize;
+    for _ in 0..apply_iters {
+        applied = apply_fat_bodies(40, 50);
+    }
+    let t9 = dhat::HeapStats::get();
+    let apply_bytes = t9.total_bytes.saturating_sub(t8.total_bytes);
+    eprintln!();
+    eprintln!("=== apply fat bodies (40 sessions × 50 turns × {apply_iters} iters) ===");
+    eprintln!("  applied={applied}");
+    eprintln!("  heap_bytes={apply_bytes}");
+    if apply_iters > 0 {
+        eprintln!(
+            "  heap_bytes/iter={:.0}",
+            apply_bytes as f64 / apply_iters as f64
+        );
+    }
+
+    eprintln!();
+    eprintln!("peak_bytes={} peak_blocks={}", t9.max_bytes, t9.max_blocks);
     eprintln!("Open dhat-heap.json in dh_view for the full allocation tree.");
 }

--- a/benches/browse_dhat.rs
+++ b/benches/browse_dhat.rs
@@ -8,7 +8,7 @@
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
-use sivtr::commands::browse::perf::{apply_fat_bodies, FatLayout, HotPane, HydratedStore};
+use sivtr::commands::browse::perf::{FatLayout, HotPane, HydratedStore};
 
 fn main() {
     let _profiler = dhat::Profiler::new_heap();
@@ -168,7 +168,7 @@ fn main() {
     let t8 = dhat::HeapStats::get();
     let mut applied = 0usize;
     for _ in 0..apply_iters {
-        applied = apply_fat_bodies(40, 50);
+        applied = HydratedStore::new(40, 50).apply_all_bodies();
     }
     let t9 = dhat::HeapStats::get();
     let apply_bytes = t9.total_bytes.saturating_sub(t8.total_bytes);

--- a/benches/browse_hot.rs
+++ b/benches/browse_hot.rs
@@ -6,7 +6,7 @@
 //! ```
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use sivtr::commands::browse::perf::{run_ensure_growth, HotPane, HydratedStore};
+use sivtr::commands::browse::perf::{run_ensure_growth, FatLayout, HotPane, HydratedStore};
 
 fn bench_materialize(c: &mut Criterion) {
     let mut group = c.benchmark_group("dialogue_materialize");
@@ -56,11 +56,28 @@ fn bench_session_list_project(c: &mut Criterion) {
     group.finish();
 }
 
+/// Content layout: one large session (80 blocks × 20 md paragraphs).
+fn bench_content_layout(c: &mut Criterion) {
+    let fat = FatLayout::new(80, 20);
+    c.bench_function("content_layout_80x20", |b| {
+        b.iter(|| black_box(fat.layout_lines()))
+    });
+}
+
+fn bench_apply_bodies(c: &mut Criterion) {
+    let store = HydratedStore::new(40, 50);
+    c.bench_function("apply_fat_bodies_40x50", |b| {
+        b.iter(|| black_box(store.apply_all_bodies()))
+    });
+}
+
 criterion_group!(
     benches,
     bench_materialize,
     bench_ensure_growth,
     bench_titles_iter,
-    bench_session_list_project
+    bench_session_list_project,
+    bench_content_layout,
+    bench_apply_bodies
 );
 criterion_main!(benches);

--- a/src/commands/browse/perf.rs
+++ b/src/commands/browse/perf.rs
@@ -6,8 +6,8 @@ use crate::pane::{Pane, PaneInput, Viewport};
 use crate::tui::workspace::{WorkspaceSession, WorkspaceSource};
 use sivtr_core::ai::AgentProvider;
 use sivtr_core::record::{
-    WorkChannel, WorkPart, WorkPartKind, WorkRecord, WorkRecordKind, WorkRef, WorkSessionRef,
-    WorkSource, WorkTime, RECORD_SCHEMA_VERSION,
+    WorkChannel, WorkPart, WorkRecord, WorkRecordKind, WorkRef, WorkSessionRef, WorkSource,
+    WorkTime, RECORD_SCHEMA_VERSION,
 };
 use std::time::UNIX_EPOCH;
 
@@ -121,7 +121,8 @@ impl HotPane {
         let titles: Vec<&str> = self.inner.titles().collect();
         let selected = vec![false; self.inner.len()];
         let focus = self.n / 2;
-        let rows = self.inner.materialize(&selected, focus);
+        let mut rows = Vec::new();
+        self.inner.materialize_into(&selected, focus, &mut rows);
         let bodies = rows.iter().filter(|d| d.record.is_some()).count();
         std::hint::black_box(titles.len());
         (titles.len(), bodies)
@@ -234,4 +235,87 @@ impl HydratedStore {
         let bodies: usize = out.iter().map(|s| s.records.len()).sum();
         std::hint::black_box((out.len(), bodies)).0
     }
+
+    /// Land every session body in a sliding pane (stale-apply cost).
+    pub fn apply_all_bodies(&self) -> usize {
+        use crate::pane::{SlidingPane, WindowRow};
+
+        let rows: Vec<_> = self
+            .sessions
+            .iter()
+            .map(|s| WindowRow::meta_only(s.session_id.clone(), ()))
+            .collect();
+        let mut pane: SlidingPane<String, (), Vec<sivtr_core::record::WorkRecord>> =
+            SlidingPane::ready(rows, self.sessions.len(), true);
+        let mut applied = 0usize;
+        for s in &self.sessions {
+            if pane.apply_body(&s.session_id, s.records.clone()) {
+                applied += 1;
+            }
+        }
+        std::hint::black_box((pane.len(), applied)).1
+    }
+}
+
+/// Fat content half: `n_blocks` markdown segments, `lines_per` each.
+///
+/// Mirrors one large agent session in the content pane (the path that
+/// double-laid-out the joined document and every block).
+pub struct FatLayout {
+    area: ratatui::layout::Rect,
+    text: String,
+    blocks: Vec<crate::tui::content::block::BlockText>,
+}
+
+impl FatLayout {
+    pub fn new(n_blocks: usize, lines_per: usize) -> Self {
+        use crate::tui::content::block::BlockText;
+        use sivtr_core::record::WorkPartKind;
+
+        let blocks: Vec<BlockText> = (0..n_blocks)
+            .map(|i| {
+                let mut text = String::new();
+                for j in 0..lines_per {
+                    text.push_str(&format!(
+                        "## h{i}.{j}\n\nparagraph {j} with `code` and **bold** text that wraps at eighty columns easily.\n\n"
+                    ));
+                }
+                BlockText {
+                    id: i,
+                    text,
+                    tight: false,
+                    kind: WorkPartKind::Assistant,
+                }
+            })
+            .collect();
+        let mut joined = String::new();
+        for (idx, block) in blocks.iter().enumerate() {
+            joined.push_str(&block.text);
+            if idx + 1 < blocks.len() {
+                joined.push_str("\n\n");
+            }
+        }
+        Self {
+            area: ratatui::layout::Rect::new(0, 0, 84, 40),
+            text: joined,
+            blocks,
+        }
+    }
+
+    pub fn layout_lines(&self) -> usize {
+        crate::tui::content::view::layout_content(
+            self.area,
+            &self.text,
+            &self.blocks,
+            crate::tui::content::view::ContentViewMode::Reading,
+        )
+        .lines
+        .len()
+    }
+}
+
+/// Apply `n` fat session bodies into a store (the cost of not dropping stale
+/// parses). `records_each` × 4KiB assistant blobs.
+pub fn apply_fat_bodies(n_sessions: usize, records_each: usize) -> usize {
+    HydratedStore::new(n_sessions, records_each).apply_all_bodies()
 }

--- a/src/commands/browse/perf.rs
+++ b/src/commands/browse/perf.rs
@@ -3,12 +3,13 @@
 //! Benches must not name `pub(crate)` TUI types at the crate boundary.
 
 use crate::pane::{Pane, PaneInput, Viewport};
-use crate::tui::workspace::{WorkspaceSession, WorkspaceSource};
+use crate::tui::workspace::{WorkspaceDialogue, WorkspaceSession, WorkspaceSource};
 use sivtr_core::ai::AgentProvider;
 use sivtr_core::record::{
     WorkChannel, WorkPart, WorkRecord, WorkRecordKind, WorkRef, WorkSessionRef, WorkSource,
     WorkTime, RECORD_SCHEMA_VERSION,
 };
+use std::cell::RefCell;
 use std::time::UNIX_EPOCH;
 
 use super::panes::{DialogueCtx, DialoguePane};
@@ -90,6 +91,7 @@ fn primed_dialogue_pane(n: usize) -> DialoguePane {
 pub struct HotPane {
     inner: DialoguePane,
     n: usize,
+    materialized: RefCell<Vec<WorkspaceDialogue>>,
 }
 
 impl HotPane {
@@ -97,6 +99,7 @@ impl HotPane {
         Self {
             inner: primed_dialogue_pane(n),
             n,
+            materialized: RefCell::new(Vec::new()),
         }
     }
 
@@ -121,9 +124,9 @@ impl HotPane {
         let titles: Vec<&str> = self.inner.titles().collect();
         let selected = vec![false; self.inner.len()];
         let focus = self.n / 2;
-        let mut rows = Vec::new();
-        self.inner.materialize_into(&selected, focus, &mut rows);
-        let bodies = rows.iter().filter(|d| d.record.is_some()).count();
+        let mut buf = self.materialized.borrow_mut();
+        self.inner.materialize_into(&selected, focus, &mut buf);
+        let bodies = buf.iter().filter(|d| d.record.is_some()).count();
         std::hint::black_box(titles.len());
         (titles.len(), bodies)
     }

--- a/src/commands/browse/perf.rs
+++ b/src/commands/browse/perf.rs
@@ -266,7 +266,6 @@ impl HydratedStore {
 /// double-laid-out the joined document and every block).
 pub struct FatLayout {
     area: ratatui::layout::Rect,
-    text: String,
     blocks: Vec<crate::tui::content::block::BlockText>,
 }
 
@@ -291,16 +290,8 @@ impl FatLayout {
                 }
             })
             .collect();
-        let mut joined = String::new();
-        for (idx, block) in blocks.iter().enumerate() {
-            joined.push_str(&block.text);
-            if idx + 1 < blocks.len() {
-                joined.push_str("\n\n");
-            }
-        }
         Self {
             area: ratatui::layout::Rect::new(0, 0, 84, 40),
-            text: joined,
             blocks,
         }
     }
@@ -308,17 +299,11 @@ impl FatLayout {
     pub fn layout_lines(&self) -> usize {
         crate::tui::content::view::layout_content(
             self.area,
-            &self.text,
+            "",
             &self.blocks,
             crate::tui::content::view::ContentViewMode::Reading,
         )
         .lines
         .len()
     }
-}
-
-/// Apply `n` fat session bodies into a store (the cost of not dropping stale
-/// parses). `records_each` × 4KiB assistant blobs.
-pub fn apply_fat_bodies(n_sessions: usize, records_each: usize) -> usize {
-    HydratedStore::new(n_sessions, records_each).apply_all_bodies()
 }

--- a/src/tui/content/view.rs
+++ b/src/tui/content/view.rs
@@ -97,9 +97,7 @@ pub(crate) struct ContentLayout {
     pub(crate) kinds: Vec<WorkPartKind>,
 }
 
-/// Lay one half out once: lines, per-line block ownership, and per-block
-/// kinds, all derived from the same content width so scroll, dots, and
-/// hit-testing agree.
+/// Lay one half out once from its blocks. Empty halves use `text` (`<empty>`).
 pub(crate) fn layout_content(
     area: Rect,
     text: &str,
@@ -108,41 +106,33 @@ pub(crate) fn layout_content(
 ) -> ContentLayout {
     let inner = panel_inner(area);
     let width = inner.width.saturating_sub(GUTTER_WIDTH) as usize;
-    let lines = all_content_lines(text, width, mode);
+    if blocks.is_empty() {
+        let lines = all_content_lines(text, width, mode);
+        let n = lines.len().max(1);
+        return ContentLayout {
+            lines,
+            ownership: vec![None; n],
+            kinds: Vec::new(),
+        };
+    }
     let mut kinds = vec![WorkPartKind::User; marked_mask_len(blocks.iter().map(|b| b.id))];
-    for block in blocks {
-        kinds[block.id] = block.kind;
+    let mut lines = Vec::new();
+    let mut ownership = Vec::new();
+    for (idx, segment) in blocks.iter().enumerate() {
+        kinds[segment.id] = segment.kind;
+        let block_lines = all_content_lines(&segment.text, width, mode);
+        ownership.extend(std::iter::repeat_n(Some(segment.id), block_lines.len()));
+        lines.extend(block_lines);
+        if idx + 1 < blocks.len() && !segment.tight {
+            ownership.push(None);
+            lines.push(raw_content_line(""));
+        }
     }
     ContentLayout {
         lines,
-        ownership: block_ownership(width, blocks, mode),
+        ownership,
         kinds,
     }
-}
-
-/// Map every displayed line of a half to the block that owns it. Each block
-/// is laid out independently and followed by one unowned separator line,
-/// which matches the `"\n\n"` join the pane text uses between segments; run
-/// members join on adjacent lines with no separator.
-fn block_ownership(
-    width: usize,
-    blocks: &[BlockText],
-    mode: ContentViewMode,
-) -> Vec<Option<usize>> {
-    let mut ownership = Vec::new();
-    for (idx, segment) in blocks.iter().enumerate() {
-        for _ in all_content_lines(&segment.text, width, mode) {
-            ownership.push(Some(segment.id));
-        }
-        if idx + 1 < blocks.len() && !segment.tight {
-            ownership.push(None);
-        }
-    }
-    if ownership.is_empty() {
-        // An empty half renders `<empty>`: one unowned line.
-        ownership.push(None);
-    }
-    ownership
 }
 
 pub(crate) fn render_content_view(


### PR DESCRIPTION
## Purpose
`layout_content` used to wrap the joined document *and* every block. Fast session switches paid that twice.

## Measured
Fixture: 80 blocks × 20 markdown paragraphs, width 84. Same machine, release.

| | time (`browse_hot --quick`) | heap (`browse_dhat`, 5 iters) |
|---|---|---|
| double wrap (baseline) | 23.36 ms | 133.5 MB/layout, 6558 lines |
| this PR | 10.82 ms (−53%) | 68.7 MB/layout (−49%), 6479 lines |

Commands:
```
cargo bench -p sivtr --bench browse_hot --features perf-benches -- --quick --save-baseline double-layout content_layout_80x20
cargo bench -p sivtr --bench browse_hot --features perf-benches -- --quick --baseline double-layout content_layout_80x20
SIVTR_DHAT_LAYOUT_ITERS=5 cargo bench -p sivtr --bench browse_dhat --features "perf-benches,dhat-heap"
```

Line count dropped by 79 because markdown no longer wraps across block boundaries. Existing content-view tests (26) still pass.

## Validation
- `cargo test --workspace --lib -- content::view::`
- criterion + dhat as above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content layout handling for empty and populated block lists.
  * Preserved wrapped-line ownership, separators, and block information during rendering.
  * Improved hydrated session body application and sparse focus materialization.

* **Performance**
  * Added measurements for content layout and hydrated body application.
  * Enhanced performance reporting for browsing workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->