### PR TITLE
ci(release): push release tag with a PAT so release.yml triggers

### DIFF
--- a/.github/workflows/release-plz-release.yml
+++ b/.github/workflows/release-plz-release.yml
@@ -33,4 +33,6 @@ jobs:
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN pushes do not trigger other workflows (e.g. release.yml),
+          # so the tag must be pushed with a PAT to kick off assets/crates.io.
+          RELEASE_PLZ_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}


### PR DESCRIPTION
## Purpose

`release-plz-release.yml` pushed the `v0.5.0` tag with `GITHUB_TOKEN`. GitHub does not run tag-triggered workflows for `GITHUB_TOKEN` pushes, so `release.yml` (assets, crates.io, GitHub Release, installer smoke) never fired for v0.5.0.

## Changes

- Swap `GITHUB_TOKEN` for `RELEASE_PLZ_TOKEN` (PAT) on the `release` command in `.github/workflows/release-plz-release.yml` so tag pushes trigger `release.yml`.

## Validation

- `gh run list --workflow=release.yml` confirmed no v0.5.0 run; latest GitHub Release stuck at v0.4.1.
- `RELEASE_PLZ_TOKEN` secret added to the repo.

## Risk

- Requires the PAT secret to exist; fine-grained token with Contents: read/write on `Ariestar/sivtr`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process authentication to ensure release tags can trigger downstream automation reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->