### PR TITLE
ci(release): keep GITHUB_TOKEN for git author alongside release PAT

### DIFF
--- a/.github/workflows/release-plz-release.yml
+++ b/.github/workflows/release-plz-release.yml
@@ -33,6 +33,8 @@ jobs:
         with:
           command: release
         env:
-          # GITHUB_TOKEN pushes do not trigger other workflows (e.g. release.yml),
-          # so the tag must be pushed with a PAT to kick off assets/crates.io.
+          # The action itself needs GITHUB_TOKEN to resolve the git author.
+          # The tag must be pushed with a PAT instead, because GITHUB_TOKEN
+          # pushes do not trigger other workflows (e.g. release.yml).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_PLZ_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}


### PR DESCRIPTION
## Purpose

`release-plz-release.yml` swapped `GITHUB_TOKEN` for `RELEASE_PLZ_TOKEN`, but the release-plz action's `git-config` step needs `GITHUB_TOKEN` to resolve the git author. Removing it broke the `Tag release` job after the #159 merge:

`Error: environment variable GITHUB_TOKEN is undefined`

## Changes

- Restore `GITHUB_TOKEN` on the release-plz action env.
- Keep `RELEASE_PLZ_TOKEN` so the pushed tag triggers `release.yml` (GITHUB_TOKEN pushes do not fire other workflows).

## Validation

- Not yet validated; `Tag release` on #159 failed before the tag was created, so v0.5.1 has no tag. After this merges, re-push the tag to complete the v0.5.1 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified release workflow comments to distinguish the action’s token requirement from the token used to push tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->