### PR TITLE
docs(readme): align README with v0.5 features

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -64,10 +64,11 @@ With `sivtr`, you can:
 
 - **MCP-first agent memory**: install once with `sivtr mcp install`, then agents call `sivtr_search` / `sivtr_show` / `sivtr_zoom` / `sivtr_filter` / `sivtr_status` instead of asking you to paste logs.
 - **Shell history that keeps the output**: capture commands from Bash, Zsh, PowerShell, and Nushell, including stdout, stderr, exit code, cwd, and timing.
-- **One search surface for local work**: terminal output plus all registered agent providers (Codex, Claude Code, Cursor, Hermes, OpenCode, OpenClaw, Grok, Pi, …) from the current repo — via MCP or CLI.
+- **One search surface for local work**: terminal output plus all registered agent providers (Codex, Claude Code, Cursor, Dsh, Gemini, Goose, Hermes, OpenCode, OpenClaw, Grok, Pi, Qoder, Qoder-CN, Qwen, …) — via MCP or CLI.
 - **Exact evidence, not summaries**: every hit resolves to a stable ref you can show, zoom, filter, or hand to the next agent.
 - **Named memory variables**: save result sets as `@failures`, reuse `@last`, pipe with `@`, and slice with `@failures[1,3..5]`.
-- **Cross-device access**: share a workspace read-only and browse another device with a `desk:...` ref.
+- **Cross-device access**: share a workspace read-only and browse another device with a `desk:...` ref; multiple devices can form a `group` that syncs membership and lets members read each other's memory.
+- **Configurable theme**: `[theme] mode = auto|dark|light`, follows the system appearance and detects truecolor.
 - **One-command setup**: `sivtr setup` for hooks + MCP host install; `sivtr doctor --fix` to repair.
 - **CLI still there when you want it**: search, show, filter, nav, and a TUI browser for humans — useful, not the main product story.
 
@@ -106,7 +107,7 @@ First-time setup (hooks + MCP hosts):
 sivtr setup             # hooks + MCP hosts + sivtr-memory skill (if missing)
 # or step by step:
 sivtr init powershell   # or bash, zsh, nushell
-sivtr mcp install       # detect installed hosts; or -p claude,cursor,codex,opencode,openclaw,grok,hermes,pi
+sivtr mcp install       # detect installed hosts; or -p claude,cursor,codex,opencode,openclaw,grok,hermes,pi,qoder,qodercn,gemini,qwen,goose
 npx skills add Ariestar/sivtr --skill sivtr-memory -g -y
 sivtr doctor
 ```
@@ -181,11 +182,11 @@ Memory variables:
 
 | Command | Purpose |
 | --- | --- |
-| `sivtr` | TTY: workspace browser; piped stdin: single-buffer browser. |
-| `sivtr pipe` | Read stdin and open the output browser. |
-| `sivtr run <command>` | Execute a command, capture output, then browse it. |
+| `sivtr` | TTY: workspace browser (TUI). |
+| `sivtr pipe` | Read stdin, write to history, open the external editor. |
+| `sivtr run <command>` | Execute a command, capture output, open the external editor. |
 | `sivtr copy` | Copy recent terminal command blocks. |
-| `sivtr copy <provider>` | Copy content from any registered agent provider (registry-driven: Codex, Claude, Cursor, OpenCode, OpenClaw, Hermes, Grok, Pi, …). |
+| `sivtr copy <provider>` | Copy content from any registered agent provider (registry-driven: Codex, Claude, Cursor, Dsh, Gemini, Goose, OpenCode, OpenClaw, Hermes, Grok, Pi, Qoder, Qoder-CN, Qwen, …). |
 | `sivtr search` / `sivtr s` | Search terminal and agent memory; saves matches as `@last`. |
 | `sivtr filter <source>` | Apply the shared WorkSet filters to a source or piped WorkSet. |
 | `sivtr var` | List, save, remove, merge, drop, or clean up named WorkSet variables. |
@@ -198,7 +199,10 @@ Memory variables:
 | `sivtr diff <left> <right>` | Compare recent command blocks. |
 | `sivtr serve` | Start/stop the local remote-memory daemon. |
 | `sivtr share` | Explicitly share a local workspace for remote peers. |
-| `sivtr remote` | Name peer shares in the current workspace (`add`/`list`/`remove`/`test`, like `git remote`). |
+| `sivtr peer` | List/forget device identities known to the daemon. |
+| `sivtr remote` | Name peer shares in the current workspace (`add`/`list`/`remove`/`rename`/`test`, like `git remote`). |
+| `sivtr group` / `sivtr g` | Group devices so they share memory automatically (create/invite/join/list/members/remove/rename/leave/sync). |
+| `sivtr origin` | One rename path for every addressable source — a single name for a local workspace alias or a remote mount. |
 | `sivtr workspace` / `sivtr ws` | List known local workspaces (origin labels for `name:body` refs). |
 | `sivtr mcp` | MCP server + host install (`serve` / `install` / `uninstall` / `print-config`). |
 | `sivtr doctor` | Diagnose binary, config, session logs, hooks, providers, and clipboard; reports new releases. |
@@ -242,6 +246,27 @@ sivtr copy desk:terminal/session_42/3 --print
 
 Sharing is opt-in and read-only. Secrets are redacted by default before data leaves the machine. Remote access uses encrypted iroh transport; the daemon auto-starts when needed. Unregistered origins error — register remotes with `sivtr remote add`, or list local workspaces with `sivtr ws`.
 
+## Groups
+
+When more than two devices want long-lived shared memory, instead of each `share` + `remote add`, form a group: every device contributes its own workspace and members sync automatically and read each other's memory.
+
+```bash
+# Owner on device A:
+sivtr group create team        # create the group and contribute the current workspace
+sivtr group invite team        # mint a multi-device join link (stdout = bare key)
+
+# Member on device B:
+sivtr group join <invite>      # join and contribute your own workspace
+sivtr group list               # all groups
+sivtr group members team       # members and their contributions
+sivtr group sync team          # force a roster pull
+
+# Day to day: read a teammate's memory like local
+sivtr s <peer>:terminal --status failure --latest 5 --refs
+```
+
+The owner manages the group: `rename` to rename, `remove <group> <peer>` to kick; when the owner `leave`s, the group disbands. Membership changes sync to every member automatically.
+
 ## Supported sources
 
 | Source | Support |
@@ -254,7 +279,12 @@ Sharing is opt-in and read-only. Secrets are redacted by default before data lea
 | OpenClaw | Local OpenClaw agent SQLite (+ legacy JSONL). |
 | Hermes | Local Hermes `state.db` (JSONL under `sessions/` as residual). |
 | Grok | Local Grok agent sessions under `~/.grok` (`GROK_HOME`). |
+| Dsh | Local Dsh agent sessions. |
+| Gemini | Local Gemini CLI sessions. |
+| Goose | Local Goose agent sessions. |
 | Pi | Local Pi agent session logs. |
+| Qoder / Qoder-CN | Local Qoder and Qoder-CN agent sessions. |
+| Qwen | Local Qwen Code sessions. |
 
 ## Documentation
 

--- a/README.en.md
+++ b/README.en.md
@@ -214,8 +214,8 @@ sivtr copy 3 --print                     # print block 3 to stdout
 sivtr share                              # interactively create a read-only share of a workspace
 sivtr share invite <share> --expires 10m # mint a single-use invite (stdout = bare key)
 sivtr remote add desk <invite-key>       # mount a teammate's share as local remote `desk`
-sivtr group create team                  # create a group and contribute the current workspace
-sivtr group invite team --expires 1d --max-uses 10   # mint a multi-device join link
+sivtr group create <name>                  # create a group and contribute the current workspace
+sivtr group invite <name> --expires 1d --max-uses 10   # mint a multi-device join link
 sivtr group join <invite-key>            # join and contribute your own workspace
 sivtr group members team                 # members and their contributions
 sivtr s <peer>:terminal --status failure --latest 5 --refs  # read a teammate like local
@@ -261,14 +261,14 @@ When more than two devices want long-lived shared memory, instead of each `share
 
 ```bash
 # Owner on device A:
-sivtr group create team        # create the group and contribute the current workspace
-sivtr group invite team        # mint a multi-device join link (stdout = bare key)
+sivtr group create <name>        # create the group and contribute the current workspace
+sivtr group invite <name>        # mint a multi-device join link (stdout = bare key)
 
 # Member on device B:
 sivtr group join <invite>      # join and contribute your own workspace
 sivtr group list               # all groups
-sivtr group members team       # members and their contributions
-sivtr group sync team          # force a roster pull
+sivtr group members <name>     # members and their contributions
+sivtr group sync <name>        # force a roster pull
 
 # Day to day: read a teammate's memory like local
 sivtr s <peer>:terminal --status failure --latest 5 --refs

--- a/README.en.md
+++ b/README.en.md
@@ -180,37 +180,20 @@ Memory variables:
 
 ## Command overview
 
-| Command | Purpose |
-| --- | --- |
-| `sivtr` | TTY: workspace browser (TUI). |
-| `sivtr pipe` | Read stdin, write to history, open the external editor. |
-| `sivtr run <command>` | Execute a command, capture output, open the external editor. |
-| `sivtr copy` | Copy recent terminal command blocks. |
-| `sivtr copy <provider>` | Copy content from any registered agent provider (registry-driven: Codex, Claude, Cursor, Dsh, Gemini, Goose, OpenCode, OpenClaw, Hermes, Grok, Pi, Qoder, Qoder-CN, Qwen, …). |
-| `sivtr search` / `sivtr s` | Search terminal and agent memory; saves matches as `@last`. |
-| `sivtr filter <source>` | Apply the shared WorkSet filters to a source or piped WorkSet. |
-| `sivtr var` | List, save, remove, merge, drop, or clean up named WorkSet variables. |
-| `sivtr nav <source> <motion>` | Move anchors deterministically with `<`, `>N`, `+N`, `-N`, `[A..B]`, and `~`. |
-| `sivtr work sessions` | List terminal and agent sessions in the current workspace. |
-| `sivtr work records <source>` | Turn sessions or saved variables into event-level refs. |
-| `sivtr work parts <source>` | Extract only useful inputs/outputs from matching events. |
-| `sivtr show <ref-or-workset>` | Print the content behind refs, `@last`, `@name`, or piped results. Also accepts remote refs like `desk:terminal/...`. |
-| `sivtr zoom <source>` | Add surrounding record context around search hits. |
-| `sivtr diff <left> <right>` | Compare recent command blocks. |
-| `sivtr serve` | Start/stop the local remote-memory daemon. |
-| `sivtr share` | Explicitly share a local workspace for remote peers. |
-| `sivtr peer` | List/forget device identities known to the daemon. |
-| `sivtr remote` | Name peer shares in the current workspace (`add`/`list`/`remove`/`rename`/`test`, like `git remote`). |
-| `sivtr group` / `sivtr g` | Group devices so they share memory automatically (create/invite/join/list/members/remove/rename/leave/sync). |
-| `sivtr origin` | One rename path for every addressable source — a single name for a local workspace alias or a remote mount. |
-| `sivtr workspace` / `sivtr ws` | List known local workspaces (origin labels for `name:body` refs). |
-| `sivtr mcp` | MCP server + host install (`serve` / `install` / `uninstall` / `print-config`). |
-| `sivtr doctor` | Diagnose binary, config, session logs, hooks, providers, and clipboard; reports new releases. |
-| `sivtr update` | Self-update to the latest GitHub release. |
-| `sivtr init <shell>` | Install shell integration; also supports `show` and `uninstall`. |
-| `sivtr config` | Manage the TOML config file. |
-| `sivtr history` | List, search, and show captured output history. |
-| `sivtr hotkey` | Manage the Windows AI session picker hotkey daemon. |
+A quick cheat sheet; the full command, subcommand, and flag reference lives in the [CLI Reference](https://sivtr.pages.dev/reference/cli/).
+
+```text
+sivtr                    # TUI workspace browser
+sivtr run <cmd>          # run a command and capture its output
+sivtr s <source> <query> # search terminal / agent memory
+sivtr copy               # copy recent command blocks
+sivtr show <ref>         # show the content behind a ref
+sivtr group              # multi-device shared-memory groups
+sivtr remote / share     # read-only sharing between devices
+sivtr mcp install        # register the MCP server for agent hosts
+```
+
+Full command list: `search / filter / var / nav / zoom / work / diff / serve / peer / origin / workspace / config / doctor / update / setup / init / history / hotkey / codex / clear / version`.
 
 ## Remote access
 

--- a/README.en.md
+++ b/README.en.md
@@ -178,22 +178,38 @@ Memory variables:
 | `@name[1,3..5]` | Pick only a few items from a saved variable. |
 | `@` | Use the result coming from the previous command in a pipeline. |
 
-## Command overview
+## Command cheat sheet
 
-A quick cheat sheet; the full command, subcommand, and flag reference lives in the [CLI Reference](https://sivtr.pages.dev/reference/cli/).
+The full command, subcommand, and flag reference lives in the [CLI Reference](https://sivtr.pages.dev/reference/cli/). Core commands at a glance:
 
-```text
-sivtr                    # TUI workspace browser
-sivtr run <cmd>          # run a command and capture its output
-sivtr s <source> <query> # search terminal / agent memory
-sivtr copy               # copy recent command blocks
-sivtr show <ref>         # show the content behind a ref
-sivtr group              # multi-device shared-memory groups
-sivtr remote / share     # read-only sharing between devices
-sivtr mcp install        # register the MCP server for agent hosts
+**Setup & maintenance**
+
+```bash
+sivtr setup                    # one-command setup: detect env, hooks + MCP + skill, smoke test
+sivtr doctor --fix             # diagnose and auto-repair binary/config/hooks/providers
+sivtr mcp install              # register MCP for detected agent hosts; or -p claude,cursor,codex,...
+sivtr update                   # self-update to the latest release
+sivtr config                   # view/init/edit the TOML config (e.g. [theme] mode)
 ```
 
-Full command list: `search / filter / var / nav / zoom / work / diff / serve / peer / origin / workspace / config / doctor / update / setup / init / history / hotkey / codex / clear / version`.
+**Everyday use**
+
+```bash
+sivtr                          # TUI workspace browser
+sivtr run cargo test           # run a command and capture its output to history
+sivtr s terminal --status failure --latest 5   # find recent failures
+sivtr show @last               # open the exact content behind a hit
+sivtr copy 3                   # copy the 3rd recent command block
+```
+
+**Remote & collaboration**
+
+```bash
+sivtr share                    # share a local workspace read-only (opt-in)
+sivtr remote add desk <invite> # mount a teammate's share
+sivtr group create team        # group devices for automatic shared memory
+sivtr s <peer>:terminal --latest 5 --refs       # read a teammate like local
+```
 
 ## Remote access
 

--- a/README.en.md
+++ b/README.en.md
@@ -185,30 +185,40 @@ The full command, subcommand, and flag reference lives in the [CLI Reference](ht
 **Setup & maintenance**
 
 ```bash
-sivtr setup                    # one-command setup: detect env, hooks + MCP + skill, smoke test
-sivtr doctor --fix             # diagnose and auto-repair binary/config/hooks/providers
-sivtr mcp install              # register MCP for detected agent hosts; or -p claude,cursor,codex,...
-sivtr update                   # self-update to the latest release
-sivtr config                   # view/init/edit the TOML config (e.g. [theme] mode)
+sivtr setup                              # one-command setup: env detect + hooks + MCP + skill + smoke
+sivtr doctor --fix                       # diagnose and auto-repair binary/config/hooks/providers
+sivtr mcp install -p claude,cursor,codex # register MCP for specific hosts (or detect installed)
+sivtr update                             # self-update to the latest release
+sivtr config show                        # view config (init writes defaults / edit opens $EDITOR)
 ```
 
 **Everyday use**
 
 ```bash
-sivtr                          # TUI workspace browser
-sivtr run cargo test           # run a command and capture its output to history
-sivtr s terminal --status failure --latest 5   # find recent failures
-sivtr show @last               # open the exact content behind a hit
-sivtr copy 3                   # copy the 3rd recent command block
+sivtr                                    # TUI workspace browser
+sivtr run cargo test                     # run a command and capture its output (run <COMMAND> [ARGS...])
+sivtr s terminal --status failure --latest 5 --refs   # 5 most recent failed terminal events
+sivtr s agent -m "panic|TODO" --since today -f timeline # today's agent decisions as a timeline
+sivtr show @last                         # open the content behind the last search
+sivtr show desk:terminal/session_42/3    # open an exact remote ref
+sivtr copy                               # copy the most recent command block
+sivtr copy out 2..4                      # output of blocks 2..4
+sivtr copy in --pick --regex panic       # interactively pick the input block matching "panic"
+sivtr copy cmd --pick                    # interactively pick a command itself
+sivtr copy 3 --print                     # print block 3 to stdout
 ```
 
 **Remote & collaboration**
 
 ```bash
-sivtr share                    # share a local workspace read-only (opt-in)
-sivtr remote add desk <invite> # mount a teammate's share
-sivtr group create team        # group devices for automatic shared memory
-sivtr s <peer>:terminal --latest 5 --refs       # read a teammate like local
+sivtr share                              # interactively create a read-only share of a workspace
+sivtr share invite <share> --expires 10m # mint a single-use invite (stdout = bare key)
+sivtr remote add desk <invite-key>       # mount a teammate's share as local remote `desk`
+sivtr group create team                  # create a group and contribute the current workspace
+sivtr group invite team --expires 1d --max-uses 10   # mint a multi-device join link
+sivtr group join <invite-key>            # join and contribute your own workspace
+sivtr group members team                 # members and their contributions
+sivtr s <peer>:terminal --status failure --latest 5 --refs  # read a teammate like local
 ```
 
 ## Remote access

--- a/README.md
+++ b/README.md
@@ -176,30 +176,40 @@ sivtr s agent -m "TODO|decision|failed" --since today -f timeline
 **安装与维护**
 
 ```bash
-sivtr setup                    # 一键配置：检测环境、装 hooks + MCP + skill、smoke test
-sivtr doctor --fix             # 诊断并自动修复 binary/config/hooks/providers
-sivtr mcp install              # 给已检测的 Agent 宿主注册 MCP；或 -p claude,cursor,codex,...
-sivtr update                   # 自更新到最新 release
-sivtr config                   # 查看/初始化/编辑 TOML 配置（如 [theme] mode）
+sivtr setup                              # 一键配置：环境检测 + hooks + MCP + skill + smoke
+sivtr doctor --fix                       # 诊断并自动修复 binary/config/hooks/providers
+sivtr mcp install -p claude,cursor,codex # 指定宿主注册 MCP（不指定则检测已装的）
+sivtr update                             # 自更新到最新 release
+sivtr config show                        # 查看配置（init 生成默认文件 / edit 用 $EDITOR 打开）
 ```
 
 **日常使用**
 
 ```bash
-sivtr                          # TUI workspace 浏览器
-sivtr run cargo test           # 执行命令并捕获输出到历史
-sivtr s terminal --status failure --latest 5   # 搜索最近失败
-sivtr show @last               # 打开命中背后的精确内容
-sivtr copy 3                   # 复制最近第 3 个命令块
+sivtr                                    # TUI workspace 浏览器
+sivtr run cargo test                     # 执行命令并捕获输出（run <COMMAND> [ARGS...]）
+sivtr s terminal --status failure --latest 5 --refs   # 最近 5 个失败终端事件
+sivtr s agent -m "panic|TODO" --since today -f timeline # 今天的 agent 决策时间线
+sivtr show @last                         # 打开上次搜索结果内容
+sivtr show desk:terminal/session_42/3    # 打开远端精确 ref
+sivtr copy                               # 复制最近命令块
+sivtr copy out 2..4                      # 第 2~4 块的输出
+sivtr copy in --pick --regex panic       # 交互挑选含 panic 的输入块
+sivtr copy cmd --pick                    # 交互挑选命令本身
+sivtr copy 3 --print                     # 第 3 块直接打印到 stdout
 ```
 
 **远程与协同**
 
 ```bash
-sivtr share                    # 本机 workspace 只读分享（opt-in）
-sivtr remote add desk <invite> # 把队友的 share 挂到本机
-sivtr group create team        # 多设备组队，组内自动共享记忆
-sivtr s <peer>:terminal --latest 5 --refs       # 像读本地一样读队友
+sivtr share                              # 交互选择 workspace 创建只读分享
+sivtr share invite <share> --expires 10m # 签发单次 invite（stdout = bare key）
+sivtr remote add desk <invite-key>       # 把队友的 share 挂成本机 remote `desk`
+sivtr group create team                  # 建组并贡献当前 workspace
+sivtr group invite team --expires 1d --max-uses 10   # 签发多设备 join 链接
+sivtr group join <invite-key>            # 加入并贡献自己的 workspace
+sivtr group members team                 # 组内成员与其贡献
+sivtr s <peer>:terminal --status failure --latest 5 --refs  # 读队友记忆像读本地
 ```
 
 ## 远程访问

--- a/README.md
+++ b/README.md
@@ -55,10 +55,11 @@
 
 - **MCP 优先的 Agent 记忆**：一次 `sivtr mcp install`，Agent 直接调用 `sivtr_search` / `sivtr_show` / `sivtr_zoom` / `sivtr_filter` / `sivtr_status`，不用你粘贴日志。
 - **带输出的 shell history**：记录 Bash、Zsh、PowerShell、Nushell 里的命令、stdout/stderr、退出码、目录和耗时。
-- **一个搜索面覆盖本地工作**：终端输出 + 所有已注册 Agent provider（Codex / Claude Code / Cursor / Hermes / OpenCode / OpenClaw / Grok / Pi …）——MCP 或 CLI 都能用。
+- **一个搜索面覆盖本地工作**：终端输出 + 所有已注册 Agent provider（Codex / Claude Code / Cursor / Dsh / Gemini / Goose / Hermes / OpenCode / OpenClaw / Grok / Pi / Qoder / Qoder-CN / Qwen …）——MCP 或 CLI 都能用。
 - **精确证据，而不是摘要**：每个命中都落到稳定 ref，可 show / zoom / filter，或交给下一个 Agent。
 - **命名记忆变量**：把结果保存成 `@failures`，复用 `@last`，管道用 `@`，也可 `@failures[1,3..5]` 取子集。
-- **跨设备访问**：只读分享 workspace，用 `desk:...` ref 像读本地一样浏览另一台设备。
+- **跨设备访问**：只读分享 workspace，用 `desk:...` ref 像读本地一样浏览另一台设备；多设备还能组成 `group`，成员间自动同步、一次 `sync` 拉齐。
+- **主题可配**：`[theme] mode = auto|dark|light`，自动跟随系统外观并检测 truecolor。
 - **一键安装与诊断**：`sivtr setup` 装 hooks + MCP；`sivtr doctor --fix` 自动修复。
 - **人用 CLI 仍然在**：search / show / filter / nav，以及 TUI 浏览器——有用，但不是主叙事。
 
@@ -97,7 +98,7 @@ sivtr update    # 下载最新 release，SHA256 校验后原地替换
 sivtr setup             # hooks + MCP 宿主 + sivtr-memory skill（缺失时安装）
 # 或分步：
 sivtr init powershell   # 或 bash、zsh、nushell
-sivtr mcp install       # 检测已装宿主；或 -p claude,cursor,codex,opencode,openclaw,grok,hermes,pi
+sivtr mcp install       # 检测已装宿主；或 -p claude,cursor,codex,opencode,openclaw,grok,hermes,pi,qoder,qodercn,gemini,qwen,goose
 npx skills add Ariestar/sivtr --skill sivtr-memory -g -y
 sivtr doctor
 ```
@@ -172,11 +173,11 @@ sivtr s agent -m "TODO|decision|failed" --since today -f timeline
 
 | 命令 | 用途 |
 | --- | --- |
-| `sivtr` | TTY 打开 workspace 浏览器；管道 stdin 打开单缓冲浏览器。 |
-| `sivtr pipe` | 读取 stdin 并打开输出浏览器。 |
-| `sivtr run <command>` | 执行命令、捕获输出并浏览。 |
+| `sivtr` | TTY 打开 workspace 浏览器（TUI）。 |
+| `sivtr pipe` | 读取 stdin 写入历史，用外部编辑器打开。 |
+| `sivtr run <command>` | 执行命令、捕获输出，用外部编辑器打开。 |
 | `sivtr copy` | 复制最近终端命令块。 |
-| `sivtr copy <provider>` | 从任意已注册 Agent provider 复制内容（registry 驱动：Codex、Claude、Cursor、OpenCode、OpenClaw、Hermes、Grok、Pi…）。 |
+| `sivtr copy <provider>` | 从任意已注册 Agent provider 复制内容（registry 驱动：Codex、Claude、Cursor、Dsh、Gemini、Goose、OpenCode、OpenClaw、Hermes、Grok、Pi、Qoder、Qoder-CN、Qwen…）。 |
 | `sivtr search` / `sivtr s` | 搜索终端和 Agent memory；命中结果保存为 `@last`。 |
 | `sivtr filter <source>` | 对 source 或管道传入的 WorkSet 应用统一过滤。 |
 | `sivtr var` | 列出、保存、删除、合并、移除或清空命名 WorkSet 变量。 |
@@ -189,7 +190,10 @@ sivtr s agent -m "TODO|decision|failed" --since today -f timeline
 | `sivtr diff <left> <right>` | 对比最近命令块。 |
 | `sivtr serve` | 启动/停止本机 remote-memory daemon。 |
 | `sivtr share` | 显式分享本机 workspace 给远端。 |
-| `sivtr remote` | 把远端 share 挂到当前 workspace（`add`/`list`/`remove`/`test`）。 |
+| `sivtr peer` | 列出/遗忘本机 daemon 认识的设备身份。 |
+| `sivtr remote` | 把远端 share 挂到当前 workspace（`add`/`list`/`remove`/`rename`/`test`）。 |
+| `sivtr group` / `sivtr g` | 把多台设备组成一组，组内自动共享彼此的记忆（create/invite/join/list/members/remove/rename/leave/sync）。 |
+| `sivtr origin` | 统一的来源改名入口——一个名字代表本地 workspace 别名或远端 mount，改名一处生效。 |
 | `sivtr workspace` / `sivtr ws` | 列出本机已知 workspace（`name:body` 的 origin 标签）。 |
 | `sivtr mcp` | MCP server 与宿主安装（`serve` / `install` / `uninstall` / `print-config`）。 |
 | `sivtr doctor` | 诊断 binary、config、session logs、hooks、providers、clipboard；有新版本时提示。 |
@@ -233,6 +237,27 @@ sivtr copy desk:terminal/session_42/3 --print
 
 分享是 opt-in、只读，默认在数据离开本机前脱敏常见密钥。远程传输走加密 iroh；需要时会自动启动 daemon。未登记的 origin 会报错——用 `sivtr remote add` 登记 remote，或用 `sivtr ws` 查看本机 workspace。
 
+## 群组（group）
+
+两台以上设备要长期共享记忆时，与其各自 `share` 再挂载，不如组成一个群组：组内每台设备贡献自己的 workspace，成员之间自动同步、随时互相读取。
+
+```bash
+# 组主（owner）在 A 机上：
+sivtr group create team        # 建组并贡献当前 workspace
+sivtr group invite team        # 签发多设备 join 链接（stdout = bare key）
+
+# 成员在 B 机上：
+sivtr group join <invite>      # 加入并贡献自己的 workspace
+sivtr group list               # 所有组
+sivtr group members team       # 组内成员与其贡献
+sivtr group sync team          # 手动拉一次成员清单
+
+# 日常使用：像本地一样读队友的记忆
+sivtr s <peer>:terminal --status failure --latest 5 --refs
+```
+
+组由 owner 管理：`rename` 改名、`remove <group> <peer>` 踢人；owner 退出（`leave`）会解散整组。成员每次变更都自动同步给全组，无需手动刷新。
+
 ## 支持来源
 
 | Source | 支持内容 |
@@ -245,7 +270,12 @@ sivtr copy desk:terminal/session_42/3 --print
 | OpenClaw | 本地 OpenClaw agent SQLite（+ legacy JSONL）。 |
 | Hermes | 本地 Hermes `state.db`（`sessions/` 下 JSONL 为 residual）。 |
 | Grok | 本地 Grok agent sessions（`~/.grok`，可用 `GROK_HOME`）。 |
+| Dsh | 本地 Dsh agent sessions。 |
+| Gemini | 本地 Gemini CLI sessions。 |
+| Goose | 本地 Goose agent sessions。 |
 | Pi | 本地 Pi agent session logs。 |
+| Qoder / Qoder-CN | 本地 Qoder 与 Qoder-CN agent sessions。 |
+| Qwen | 本地 Qwen Code sessions。 |
 
 ## 文档
 

--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ sivtr copy 3 --print                     # 第 3 块直接打印到 stdout
 sivtr share                              # 交互选择 workspace 创建只读分享
 sivtr share invite <share> --expires 10m # 签发单次 invite（stdout = bare key）
 sivtr remote add desk <invite-key>       # 把队友的 share 挂成本机 remote `desk`
-sivtr group create team                  # 建组并贡献当前 workspace
-sivtr group invite team --expires 1d --max-uses 10   # 签发多设备 join 链接
+sivtr group create <name>                  # 建组并贡献当前 workspace（如 create team）
+sivtr group invite <name> --expires 1d --max-uses 10   # 签发多设备 join 链接
 sivtr group join <invite-key>            # 加入并贡献自己的 workspace
 sivtr group members team                 # 组内成员与其贡献
 sivtr s <peer>:terminal --status failure --latest 5 --refs  # 读队友记忆像读本地
@@ -252,14 +252,14 @@ sivtr copy desk:terminal/session_42/3 --print
 
 ```bash
 # 组主（owner）在 A 机上：
-sivtr group create team        # 建组并贡献当前 workspace
-sivtr group invite team        # 签发多设备 join 链接（stdout = bare key）
+sivtr group create <name>      # 建组并贡献当前 workspace
+sivtr group invite <name>      # 签发多设备 join 链接（stdout = bare key）
 
 # 成员在 B 机上：
 sivtr group join <invite>      # 加入并贡献自己的 workspace
 sivtr group list               # 所有组
-sivtr group members team       # 组内成员与其贡献
-sivtr group sync team          # 手动拉一次成员清单
+sivtr group members <name>     # 组内成员与其贡献
+sivtr group sync <name>        # 手动拉一次成员清单
 
 # 日常使用：像本地一样读队友的记忆
 sivtr s <peer>:terminal --status failure --latest 5 --refs

--- a/README.md
+++ b/README.md
@@ -169,22 +169,38 @@ sivtr s agent -m "TODO|decision|failed" --since today -f timeline
 | `@name[1,3..5]` | 从已保存变量中只取几项。 |
 | `@` | 使用管道里上一条命令传来的结果。 |
 
-## 命令概览
+## 命令速查
 
-核心命令速查；完整命令、子命令与参数见 [CLI Reference](https://sivtr.pages.dev/zh-cn/reference/cli/)。
+完整命令、子命令与参数见 [CLI Reference](https://sivtr.pages.dev/zh-cn/reference/cli/)。核心命令速查：
 
-```text
-sivtr                    # TUI workspace 浏览器
-sivtr run <cmd>          # 执行命令并捕获输出
-sivtr s <source> <query> # 搜索 terminal / agent 记忆
-sivtr copy               # 复制最近命令块
-sivtr show <ref>         # 查看精确 ref 内容
-sivtr group              # 多设备共享记忆群组
-sivtr remote / share     # 单设备间只读分享
-sivtr mcp install        # 给 Agent 宿主注册 MCP
+**安装与维护**
+
+```bash
+sivtr setup                    # 一键配置：检测环境、装 hooks + MCP + skill、smoke test
+sivtr doctor --fix             # 诊断并自动修复 binary/config/hooks/providers
+sivtr mcp install              # 给已检测的 Agent 宿主注册 MCP；或 -p claude,cursor,codex,...
+sivtr update                   # 自更新到最新 release
+sivtr config                   # 查看/初始化/编辑 TOML 配置（如 [theme] mode）
 ```
 
-完整命令表：`search / filter / var / nav / zoom / work / diff / serve / peer / origin / workspace / config / doctor / update / setup / init / history / hotkey / codex / clear / version`。
+**日常使用**
+
+```bash
+sivtr                          # TUI workspace 浏览器
+sivtr run cargo test           # 执行命令并捕获输出到历史
+sivtr s terminal --status failure --latest 5   # 搜索最近失败
+sivtr show @last               # 打开命中背后的精确内容
+sivtr copy 3                   # 复制最近第 3 个命令块
+```
+
+**远程与协同**
+
+```bash
+sivtr share                    # 本机 workspace 只读分享（opt-in）
+sivtr remote add desk <invite> # 把队友的 share 挂到本机
+sivtr group create team        # 多设备组队，组内自动共享记忆
+sivtr s <peer>:terminal --latest 5 --refs       # 像读本地一样读队友
+```
 
 ## 远程访问
 

--- a/README.md
+++ b/README.md
@@ -171,37 +171,20 @@ sivtr s agent -m "TODO|decision|failed" --since today -f timeline
 
 ## 命令概览
 
-| 命令 | 用途 |
-| --- | --- |
-| `sivtr` | TTY 打开 workspace 浏览器（TUI）。 |
-| `sivtr pipe` | 读取 stdin 写入历史，用外部编辑器打开。 |
-| `sivtr run <command>` | 执行命令、捕获输出，用外部编辑器打开。 |
-| `sivtr copy` | 复制最近终端命令块。 |
-| `sivtr copy <provider>` | 从任意已注册 Agent provider 复制内容（registry 驱动：Codex、Claude、Cursor、Dsh、Gemini、Goose、OpenCode、OpenClaw、Hermes、Grok、Pi、Qoder、Qoder-CN、Qwen…）。 |
-| `sivtr search` / `sivtr s` | 搜索终端和 Agent memory；命中结果保存为 `@last`。 |
-| `sivtr filter <source>` | 对 source 或管道传入的 WorkSet 应用统一过滤。 |
-| `sivtr var` | 列出、保存、删除、合并、移除或清空命名 WorkSet 变量。 |
-| `sivtr nav <source> <motion>` | 用 `<`、`>N`、`+N`、`-N`、`[A..B]`、`~` 确定性移动 anchors。 |
-| `sivtr work sessions` | 列出当前 workspace 的 terminal 和 Agent sessions。 |
-| `sivtr work records <source>` | 把 sessions 或已保存变量转成事件级 refs。 |
-| `sivtr work parts <source>` | 从匹配事件里抽出真正有用的输入/输出片段。 |
-| `sivtr show <ref-or-workset>` | 打印 refs、`@last`、`@name` 或管道结果背后的内容。也支持远程 ref，如 `desk:terminal/...`。 |
-| `sivtr zoom <source>` | 给搜索命中补上前后 record 上下文。 |
-| `sivtr diff <left> <right>` | 对比最近命令块。 |
-| `sivtr serve` | 启动/停止本机 remote-memory daemon。 |
-| `sivtr share` | 显式分享本机 workspace 给远端。 |
-| `sivtr peer` | 列出/遗忘本机 daemon 认识的设备身份。 |
-| `sivtr remote` | 把远端 share 挂到当前 workspace（`add`/`list`/`remove`/`rename`/`test`）。 |
-| `sivtr group` / `sivtr g` | 把多台设备组成一组，组内自动共享彼此的记忆（create/invite/join/list/members/remove/rename/leave/sync）。 |
-| `sivtr origin` | 统一的来源改名入口——一个名字代表本地 workspace 别名或远端 mount，改名一处生效。 |
-| `sivtr workspace` / `sivtr ws` | 列出本机已知 workspace（`name:body` 的 origin 标签）。 |
-| `sivtr mcp` | MCP server 与宿主安装（`serve` / `install` / `uninstall` / `print-config`）。 |
-| `sivtr doctor` | 诊断 binary、config、session logs、hooks、providers、clipboard；有新版本时提示。 |
-| `sivtr update` | 从 GitHub Releases 自更新到最新版本。 |
-| `sivtr init <shell>` | 安装 shell integration；也支持 `show` 和 `uninstall`。 |
-| `sivtr config` | 管理 TOML 配置文件。 |
-| `sivtr history` | 列出、搜索、查看捕获输出历史。 |
-| `sivtr hotkey` | 管理 Windows AI session picker 全局热键守护进程。 |
+核心命令速查；完整命令、子命令与参数见 [CLI Reference](https://sivtr.pages.dev/zh-cn/reference/cli/)。
+
+```text
+sivtr                    # TUI workspace 浏览器
+sivtr run <cmd>          # 执行命令并捕获输出
+sivtr s <source> <query> # 搜索 terminal / agent 记忆
+sivtr copy               # 复制最近命令块
+sivtr show <ref>         # 查看精确 ref 内容
+sivtr group              # 多设备共享记忆群组
+sivtr remote / share     # 单设备间只读分享
+sivtr mcp install        # 给 Agent 宿主注册 MCP
+```
+
+完整命令表：`search / filter / var / nav / zoom / work / diff / serve / peer / origin / workspace / config / doctor / update / setup / init / history / hotkey / codex / clear / version`。
 
 ## 远程访问
 


### PR DESCRIPTION
## Purpose

README.md + README.en.md drifted behind v0.5.0/v0.5.1 (groups, origins, new providers, dropped single-buffer browser).

## Changes

- Add \sivtr group\ section + command rows (create/invite/join/list/members/remove/rename/leave/sync)
- Add \sivtr origin\, \sivtr peer\ command rows
- Update provider lists (add Dsh, Gemini, Goose, Qoder/Qoder-CN, Qwen) in features, quick start, copy, supported sources
- Fix stale claims: \sivtr\/pipe/run no longer open a single-buffer browser (pipe/run open the external editor)
- Add \[theme] mode\ feature bullet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded supported agent provider documentation, including Dsh, Gemini, Goose, Qoder, Qoder-CN, and Qwen.
  * Added guidance for theme configuration and expanded MCP installation options.
  * Updated command references for peers, origins, and groups.
  * Added examples for creating, inviting, joining, synchronizing, and managing group members across devices.
  * Clarified command behavior and synchronization workflows.
  * Added a command cheat sheet for quicker reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->