### PR TITLE
docs(reference): align CLI, config, and keybindings with v0.5

### DIFF
--- a/docs-site/src/content/docs/reference/cli.md
+++ b/docs-site/src/content/docs/reference/cli.md
@@ -15,7 +15,7 @@ sivtr --all              # with bare TTY: also select remote mounts on open
 With no command:
 
 - **TTY** → multi-source workspace browser (Source / Sessions / Dialogues / Content).
-- **Piped stdin** → single-buffer browser (same as `sivtr pipe`).
+- **Piped stdin** → same as `sivtr pipe`: write to history and open the external editor.
 
 ## run
 
@@ -23,7 +23,7 @@ With no command:
 sivtr run <COMMAND> [ARGS...]
 ```
 
-Runs a command, captures combined stdout/stderr, reports the exit status, saves history when enabled, and opens the captured output.
+Runs a command, captures combined stdout/stderr, reports the exit status, saves history when enabled, and opens the captured output in the external editor.
 
 ```bash
 sivtr run cargo test
@@ -429,6 +429,55 @@ sivtr show @last --full
 sivtr show @ctx -f timeline
 ```
 
+## zoom
+
+```bash
+sivtr zoom [SOURCE=@last] [OPTIONS]
+```
+
+Expands each target WorkRecord with neighboring records from the same session. Defaults to `@last` when no source is given.
+
+Options:
+
+| Option | Meaning |
+| --- | --- |
+| `-C, --context <N>` | Records before + after each anchor (default `1`) |
+| `--before <N>` | Records before each anchor |
+| `--after <N>` | Records after each anchor |
+| `--cwd <PATH>` | Workspace directory used to resolve sessions |
+| `--json` | Alias for `--format workset` |
+| `--refs` | Alias for `--format refs` |
+| `-f, --format <FORMAT>` | `full`, `timeline`, `compact`, `md`, `refs`, or `workset` |
+| `--save <NAME>` | Save the expanded set as a named WorkSet var |
+
+```bash
+sivtr zoom                        # expand @last
+sivtr zoom claude/<session>/3 -C 2
+sivtr zoom @failures --before 2 --after 0 --refs
+```
+
+## work
+
+```bash
+sivtr work <COMMAND>
+```
+
+Traverses workspace sessions, records, and parts without printing full content — marker-level output you can pipe into other commands.
+
+| Command | Meaning |
+| --- | --- |
+| `sessions [SOURCE]` | List terminal and agent sessions in the current workspace |
+| `records <SOURCE>` | Turn sessions or saved variables into event-level refs |
+| `parts <SOURCE>` | Extract only useful inputs/outputs from matching events |
+
+Common flags: `--provider <NAME>` filter, `--cwd <PATH>`, `--json`, `--refs`, `--save <NAME>`.
+
+```bash
+sivtr work sessions
+sivtr work records codex/ --refs
+sivtr work parts @last --kind output --save out_parts
+```
+
 ## serve
 
 ```bash
@@ -533,6 +582,54 @@ sivtr peer list
 sivtr peer forget <peer>
 ```
 
+## group
+
+```bash
+sivtr group <COMMAND>
+```
+
+Groups are a named set of devices that share memory with each other: every member contributes workspaces, and roster changes sync automatically.
+
+| Command | Meaning |
+| --- | --- |
+| `create <NAME> [--workspace PATH] [--share-name NAME]` | Create the group and contribute the current workspace in one transaction |
+| `invite <GROUP> [--expires DURATION] [--max-uses N]` | Owner-only; mint a multi-use join link (stdout = bare key) |
+| `join <INVITE> [--workspace PATH] [--share-name NAME] [--no-redact]` | Redeem an invite and contribute workspaces; re-run to adjust contributions |
+| `list` | List groups you belong to |
+| `members <GROUP>` | List members and their contributions |
+| `remove <GROUP> <PEER>` | Owner-only; remove a member |
+| `rename <GROUP> <NAME>` | Owner-only; rename the group |
+| `leave <GROUP>` | Leave the group (owner leaving disbands it) |
+| `sync <GROUP>` | Force a roster pull from the owner |
+
+```bash
+sivtr group create team
+sivtr group invite team --expires 1d --max-uses 10
+sivtr group join <invite-key>
+sivtr group list
+sivtr group members team
+sivtr group sync team
+```
+
+Membership changes broadcast to every member automatically (and re-pull on a 5-minute TTL). Group access to a member's contributions is read-only and redacts secrets like shares do.
+
+## origin
+
+```bash
+sivtr origin <COMMAND>
+```
+
+One rename path for every addressable source — a name is either a local workspace alias or a remote mount, unified through an origin registry.
+
+| Command | Meaning |
+| --- | --- |
+| `rename <NAME> <NEW_NAME>` | Rename a local workspace alias or a remote mount; both kinds resolve through the same command |
+
+```bash
+sivtr origin rename docs knowledge
+sivtr origin rename desk alice-desk
+```
+
 ## workspace
 
 ```bash
@@ -593,7 +690,7 @@ sivtr mcp uninstall -p all -y
 
 | Flag | Meaning |
 | --- | --- |
-| `-p, --provider` | Provider host(s): `claude`, `cursor`, `codex`, `opencode`, `openclaw`, `grok`, `pi`, `hermes`, or `all`. Omit to detect installed hosts. |
+| `-p, --provider` | Provider host(s): `claude`, `cursor`, `codex`, `opencode`, `openclaw`, `grok`, `hermes`, `pi`, `qoder`, `qodercn`, `gemini`, `qwen`, `goose`, or `all`. Omit to detect installed hosts. |
 | `-l, --location` | `global` (default) or `local` |
 | `-y, --yes` | Non-interactive |
 
@@ -609,6 +706,10 @@ Install locations (registry-driven; paths are host defaults):
 | Grok | Grok config TOML → MCP entry |
 | Hermes | Hermes YAML → `mcp_servers.sivtr` |
 | Pi | Pi config → `mcpServers.sivtr` |
+| Qoder / Qoder-CN | Qoder settings.json → MCP entry |
+| Gemini | Gemini settings.json → `mcpServers.sivtr` |
+| Qwen | Qwen settings.json → MCP entry |
+| Goose | Goose config.yaml extensions → MCP entry |
 
 Registered command is always:
 
@@ -625,6 +726,7 @@ sivtr mcp print-config claude
 sivtr mcp print-config cursor
 sivtr mcp print-config codex
 sivtr mcp print-config grok
+sivtr mcp print-config goose
 ```
 
 MCP is not a full CLI mirror. Interactive, write, and capture commands stay on the CLI. Strategy still lives in the `sivtr-memory` skill.
@@ -652,6 +754,49 @@ Verbose output includes:
 - detected repo root;
 - local `target/debug/sivtr` binary status;
 - a warning when a different global binary is being used inside the repo.
+
+## doctor
+
+```bash
+sivtr doctor [--fix] [--json]
+```
+
+Diagnoses the installation and environment: binary, config, session logs, shell hooks, provider session counts, clipboard, and available updates.
+
+| Option | Meaning |
+| --- | --- |
+| `--fix` | Attempt to repair detected problems automatically |
+| `--json` | Machine-readable JSON output |
+
+```bash
+sivtr doctor
+sivtr doctor --fix
+sivtr doctor --json
+```
+
+## update
+
+```bash
+sivtr update
+```
+
+Self-updates to the latest GitHub release: downloads the matching platform asset, verifies its SHA256, and replaces the binary in place.
+
+```bash
+sivtr update
+```
+
+## setup
+
+```bash
+sivtr setup
+```
+
+One-command setup for a fresh install: detects the environment, installs shell hooks, registers the MCP server with detected agent hosts, installs the `sivtr-memory` skill when missing, and runs a smoke test. Equivalent to running `sivtr init`, `sivtr mcp install`, the skill install, and `sivtr doctor` step by step.
+
+```bash
+sivtr setup
+```
 
 ## history
 

--- a/docs-site/src/content/docs/reference/config-file.md
+++ b/docs-site/src/content/docs/reference/config-file.md
@@ -28,6 +28,12 @@ session_dirs = ["/srv/sivtr/root-codex/sessions"]
 
 [hotkey]
 chord = "alt+y"
+
+[theme]
+mode = "auto"
+
+[mcp]
+idle_exit_secs = 60
 ```
 
 ## editor
@@ -76,7 +82,7 @@ session_dirs = []
 
 On macOS, a typical shared path is `/Users/Shared/sivtr/root-codex/sessions`.
 
-Only Codex mirrors are currently configured here. Other registered providers (Claude, Cursor, OpenCode, OpenClaw, Hermes, Grok, Pi, …) use their own local locations and environment signals.
+Only Codex mirrors are currently configured here. Other registered providers (Claude, Cursor, OpenCode, OpenClaw, Hermes, Grok, Pi, Dsh, Gemini, Goose, Qoder/Qoder-CN, Qwen, …) use their own local locations and environment signals.
 
 ## hotkey
 
@@ -88,3 +94,27 @@ chord = "alt+y"
 | Key | Type | Default | Meaning |
 | --- | --- | --- | --- |
 | `chord` | string | `"alt+y"` | Chord used by `sivtr hotkey start` |
+
+## theme
+
+```toml
+[theme]
+mode = "auto"
+```
+
+| Key | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `mode` | string | `"auto"` | TUI color scheme: `auto`, `dark`, or `light` |
+
+`auto` follows the system appearance (macOS/Linux XDG/Windows registry) and picks the truecolor vs ANSI palette from terminal capability. `dark` and `light` force a palette. The key rejects unknown values and typos (e.g. `mode = "ligth"` is a hard error).
+
+## mcp
+
+```toml
+[mcp]
+idle_exit_secs = 60
+```
+
+| Key | Type | Default | Meaning |
+| --- | --- | --- | --- |
+| `idle_exit_secs` | integer | `60` | Seconds without tool calls before the stdio MCP server exits; `0` keeps it alive until the host closes stdin. The `sivtr mcp serve --idle-exit` flag overrides this. |

--- a/docs-site/src/content/docs/reference/keybindings.md
+++ b/docs-site/src/content/docs/reference/keybindings.md
@@ -1,62 +1,13 @@
 ---
 title: Keybindings
-description: Browser, command-block, picker, search, line-filter, and Vim-view keybindings.
+description: Workspace picker, content, search, line filter, and Vim-view keybindings.
 ---
 
-## Browser
-
-The browser is used by pipe mode, run mode, and session import.
-
-| Key | Mode | Action |
-| --- | --- | --- |
-| `j` / `Down` | Normal, Insert, Visual | Move down |
-| `k` / `Up` | Normal, Insert, Visual | Move up |
-| `h` / `Left` | Normal, Insert, Visual | Move left |
-| `l` / `Right` | Normal, Insert, Visual | Move right |
-| `0` / `Home` | Normal, Insert, Visual | Start of line |
-| `^` | Normal, Insert, Visual | First non-blank |
-| `$` / `End` | Normal, Insert, Visual | End of line |
-| `Ctrl-D` | Normal, Insert, Visual | Half page down |
-| `Ctrl-U` | Normal, Insert, Visual | Half page up |
-| `Ctrl-F` / `PageDown` | Normal, Insert, Visual | Page down |
-| `Ctrl-B` / `PageUp` | Normal, Insert, Visual | Page up |
-| `gg` | Normal, Visual | Top |
-| `G` | Normal, Visual | Bottom |
-| `H` | Normal, Visual | Top of viewport |
-| `M` | Normal, Visual | Middle of viewport |
-| `L` | Normal, Visual | Bottom of viewport |
-| `/` | Normal, Insert | Search |
-| `n` | Normal | Next match |
-| `N` | Normal | Previous match |
-| `i` | Normal | Insert mode |
-| `v` | Normal, Visual | Character selection |
-| `V` | Normal, Visual | Line selection |
-| `Ctrl-V` | Normal, Visual | Block selection |
-| `o` | Visual | Swap selection anchor |
-| `y` | Visual | Copy selection |
-| `e` | Normal, Visual | Open editor |
-| `Esc` | Insert, Visual, Search | Cancel current mode |
-| `q` | Normal | Quit |
-
-## Command-block navigation
-
-Only available when the buffer has parsed command blocks.
-
-| Key | Action |
-| --- | --- |
-| `[[` | Previous command block |
-| `]]` | Next command block |
-| `myy` | Copy current command block |
-| `myi` | Copy current command input |
-| `myo` | Copy current command output |
-| `myc` | Copy current bare command |
-| `mvv` | Select current command block |
-| `mvi` | Select current command input |
-| `mvo` | Select current command output |
+This page documents the workspace picker TUI (the default `sivtr` interface). The single-buffer browser that `pipe`/`run`/`import` used was removed — those commands now write to history and open the external editor.
 
 ## Workspace picker
 
-The workspace picker is used by agent-session pickers and command-block pickers.
+`pipe`/`run`/`import` no longer open a TUI; the picker is reached by running bare `sivtr`, via `copy --pick`, the session picker hotkey, or session import.
 
 | Key | Action |
 | --- | --- |
@@ -64,28 +15,55 @@ The workspace picker is used by agent-session pickers and command-block pickers.
 | `1` | Focus Sessions pane |
 | `2` | Focus Dialogues pane |
 | `3` | Focus Content pane |
-| `j` / `Down` | Move down in focused pane |
-| `k` / `Up` | Move up in focused pane |
-| `h` / `Left` | Focus previous pane |
-| `l` / `Right` | Focus next pane |
-| `Space` | Toggle current source, session, or dialogue |
-| `a` | Select all sources or toggle all dialogues, depending on pane |
-| `g` | Select agent sources in Source pane |
-| `t` | Select terminal source in Source pane, or open Vim-style full view elsewhere |
-| `v` | Range-select dialogues, or start visual text selection in Content pane |
-| `:` | Start a temporary line filter for the next copy |
-| `i` | Copy input/question |
-| `o` | Copy output/answer |
-| `y` | Copy input + output block |
-| `c` | Copy bare command when available |
-| `Enter` | Enter pane or copy current selection |
-| `Ctrl-D` / `PageDown` | Scroll Content down |
-| `Ctrl-U` / `PageUp` | Scroll Content up |
-| `r` | Toggle raw/read content mode in Content pane |
-| `z` | Toggle focused pane fullscreen |
-| `/` | Search all sessions |
-| `?` | Open help |
-| `q` / `Esc` | Cancel or go back |
+| `j` / `k` | Move down / up (Content: block cursor) |
+| `h` / `l` | Focus previous / next pane |
+| `Space` | Toggle source/session/dialogue, or mark a content block |
+| `a` | Select all sources (Source) or toggle all dialogues (Dialogues) |
+| `g` | Select agent sources (Source) or scroll Content to top |
+| `G` | Scroll Content to bottom |
+| `t` | Select terminal source (Source), or open the Vim-style full view |
+| `R` | Refresh the next level under the active rows |
+| `v` | Range-select rows (lists) or block-range mark a span (Content) |
+| `Tab` | Switch Content between Input and Output halves |
+| `r` | Toggle read/raw content mode in Content |
+| `Enter` | Focus next / copy (lists); fold/unfold the cursor block (Content) |
+| `i` / `o` / `y` / `c` | Copy input / output / input+output block / bare command |
+| `J` / `K` | Page next/previous selected dialogue (Content, multi-select) |
+| `z` | Toggle the focused pane fullscreen |
+| `?` | Toggle help overlay |
+| `/` | Open search |
+| `q` / `Esc` | Cancel / go back (Esc also goes up a pane level) |
+| `Ctrl-C` | Hard cancel |
+
+Content scrolling:
+
+| Key | Action |
+| --- | --- |
+| `Ctrl-D` / `PgDn` | Scroll Content down 10 lines |
+| `Ctrl-U` / `PgUp` | Scroll Content up 10 lines |
+
+## Structure-block folding
+
+Every workpart is a foldable block; tool call + result are grouped by call id. Consecutive structure units fold into a run tagged like `<:kind xN:>`.
+
+- **`Enter`** on the cursor block — fold/unfold.
+- **Single click** on a block tag — toggle it (Reading mode only; raw mode always full).
+- **Double-click** (< 400ms) — fold a block.
+- **`r`** — switch between read mode (markdown + fold tags) and raw mode (full payloads).
+
+Two levels: a run tag expands to reveal its members (still folded), and a member expands to show its body. Defaults: structure blocks collapsed, body blocks expanded.
+
+## Mouse
+
+| Gesture | Action |
+| --- | --- |
+| Wheel | Scroll (3 lines; Content smooth-scrolls) |
+| Click | Focus + select |
+| Click dot gutter | Toggle a block mark |
+| Drag | Linear select |
+| Ctrl-drag | Block select |
+| Double-click | Fold a block |
+| Click a link | Open it |
 
 ## Workspace search
 
@@ -95,6 +73,7 @@ The workspace picker is used by agent-session pickers and command-block pickers.
 | `Enter` | Accept search input |
 | `Esc` | Clear or close search |
 | `Backspace` | Edit query while input is open |
+| `Ctrl-U` | Clear the query |
 | `n` | Next match |
 | `N` | Previous match |
 
@@ -108,31 +87,26 @@ Search prefixes:
 
 ## Line filter input
 
-Opened from the workspace picker with `:`.
+Opened from the picker with `:`. Requires at least one dialogue.
 
 | Key | Action |
 | --- | --- |
 | digits, `,`, `:` | Build a 1-based line spec |
 | `Backspace` | Edit pending filter |
-| `Enter` | Apply to the next copy |
 | `Esc` | Clear/cancel |
 
-Examples: `2:8`, `1,3,8:12`.
+The filter applies to the next copy shortcut (`i`/`o`/`y`/`c`) automatically. Examples: `2:8`, `1,3,8:12`.
 
 ## Vim-style full view
 
-This view is opened from the picker with `t`.
+Opened from the picker with `t` on Sessions, Dialogues, or Content. Launches the real `vim` with bindings configured for block navigation and copying.
 
 | Key | Action |
 | --- | --- |
-| `[[` | Previous block |
-| `]]` | Next block |
 | `myy` | Copy block |
 | `myi` | Copy input |
 | `myo` | Copy output |
-| `myc` | Copy command |
 | `mvv` | Select block |
 | `mvi` | Select input |
 | `mvo` | Select output |
-| `T` | Toggle alternate tool view when available |
 | `p`, `q`, `Esc` | Return to picker |


### PR DESCRIPTION
## Purpose

Reference docs drifted behind v0.5.x.

## Changes

- cli.md: add group, origin, doctor, update, setup, zoom, work sections; drop stale 'single-buffer browser' claim (pipe/run open the external editor); expand mcp providers (Qoder/Qoder-CN, Gemini, Qwen, Goose)
- config-file.md: add [theme] mode and [mcp] idle_exit_secs sections; update provider list
- keybindings.md: rewrite to the current workspace picker only (single-buffer browser removed); document folding, mouse, J/K paging, read/raw, search prefixes, Vim view

## Validation

- Not run locally (bun docs build); CI will run the Docs site job.