### PR TITLE
docs(usage): align usage guides with v0.5 features

### DIFF
--- a/docs-site/src/content/docs/usage/ai-sessions.md
+++ b/docs-site/src/content/docs/usage/ai-sessions.md
@@ -1,6 +1,6 @@
 ---
 title: Agent Sessions
-description: Turn registered agent providers (Codex, Claude, Cursor, Hermes, OpenCode, OpenClaw, Grok, Pi, …) into reusable agent memory.
+description: Turn registered agent providers (Codex, Claude, Cursor, Hermes, OpenCode, OpenClaw, Grok, Pi, Dsh, Gemini, Goose, Qoder, Qwen, …) into reusable agent memory.
 ---
 
 `sivtr` treats agent transcripts as local workspace memory sources. You can copy the latest useful turn, browse older sessions in a picker, search across providers, and show exact refs without opening raw transcript files. Prior agent work becomes memory for both humans and later agents.
@@ -20,7 +20,12 @@ Providers come from the `AgentProvider` registry. Copy uses the same names:
 | OpenClaw | `sivtr copy openclaw ...` | OpenClaw agent SQLite (+ legacy JSONL) |
 | Hermes | `sivtr copy hermes ...` | Hermes `state.db` (JSONL under `sessions/` residual) |
 | Grok | `sivtr copy grok ...` | Grok sessions under `~/.grok` (`GROK_HOME`) |
+| Dsh | `sivtr copy dsh ...` | Dsh agent sessions |
+| Gemini | `sivtr copy gemini ...` | Gemini CLI sessions |
+| Goose | `sivtr copy goose ...` | Goose agent sessions |
 | Pi | `sivtr copy pi ...` | Pi session JSONL under the Pi agent directory |
+| Qoder / Qoder-CN | `sivtr copy qoder ...` | Qoder and Qoder-CN sessions |
+| Qwen | `sivtr copy qwen ...` | Qwen Code sessions |
 
 Use `agent` in search commands when you want all registered providers:
 
@@ -63,7 +68,7 @@ sivtr copy claude all
 | `tool` | Last tool output |
 | `all` | Whole parsed session |
 
-Replace `claude` with any registered provider name (`codex`, `cursor`, `hermes`, `opencode`, `openclaw`, `grok`, `pi`, …).
+Replace `claude` with any registered provider name (`codex`, `cursor`, `hermes`, `opencode`, `openclaw`, `grok`, `pi`, `dsh`, `gemini`, `goose`, `qoder`, `qodercn`, `qwen`, …).
 
 ## Select older items
 

--- a/docs-site/src/content/docs/usage/browse-and-select.md
+++ b/docs-site/src/content/docs/usage/browse-and-select.md
@@ -1,12 +1,9 @@
 ---
 title: Browse and Select
-description: Navigate the workspace browser and single-buffer browser, select text, and copy.
+description: Navigate the workspace browser, fold structure blocks, select, and copy.
 ---
 
-`sivtr` has two interactive surfaces:
-
-- the **workspace browser** (bare `sivtr` on a TTY, or `sivtr copy --pick` / hotkey): multi-source Source → Sessions → Dialogues → Content;
-- the **single-buffer browser** (piped stdin or `sivtr run` / `sivtr pipe`): one captured output buffer.
+The **workspace browser** (bare `sivtr` on a TTY, or `sivtr copy --pick` / hotkey) is the interactive surface: multi-source Source → Sessions → Dialogues → Content. `sivtr pipe` and `sivtr run` no longer open a TUI — they write to history and open the external editor.
 
 ## Open the workspace browser
 
@@ -26,48 +23,41 @@ Layout: Source · Sessions · Dialogues · Content. Content splits into **Input*
 | `0` / `1` / `2` / `3` | Focus Source, Sessions, Dialogues, or Content |
 | `h` / `l` | Previous / next pane |
 | `j` / `k` | Move down / up |
-| `Space` | Toggle selection (source, session, or dialogue) |
+| `Space` | Toggle selection (source, session, or dialogue) · mark a content block |
 | `a` | Select all sources (Source) · toggle all dialogues (Dialogues) |
 | `g` / `t` | Select agent sources / terminal source (Source) |
 | `R` | Refresh next level under active rows |
-| `v` | Range-select dialogues · visual text select on Content |
+| `v` | Range-select rows · block-range mark a span (Content) |
 | `Tab` | Switch Content Input ↔ Output half |
-| `r` | Toggle fold/full content (structure markers vs expanded payloads) |
+| `r` | Toggle read/raw content (structure markers + fold tags vs expanded payloads) |
 | `Ctrl-d` / `Ctrl-u` · `PgDn` / `PgUp` | Scroll content |
 | `g` / `G` | Content top / bottom |
+| `J` / `K` | Page next/previous selected dialogue (Content, multi-select) |
 | `i` / `o` / `y` / `c` | Copy input / output / block / command |
-| `Enter` | Confirm / open next / copy |
+| `Enter` | Confirm / open next / copy; fold/unfold the cursor block (Content) |
 | `/` | Search |
 | `z` | Toggle focused pane fullscreen |
-| `t` | Open Vim-style full view (Sessions/Dialogues) |
+| `t` | Open Vim-style full view (Sessions/Dialogues/Content) |
 | `?` | Help |
 | `q` / `Esc` | Quit / back |
 
-Mouse: drag on Content selects text; `Ctrl`-drag is block select. Source list expands when focused; unfocused stays a compact strip. Content half heights bias toward the focused half.
+Mouse: click focuses + selects; drag selects linearly and `Ctrl`-drag is block select; clicking the dot gutter toggles a block mark; a single/double click folds a structure block. Content half heights bias toward the focused half.
 
-Structure parts (tool / skill / thinking) show as `<:channel:…:>` markers in fold mode; `r` expands full payloads.
+### Structure blocks
+
+Every workpart is a foldable block, and tool call + result group into one block. Consecutive structure units (tool / skill / thinking) fold into a **run** shown as `<:kind xN:>`:
+
+- `Enter` on the cursor block folds/unfolds it.
+- Clicking a run tag expands it to its members; clicking a member expands its body (two levels).
+- `r` toggles read mode (markdown + fold tags) and raw mode (full payloads).
+
+Run members and tool calls are grouped by call id, so interleaved parallel tool calls pair correctly.
 
 See [Keybindings](/reference/keybindings/) for the full table.
 
-## Single-buffer browser
+## Copy to clipboard
 
-Pipe capture or `sivtr run` opens a Vim-shaped read-only browser for one buffer.
-
-| Key | Action |
-| --- | --- |
-| `j` / `k` · arrows | Move |
-| `Ctrl-D` / `Ctrl-U` | Half page |
-| `Ctrl-F` / `Ctrl-B` · Page keys | Page |
-| `gg` / `G` | Top / bottom |
-| `/` · `n` / `N` | Search · next / previous match |
-| `v` / `V` / `Ctrl-V` | Character / line / block select |
-| `y` | Copy selection |
-| mouse drag · `Ctrl`-drag | Select · block select |
-| `e` | Open selection (or whole buffer) in the configured editor |
-| `[[` / `]]` | Previous / next command block (session logs) |
-| `myy` / `myi` / `myo` / `myc` | Copy block / input / output / bare command |
-
-Configure the editor:
+Configure the editor used by `pipe`/`run`/`import` (not a TUI):
 
 ```toml
 [editor]

--- a/docs-site/src/content/docs/usage/capture-output.md
+++ b/docs-site/src/content/docs/usage/capture-output.md
@@ -11,13 +11,13 @@ Capture is the first step in turning terminal output into reusable text. Use the
 | --- | --- | --- |
 | Inspect one existing command pipeline | `command 2>&1 \| sivtr` | No |
 | Let `sivtr` run one command | `sivtr run command` | Partially, for the captured run |
-| Browse the current shell's recorded work | `sivtr import` | Yes, after shell integration |
+| Open the current shell's recorded work | `sivtr import` | Yes, after shell integration |
 | Copy one recent command block | `sivtr copy out` | Yes, after shell integration |
 | Search saved output history | `sivtr history search "query"` | Yes, for saved captures |
 
 ## Pipe mode
 
-Pipe mode reads stdin and opens the result.
+Pipe mode reads stdin, writes it to history (when enabled), and opens the result in the external editor.
 
 ```bash
 ls -la | sivtr
@@ -49,10 +49,10 @@ sivtr run git status --short
 Use run mode when:
 
 - you want `sivtr` to execute and capture a single command;
-- you want the exit status printed before browsing;
+- you want the exit status reported and the output saved before the editor opens;
 - you prefer not to manage shell redirection manually.
 
-Run mode captures stdout and stderr together. If the command produces no output, `sivtr` exits after reporting that nothing was captured.
+Run mode captures stdout and stderr together and saves the result to history. If the command produces no output, `sivtr` exits after reporting that nothing was captured.
 
 ## Shell session import
 
@@ -62,7 +62,7 @@ Shell integration records structured command entries over time. After installing
 sivtr import
 ```
 
-This is useful when you have been working normally and later want to browse the accumulated session as one workspace.
+This is useful when you have been working normally and later want to open the accumulated session in the editor.
 
 Install shell integration with:
 

--- a/docs-site/src/content/docs/usage/configuration.md
+++ b/docs-site/src/content/docs/usage/configuration.md
@@ -34,6 +34,12 @@ session_dirs = []
 
 [hotkey]
 chord = "alt+y"
+
+[theme]
+mode = "auto"
+
+[mcp]
+idle_exit_secs = 60
 ```
 
 For a field-by-field reference, see [Config File](/reference/config-file/).
@@ -81,3 +87,26 @@ Provider selection is a runtime CLI option, not a config key:
 sivtr hotkey start --provider all
 sivtr hotkey start --provider claude
 ```
+
+## TUI theme
+
+```toml
+[theme]
+mode = "auto"
+```
+
+`auto` follows the system appearance and picks the truecolor vs ANSI palette from the terminal. Force a scheme with `dark` or `light`:
+
+```toml
+[theme]
+mode = "dark"
+```
+
+## MCP idle exit
+
+```toml
+[mcp]
+idle_exit_secs = 60
+```
+
+Seconds without tool calls before the stdio MCP server exits (`0` = stay alive until the host closes stdin). The `sivtr mcp serve --idle-exit` flag overrides this per invocation.

--- a/docs-site/src/content/docs/usage/launchers-and-hotkeys.md
+++ b/docs-site/src/content/docs/usage/launchers-and-hotkeys.md
@@ -77,7 +77,7 @@ sivtr hotkey start --provider all
 sivtr hotkey start --provider claude
 ```
 
-Supported provider values are `all`, `codex`, `claude`, `hermes`, `opencode`, and `pi`.
+Supported provider values are `all`, `codex`, `claude`, `hermes`, `opencode`, `pi`, `cursor`, `openclaw`, `grok`, `dsh`, `gemini`, `goose`, `qoder`, `qodercn`, and `qwen`.
 
 When the chord is pressed, the daemon opens a terminal running an internal picker command for the daemon working directory. The picker tries the newest non-empty current session first and falls back to the session list.
 

--- a/docs-site/src/content/docs/usage/remote-access.md
+++ b/docs-site/src/content/docs/usage/remote-access.md
@@ -73,6 +73,31 @@ sivtr peer list
 sivtr peer forget <peer>
 ```
 
+## Groups
+
+When more than two devices want long-lived shared memory, instead of each pair doing `share` + `remote add`, form a **group**: a named set of devices that share memory with each other. Every member contributes workspaces, and membership syncs automatically.
+
+```bash
+# Owner on device A:
+sivtr group create <name>        # create the group and contribute the current workspace
+sivtr group invite <name> --expires 1d --max-uses 10   # multi-device join link (stdout = bare key)
+
+# Member on device B:
+sivtr group join <invite>        # join and contribute your own workspace
+sivtr group list
+sivtr group members <name>
+sivtr group sync <name>          # force a roster pull from the owner
+```
+
+The owner manages the group: `rename` renames it, `remove <group> <peer>` kicks a member, and an owner `leave` disbands the group. Membership changes broadcast to every member automatically, so teammates' memory appears under their peer name without any further setup:
+
+```bash
+sivtr s <peer>:terminal --status failure --latest 5 --refs
+sivtr s <peer>:agent -m "decision" --latest 20 --refs
+```
+
+Group access is read-only and redacts secrets just like shares. Groups and one-off shares are independent: you can use both, or only one.
+
 ## Use remote memory
 
 Remotes work with the same WorkSet surface as local sources:
@@ -122,6 +147,8 @@ See [Data Locations](/reference/data-locations/) and [Local-first and Privacy](/
 | `sivtr share` | Interactive share (no invite) |
 | `sivtr share add\|list\|invite\|grants\|revoke...` | Manage shares |
 | `sivtr remote add\|list\|remove\|rename\|test` | Manage remotes in the current workspace |
+| `sivtr group create\|invite\|join\|list\|members\|remove\|rename\|leave\|sync` | Manage shared-memory groups |
+| `sivtr origin rename` | Rename a local workspace alias or remote mount |
 | `sivtr peer list\|forget` | Manage known peer identities |
 | `sivtr serve ...` | Manage the device daemon |
 | `sivtr ws list` | List local workspace origin labels |

--- a/docs-site/src/content/docs/usage/skills.md
+++ b/docs-site/src/content/docs/usage/skills.md
@@ -25,7 +25,7 @@ sivtr mcp install -y
 sivtr mcp install -p claude,cursor -l global
 ```
 
-This writes `sivtr mcp serve` into host config for registered hosts (Claude Code, Cursor, Codex, OpenCode, OpenClaw, Grok, Hermes, Pi, …). MCP tools: `sivtr_search`, `sivtr_show`, `sivtr_zoom`, `sivtr_filter`, `sivtr_status` (includes local workspace origin labels from `ws` and remotes). The skill still teaches *when* and *how* to retrieve evidence; MCP is the structured execution surface. See [CLI Reference](/reference/cli/#mcp).
+This writes `sivtr mcp serve` into host config for registered hosts (Claude Code, Cursor, Codex, OpenCode, OpenClaw, Grok, Hermes, Pi, Qoder/Qoder-CN, Gemini, Qwen, Goose, …). MCP tools: `sivtr_search`, `sivtr_show`, `sivtr_zoom`, `sivtr_filter`, `sivtr_status` (includes local workspace origin labels from `ws` and remotes). The skill still teaches *when* and *how* to retrieve evidence; MCP is the structured execution surface. See [CLI Reference](/reference/cli/#mcp).
 
 ## Why skills matter
 


### PR DESCRIPTION
## Purpose

Usage guides drifted behind v0.5.x.

## Changes

- remote-access.md: add Groups section + command map rows (group, origin)
- configuration.md: full default config (theme, mcp); theme + MCP idle-exit sections
- browse-and-select.md: remove dead single-buffer browser; document structure-block folding, mouse, J/K paging, read/raw
- capture-output.md: pipe/run/import now open the external editor (not a TUI)
- ai-sessions.md: add Dsh, Gemini, Goose, Qoder/Qoder-CN, Qwen providers
- skills.md: update MCP host list
- launchers-and-hotkeys.md: full provider list

## Validation

- CI will run the Docs site job.