### PR TITLE
docs(zh-cn): mirror reference and usage alignment

### DIFF
--- a/docs-site/src/content/docs/zh-cn/reference/cli.md
+++ b/docs-site/src/content/docs/zh-cn/reference/cli.md
@@ -15,7 +15,7 @@ sivtr --all              # 裸 TTY 打开时也选中 remote mount
 不提供命令时：
 
 - **TTY** → 多源 workspace 浏览器（Source / Sessions / Dialogues / Content）。
-- **管道 stdin** → 单缓冲浏览器（等价 `sivtr pipe`）。
+- **管道 stdin** → 等价 `sivtr pipe`：写入历史后用外部编辑器打开。
 
 ## run
 
@@ -427,6 +427,53 @@ sivtr show @last --full
 sivtr show @ctx -f timeline
 ```
 
+## zoom
+
+```bash
+sivtr zoom [SOURCE=@last] [OPTIONS]
+```
+
+把每个目标 WorkRecord 用同一 session 的相邻 records 展开。未给 source 时默认 `@last`。
+
+| 选项 | 含义 |
+| --- | --- |
+| `-C, --context <N>` | 每个 anchor 前后各取 N 条（默认 `1`） |
+| `--before <N>` | 每个 anchor 前取 N 条 |
+| `--after <N>` | 每个 anchor 后取 N 条 |
+| `--cwd <PATH>` | 用于解析 sessions 的 workspace 目录 |
+| `--json` | `--format workset` 别名 |
+| `--refs` | `--format refs` 别名 |
+| `-f, --format <FORMAT>` | `full`、`timeline`、`compact`、`md`、`refs`、`workset` |
+| `--save <NAME>` | 把展开结果保存为命名 WorkSet 变量 |
+
+```bash
+sivtr zoom                        # 展开 @last
+sivtr zoom claude/<session>/3 -C 2
+sivtr zoom @failures --before 2 --after 0 --refs
+```
+
+## work
+
+```bash
+sivtr work <COMMAND>
+```
+
+遍历 workspace 的 sessions、records、parts，只输出 marker 级信息（不打印全文），可管道给其他命令。
+
+| 命令 | 含义 |
+| --- | --- |
+| `sessions [SOURCE]` | 列出当前 workspace 的 terminal 与 agent sessions |
+| `records <SOURCE>` | 把 sessions 或已保存变量转成事件级 refs |
+| `parts <SOURCE>` | 从匹配事件里抽出真正有用的输入/输出片段 |
+
+常用 flag：`--provider <NAME>` 过滤、`--cwd <PATH>`、`--json`、`--refs`、`--save <NAME>`。
+
+```bash
+sivtr work sessions
+sivtr work records codex/ --refs
+sivtr work parts @last --kind output --save out_parts
+```
+
 ## serve
 
 ```bash
@@ -531,6 +578,54 @@ sivtr peer list
 sivtr peer forget <peer>
 ```
 
+## group
+
+```bash
+sivtr group <COMMAND>
+```
+
+群组是互相共享记忆的一组设备：每个成员贡献 workspace，成员变更自动同步。
+
+| 命令 | 含义 |
+| --- | --- |
+| `create <NAME> [--workspace PATH] [--share-name NAME]` | 建组并在同一事务里贡献当前 workspace |
+| `invite <GROUP> [--expires DURATION] [--max-uses N]` | 仅 owner；签发多设备 join 链接（stdout = bare key） |
+| `join <INVITE> [--workspace PATH] [--share-name NAME] [--no-redact]` | 兑换邀请并贡献 workspace；重跑可调整贡献 |
+| `list` | 列出你所属的组 |
+| `members <GROUP>` | 列出成员及其贡献 |
+| `remove <GROUP> <PEER>` | 仅 owner；移除成员 |
+| `rename <GROUP> <NAME>` | 仅 owner；给组改名 |
+| `leave <GROUP>` | 退出组（owner 退出会解散整组） |
+| `sync <GROUP>` | 强制从 owner 拉一次成员清单 |
+
+```bash
+sivtr group create team
+sivtr group invite team --expires 1d --max-uses 10
+sivtr group join <invite-key>
+sivtr group list
+sivtr group members team
+sivtr group sync team
+```
+
+成员变更会自动广播给每个成员（并每 5 分钟 TTL 重新拉取）。成员对他人贡献的访问是只读的，默认脱敏密钥，与 share 一致。
+
+## origin
+
+```bash
+sivtr origin <COMMAND>
+```
+
+所有可寻址来源的统一改名入口——一个名字既代表本地 workspace 别名，也代表远端 mount，通过 origin registry 解析。
+
+| 命令 | 含义 |
+| --- | --- |
+| `rename <NAME> <NEW_NAME>` | 改本地 workspace 别名或远端 mount 的名字；两种都走同一条命令 |
+
+```bash
+sivtr origin rename docs knowledge
+sivtr origin rename desk alice-desk
+```
+
 ## workspace
 
 ```bash
@@ -591,7 +686,7 @@ sivtr mcp uninstall -p all -y
 
 | 选项 | 含义 |
 | --- | --- |
-| `-p, --provider` | Provider 宿主：`claude`、`cursor`、`codex`、`opencode`、`openclaw`、`grok`、`pi`、`hermes` 或 `all`。省略则自动检测已安装宿主。 |
+| `-p, --provider` | Provider 宿主：`claude`、`cursor`、`codex`、`opencode`、`openclaw`、`grok`、`hermes`、`pi`、`qoder`、`qodercn`、`gemini`、`qwen`、`goose` 或 `all`。省略则自动检测已安装宿主。 |
 | `-l, --location` | `global`（默认）或 `local` |
 | `-y, --yes` | 非交互 |
 
@@ -607,6 +702,10 @@ sivtr mcp uninstall -p all -y
 | Grok | Grok config TOML → MCP entry |
 | Hermes | Hermes YAML → `mcp_servers.sivtr` |
 | Pi | Pi config → `mcpServers.sivtr` |
+| Qoder / Qoder-CN | Qoder settings.json → MCP entry |
+| Gemini | Gemini settings.json → `mcpServers.sivtr` |
+| Qwen | Qwen settings.json → MCP entry |
+| Goose | Goose config.yaml extensions → MCP entry |
 
 注册命令始终为：
 
@@ -623,6 +722,7 @@ sivtr mcp print-config claude
 sivtr mcp print-config cursor
 sivtr mcp print-config codex
 sivtr mcp print-config grok
+sivtr mcp print-config goose
 ```
 
 MCP 不是完整 CLI 镜像。交互、写入和捕获命令仍走 CLI。策略仍在 `sivtr-memory` skill。
@@ -650,6 +750,49 @@ Verbose 输出包含：
 - 检测到的 repo root；
 - 本地 `target/debug/sivtr` binary 状态；
 - 在 repo 内运行不同的全局 binary 时给出 warning。
+
+## doctor
+
+```bash
+sivtr doctor [--fix] [--json]
+```
+
+诊断安装与环境：binary、config、session logs、shell hooks、provider session 数量、clipboard 与可用更新。
+
+| 选项 | 含义 |
+| --- | --- |
+| `--fix` | 尝试自动修复检测到的问题 |
+| `--json` | 机器可读 JSON 输出 |
+
+```bash
+sivtr doctor
+sivtr doctor --fix
+sivtr doctor --json
+```
+
+## update
+
+```bash
+sivtr update
+```
+
+自更新到最新 GitHub release：下载匹配平台的资产，校验 SHA256 后原地替换 binary。
+
+```bash
+sivtr update
+```
+
+## setup
+
+```bash
+sivtr setup
+```
+
+新装一键配置：检测环境、安装 shell hooks、给检测到的 agent 宿主注册 MCP server、缺失时安装 `sivtr-memory` skill，并跑一次 smoke test。等价于分步执行 `sivtr init`、`sivtr mcp install`、skill 安装与 `sivtr doctor`。
+
+```bash
+sivtr setup
+```
 
 ## history
 

--- a/docs-site/src/content/docs/zh-cn/reference/config-file.md
+++ b/docs-site/src/content/docs/zh-cn/reference/config-file.md
@@ -28,6 +28,12 @@ session_dirs = ["/srv/sivtr/root-codex/sessions"]
 
 [hotkey]
 chord = "alt+y"
+
+[theme]
+mode = "auto"
+
+[mcp]
+idle_exit_secs = 60
 ```
 
 ## editor
@@ -76,7 +82,7 @@ session_dirs = []
 
 在 macOS 上，典型共享路径是 `/Users/Shared/sivtr/root-codex/sessions`。
 
-目前只有 Codex mirror 在这里配置。其他已注册 provider（Claude、Cursor、OpenCode、OpenClaw、Hermes、Grok、Pi…）使用各自本地位置和环境信号。
+目前只有 Codex mirror 在这里配置。其他已注册 provider（Claude、Cursor、OpenCode、OpenClaw、Hermes、Grok、Pi、Dsh、Gemini、Goose、Qoder/Qoder-CN、Qwen…）使用各自本地位置和环境信号。
 
 ## hotkey
 
@@ -88,3 +94,27 @@ chord = "alt+y"
 | Key | 类型 | 默认值 | 含义 |
 | --- | --- | --- | --- |
 | `chord` | string | `"alt+y"` | `sivtr hotkey start` 使用的按键 |
+
+## theme
+
+```toml
+[theme]
+mode = "auto"
+```
+
+| Key | 类型 | 默认值 | 含义 |
+| --- | --- | --- | --- |
+| `mode` | string | `"auto"` | TUI 配色方案：`auto`、`dark` 或 `light` |
+
+`auto` 跟随系统外观（macOS/Linux XDG/Windows registry），并根据终端能力选择 truecolor 或 ANSI 调色板。`dark` 和 `light` 强制调色板。未知值和拼写错误（如 `mode = "ligth"`）是硬错误。
+
+## mcp
+
+```toml
+[mcp]
+idle_exit_secs = 60
+```
+
+| Key | 类型 | 默认值 | 含义 |
+| --- | --- | --- | --- |
+| `idle_exit_secs` | integer | `60` | 无工具调用多少秒后 stdio MCP server 退出；`0` 表示保持到宿主关闭 stdin。`sivtr mcp serve --idle-exit` flag 覆盖此值。 |

--- a/docs-site/src/content/docs/zh-cn/reference/keybindings.md
+++ b/docs-site/src/content/docs/zh-cn/reference/keybindings.md
@@ -1,62 +1,13 @@
 ---
 title: 快捷键
-description: Browser、命令块、picker、搜索、行过滤和 Vim view 快捷键。
+description: Workspace picker、Content、搜索、行过滤和 Vim view 快捷键。
 ---
 
-## Browser
-
-Browser 用于 pipe mode、run mode 和 session import。
-
-| 按键 | 模式 | 动作 |
-| --- | --- | --- |
-| `j` / `Down` | Normal, Insert, Visual | 下移 |
-| `k` / `Up` | Normal, Insert, Visual | 上移 |
-| `h` / `Left` | Normal, Insert, Visual | 左移 |
-| `l` / `Right` | Normal, Insert, Visual | 右移 |
-| `0` / `Home` | Normal, Insert, Visual | 行首 |
-| `^` | Normal, Insert, Visual | 第一个非空白列 |
-| `$` / `End` | Normal, Insert, Visual | 行尾 |
-| `Ctrl-D` | Normal, Insert, Visual | 下翻半页 |
-| `Ctrl-U` | Normal, Insert, Visual | 上翻半页 |
-| `Ctrl-F` / `PageDown` | Normal, Insert, Visual | 下翻页 |
-| `Ctrl-B` / `PageUp` | Normal, Insert, Visual | 上翻页 |
-| `gg` | Normal, Visual | 顶部 |
-| `G` | Normal, Visual | 底部 |
-| `H` | Normal, Visual | 视口顶部 |
-| `M` | Normal, Visual | 视口中间 |
-| `L` | Normal, Visual | 视口底部 |
-| `/` | Normal, Insert | 搜索 |
-| `n` | Normal | 下一个匹配 |
-| `N` | Normal | 上一个匹配 |
-| `i` | Normal | Insert mode |
-| `v` | Normal, Visual | 字符选择 |
-| `V` | Normal, Visual | 行选择 |
-| `Ctrl-V` | Normal, Visual | 块选择 |
-| `o` | Visual | 交换选择锚点 |
-| `y` | Visual | 复制选择 |
-| `e` | Normal, Visual | 打开编辑器 |
-| `Esc` | Insert, Visual, Search | 取消当前模式 |
-| `q` | Normal | 退出 |
-
-## 命令块导航
-
-仅当 buffer 有解析后的命令块时可用。
-
-| 按键 | 动作 |
-| --- | --- |
-| `[[` | 上一个命令块 |
-| `]]` | 下一个命令块 |
-| `myy` | 复制当前命令块 |
-| `myi` | 复制当前命令输入 |
-| `myo` | 复制当前命令输出 |
-| `myc` | 复制当前裸命令 |
-| `mvv` | 选择当前命令块 |
-| `mvi` | 选择当前命令输入 |
-| `mvo` | 选择当前命令输出 |
+本页记录 workspace picker TUI（默认的 `sivtr` 界面）。`pipe`/`run`/`import` 使用的单缓冲 browser 已移除——这些命令现在写入历史并用外部编辑器打开。
 
 ## Workspace picker
 
-Workspace picker 用于 AI session picker 和命令块 picker。
+运行裸 `sivtr`、`copy --pick`、session picker 热键或 session import 进入 picker。
 
 | 按键 | 动作 |
 | --- | --- |
@@ -64,28 +15,55 @@ Workspace picker 用于 AI session picker 和命令块 picker。
 | `1` | 聚焦 Sessions 面板 |
 | `2` | 聚焦 Dialogues 面板 |
 | `3` | 聚焦 Content 面板 |
-| `j` / `Down` | 在聚焦面板中下移 |
-| `k` / `Up` | 在聚焦面板中上移 |
-| `h` / `Left` | 聚焦前一个面板 |
-| `l` / `Right` | 聚焦后一个面板 |
-| `Space` | 切换当前 source、session 或 dialogue |
-| `a` | 按面板不同，选择所有 source 或切换所有 dialogue |
-| `g` | 在 Source 面板中选择 agent sources |
-| `t` | 在 Source 面板选择 terminal source，或在其他位置打开 Vim-style full view |
-| `v` | Range-select dialogues，或在 Content 面板开始可视文本选择 |
-| `:` | 为下一次复制启动临时行过滤 |
-| `i` | 复制输入/问题 |
-| `o` | 复制输出/回答 |
-| `y` | 复制输入 + 输出块 |
-| `c` | 在可用时复制裸命令 |
-| `Enter` | 进入面板或复制当前选择 |
-| `Ctrl-D` / `PageDown` | Content 下滚 |
-| `Ctrl-U` / `PageUp` | Content 上滚 |
-| `r` | 在 Content 面板切换 raw/read content mode |
+| `j` / `k` | 下移 / 上移（Content：块光标） |
+| `h` / `l` | 聚焦上一个 / 下一个面板 |
+| `Space` | 切换 source/session/dialogue，或标记 content 块 |
+| `a` | 全选 sources（Source）或切换所有 dialogues（Dialogues） |
+| `g` | 选择 agent sources（Source）或 Content 滚动到顶部 |
+| `G` | Content 滚动到底部 |
+| `t` | 选择 terminal source（Source），或打开 Vim-style full view |
+| `R` | 在活动行下刷新下一级 |
+| `v` | Range-select 行（列表）或块区间标记 span（Content） |
+| `Tab` | 切换 Content 的 Input / Output 半区 |
+| `r` | 切换 Content 的 read/raw mode |
+| `Enter` | 聚焦下一个 / 复制（列表）；折叠/展开光标块（Content） |
+| `i` / `o` / `y` / `c` | 复制输入 / 输出 / 输入+输出块 / 裸命令 |
+| `J` / `K` | 翻页上一个/下一个已选 dialogue（Content，多选） |
 | `z` | 当前面板全屏切换 |
-| `/` | 搜索所有 session |
-| `?` | 打开帮助 |
-| `q` / `Esc` | 取消或返回 |
+| `?` | 切换帮助浮层 |
+| `/` | 打开搜索 |
+| `q` / `Esc` | 取消 / 返回（Esc 也逐级上退面板） |
+| `Ctrl-C` | 硬取消 |
+
+Content 滚动：
+
+| 按键 | 动作 |
+| --- | --- |
+| `Ctrl-D` / `PgDn` | Content 下滚 10 行 |
+| `Ctrl-U` / `PgUp` | Content 上滚 10 行 |
+
+## 结构块折叠
+
+每个 workpart 都是可折叠块；工具调用 + 结果按 call id 分组。连续的结构单元折叠成 `<:kind xN:>` 标签。
+
+- **`Enter`** 光标块——折叠/展开。
+- **单击** 块标签——切换（仅 Reading mode；raw mode 始终展开）。
+- **双击**（< 400ms）——折叠块。
+- **`r`**——切换 read mode（markdown + 折叠标签）和 raw mode（完整载荷）。
+
+两层：run 标签展开显示其成员（成员仍折叠），成员再展开显示正文。默认：结构块折叠、正文块展开。
+
+## 鼠标
+
+| 手势 | 动作 |
+| --- | --- |
+| 滚轮 | 滚动（3 行；Content 平滑滚动） |
+| 单击 | 聚焦 + 选择 |
+| 单击点状 gutter | 切换块标记 |
+| 拖拽 | 线性选择 |
+| Ctrl-拖拽 | 块选择 |
+| 双击 | 折叠块 |
+| 单击链接 | 打开它 |
 
 ## Workspace 搜索
 
@@ -95,6 +73,7 @@ Workspace picker 用于 AI session picker 和命令块 picker。
 | `Enter` | 接受搜索输入 |
 | `Esc` | 清除或关闭搜索 |
 | `Backspace` | 输入打开时编辑 query |
+| `Ctrl-U` | 清除 query |
 | `n` | 下一个匹配 |
 | `N` | 上一个匹配 |
 
@@ -108,31 +87,26 @@ Workspace picker 用于 AI session picker 和命令块 picker。
 
 ## 行过滤输入
 
-在 workspace picker 中按 `:` 打开。
+在 picker 中按 `:` 打开。需要至少一个 dialogue。
 
 | 按键 | 动作 |
 | --- | --- |
 | 数字、`,`、`:` | 构建 1-based 行 spec |
 | `Backspace` | 编辑待应用过滤 |
-| `Enter` | 应用到下一次复制 |
 | `Esc` | 清除/取消 |
 
-示例：`2:8`、`1,3,8:12`。
+过滤自动应用到下一次复制快捷键（`i`/`o`/`y`/`c`）。示例：`2:8`、`1,3,8:12`。
 
 ## Vim-style full view
 
-在 picker 中按 `t` 打开。
+在 Sessions、Dialogues 或 Content 中按 `t` 打开。启动真实 `vim`，并配置块导航与复制绑定。
 
 | 按键 | 动作 |
 | --- | --- |
-| `[[` | 上一个块 |
-| `]]` | 下一个块 |
 | `myy` | 复制块 |
 | `myi` | 复制输入 |
 | `myo` | 复制输出 |
-| `myc` | 复制命令 |
 | `mvv` | 选择块 |
 | `mvi` | 选择输入 |
 | `mvo` | 选择输出 |
-| `T` | 在可用时切换 alternate tool view |
 | `p`, `q`, `Esc` | 返回 picker |

--- a/docs-site/src/content/docs/zh-cn/usage/ai-sessions.md
+++ b/docs-site/src/content/docs/zh-cn/usage/ai-sessions.md
@@ -1,6 +1,6 @@
 ---
 title: Agent 会话
-description: 把已注册 Agent provider（Codex、Claude、Cursor、Hermes、OpenCode、OpenClaw、Grok、Pi…）变成可复用的 Agent 记忆。
+description: 把已注册 Agent provider（Codex、Claude、Cursor、Hermes、OpenCode、OpenClaw、Grok、Pi、Dsh、Gemini、Goose、Qoder、Qwen…）变成可复用的 Agent 记忆。
 ---
 
 `sivtr` 把 Agent transcript 当成本地 workspace memory source。你可以复制最新的有用 turn，在 picker 中浏览旧 session，跨 provider 搜索，并通过精确 ref 展示内容，而不必手动打开原始 transcript 文件。过去的 Agent 工作会成为人和后续 Agent 都能复用的记忆。
@@ -20,7 +20,12 @@ Provider 来自 `AgentProvider` registry。copy 使用同一组名字：
 | OpenClaw | `sivtr copy openclaw ...` | OpenClaw agent SQLite（+ legacy JSONL） |
 | Hermes | `sivtr copy hermes ...` | Hermes `state.db`（`sessions/` 下 JSONL 为 residual） |
 | Grok | `sivtr copy grok ...` | Grok sessions（`~/.grok`，可用 `GROK_HOME`） |
+| Dsh | `sivtr copy dsh ...` | Dsh agent sessions |
+| Gemini | `sivtr copy gemini ...` | Gemini CLI sessions |
+| Goose | `sivtr copy goose ...` | Goose agent sessions |
 | Pi | `sivtr copy pi ...` | Pi agent 目录下的 session JSONL |
+| Qoder / Qoder-CN | `sivtr copy qoder ...` | Qoder 与 Qoder-CN sessions |
+| Qwen | `sivtr copy qwen ...` | Qwen Code sessions |
 
 在 search 命令中，用 `agent` target 表示所有已注册 provider：
 
@@ -63,7 +68,7 @@ sivtr copy claude all
 | `tool` | 最近工具输出 |
 | `all` | 完整解析会话 |
 
-把 `claude` 换成任意已注册 provider 名（`codex`、`cursor`、`hermes`、`opencode`、`openclaw`、`grok`、`pi`…）即可。
+把 `claude` 换成任意已注册 provider 名（`codex`、`cursor`、`hermes`、`opencode`、`openclaw`、`grok`、`pi`、`dsh`、`gemini`、`goose`、`qoder`、`qodercn`、`qwen`…）即可。
 
 ## 选择更早内容
 

--- a/docs-site/src/content/docs/zh-cn/usage/browse-and-select.md
+++ b/docs-site/src/content/docs/zh-cn/usage/browse-and-select.md
@@ -1,12 +1,9 @@
 ---
 title: 浏览和选择
-description: 导航 workspace 浏览器与单缓冲浏览器，选择文本并复制。
+description: 导航 workspace 浏览器、折叠结构块、选择并复制。
 ---
 
-`sivtr` 有两个交互界面：
-
-- **workspace 浏览器**（TTY 下裸 `sivtr`，或 `sivtr copy --pick` / 热键）：多源 Source → Sessions → Dialogues → Content；
-- **单缓冲浏览器**（管道 stdin 或 `sivtr run` / `sivtr pipe`）：单个捕获输出缓冲区。
+**workspace 浏览器**（TTY 下裸 `sivtr`，或 `sivtr copy --pick` / 热键）是交互界面：多源 Source → Sessions → Dialogues → Content。`sivtr pipe` 和 `sivtr run` 不再打开 TUI——它们写入历史并用外部编辑器打开。
 
 ## 打开 workspace 浏览器
 
@@ -26,48 +23,41 @@ sivtr copy claude --pick
 | `0` / `1` / `2` / `3` | 聚焦 Source、Sessions、Dialogues 或 Content |
 | `h` / `l` | 上一 / 下一面板 |
 | `j` / `k` | 下移 / 上移 |
-| `Space` | 切换选择（source / session / dialogue） |
+| `Space` | 切换选择（source / session / dialogue）· 标记 content 块 |
 | `a` | 全选 source（Source）· 切换全部 dialogue（Dialogues） |
 | `g` / `t` | 选 agent 源 / terminal 源（Source） |
 | `R` | 刷新活动行下一级 |
-| `v` | Dialogue 范围选择 · Content 视觉选字 |
+| `v` | Range-select 行 · 块区间标记 span（Content） |
 | `Tab` | Content 半窗 Input ↔ Output |
-| `r` | 折叠 / 展开结构标记与完整载荷 |
+| `r` | 切换 read/raw content（结构标记 + 折叠标签 vs 完整载荷） |
 | `Ctrl-d` / `Ctrl-u` · `PgDn` / `PgUp` | 滚动 Content |
 | `g` / `G` | Content 顶 / 底 |
+| `J` / `K` | 翻页上一/下一个已选 dialogue（Content，多选） |
 | `i` / `o` / `y` / `c` | 复制输入 / 输出 / 块 / 命令 |
-| `Enter` | 确认 / 打开下一级 / 复制 |
+| `Enter` | 确认 / 打开下一级 / 复制；折叠/展开光标块（Content） |
 | `/` | 搜索 |
 | `z` | 当前面板全屏 |
-| `t` | Vim 风格 full view（Sessions/Dialogues） |
+| `t` | Vim 风格 full view（Sessions/Dialogues/Content） |
 | `?` | 帮助 |
 | `q` / `Esc` | 退出 / 返回 |
 
-鼠标：Content 上拖选文本；`Ctrl`-拖为块选。Source 聚焦时纵向展开，失焦为紧凑条。Content 半窗高度偏向当前焦点半窗。
+鼠标：单击聚焦 + 选择；拖拽线性选择，`Ctrl`-拖为块选；点击点状 gutter 切换块标记；单击/双击折叠结构块。Content 半窗高度偏向当前焦点半窗。
 
-结构 part（tool / skill / thinking）在折叠模式显示为 `<:channel:…:>` 标记；`r` 展开完整载荷。
+### 结构块
+
+每个 workpart 都是可折叠块，工具调用 + 结果按 call id 分组。连续结构单元（tool / skill / thinking）折叠成 `<:kind xN:>` run：
+
+- `Enter` 折叠/展开光标块。
+- 单击 run 标签展开成员；单击成员展开正文（两层）。
+- `r` 切换 read mode（markdown + 折叠标签）和 raw mode（完整载荷）。
+
+run 成员和工具调用按 call id 分组，交错的并行工具调用也能正确配对。
 
 完整按键见[快捷键](/zh-cn/reference/keybindings/)。
 
-## 单缓冲浏览器
+## 复制到剪贴板
 
-管道捕获或 `sivtr run` 打开 Vim 风格只读浏览器，浏览单个缓冲区。
-
-| 按键 | 动作 |
-| --- | --- |
-| `j` / `k` · 方向键 | 移动 |
-| `Ctrl-D` / `Ctrl-U` | 半页 |
-| `Ctrl-F` / `Ctrl-B` · Page 键 | 整页 |
-| `gg` / `G` | 顶 / 底 |
-| `/` · `n` / `N` | 搜索 · 下一 / 上一匹配 |
-| `v` / `V` / `Ctrl-V` | 字符 / 行 / 块选择 |
-| `y` | 复制选择 |
-| 鼠标拖 · `Ctrl`-拖 | 选字 · 块选 |
-| `e` | 把选择（或整缓冲）交给配置的编辑器 |
-| `[[` / `]]` | 上一 / 下一命令块（session log） |
-| `myy` / `myi` / `myo` / `myc` | 复制块 / 输入 / 输出 / 裸命令 |
-
-配置编辑器：
+配置 `pipe`/`run`/`import` 使用的编辑器（不是 TUI）：
 
 ```toml
 [editor]

--- a/docs-site/src/content/docs/zh-cn/usage/capture-output.md
+++ b/docs-site/src/content/docs/zh-cn/usage/capture-output.md
@@ -11,13 +11,13 @@ description: 使用 pipe mode、run mode 和 shell session import。
 | --- | --- | --- |
 | 查看已有命令管道的输出 | `command 2>&1 \| sivtr` | 否 |
 | 让 `sivtr` 执行一次命令 | `sivtr run command` | 部分保留本次运行信息 |
-| 浏览当前 shell 记录的工作 | `sivtr import` | 是，需要 shell 集成 |
+| 打开当前 shell 记录的工作 | `sivtr import` | 是，需要 shell 集成 |
 | 复制最近命令块 | `sivtr copy out` | 是，需要 shell 集成 |
 | 搜索保存过的输出历史 | `sivtr history search "query"` | 是，针对保存的捕获 |
 
 ## Pipe mode
 
-Pipe mode 读取 stdin 并打开结果。
+Pipe mode 读取 stdin，启用时写入历史，并用外部编辑器打开结果。
 
 ```bash
 ls -la | sivtr
@@ -49,10 +49,10 @@ sivtr run git status --short
 适合在这些情况下使用：
 
 - 你希望 `sivtr` 执行并捕获单个命令；
-- 你希望浏览前看到退出状态；
+- 你希望编辑器打开前先报告退出状态并把输出存入历史；
 - 你不想手动处理 shell 重定向。
 
-Run mode 会合并捕获 stdout 和 stderr。如果命令没有输出，`sivtr` 会提示没有捕获内容后退出。
+Run mode 会合并捕获 stdout 和 stderr，并把结果存入历史。如果命令没有输出，`sivtr` 会提示没有捕获内容后退出。
 
 ## Shell session import
 
@@ -62,7 +62,7 @@ Shell 集成会持续记录结构化命令条目。安装后打开当前 session
 sivtr import
 ```
 
-当你已经正常工作了一段时间，之后想把累积的 session 当成一个工作区浏览时，这很有用。
+当你已经正常工作了一段时间，之后想在编辑器里打开累积的 session 时，这很有用。
 
 安装 shell 集成：
 

--- a/docs-site/src/content/docs/zh-cn/usage/configuration.md
+++ b/docs-site/src/content/docs/zh-cn/usage/configuration.md
@@ -34,6 +34,12 @@ session_dirs = []
 
 [hotkey]
 chord = "alt+y"
+
+[theme]
+mode = "auto"
+
+[mcp]
+idle_exit_secs = 60
 ```
 
 字段级说明见[配置文件](/zh-cn/reference/config-file/)。
@@ -81,3 +87,26 @@ Provider 选择是运行时 CLI 选项，不是配置项：
 sivtr hotkey start --provider all
 sivtr hotkey start --provider claude
 ```
+
+## TUI 主题
+
+```toml
+[theme]
+mode = "auto"
+```
+
+`auto` 跟随系统外观，并根据终端能力选择 truecolor 或 ANSI 调色板。用 `dark` 或 `light` 强制配色：
+
+```toml
+[theme]
+mode = "dark"
+```
+
+## MCP 空闲退出
+
+```toml
+[mcp]
+idle_exit_secs = 60
+```
+
+无工具调用多少秒后 stdio MCP server 退出（`0` = 保持到宿主关闭 stdin）。`sivtr mcp serve --idle-exit` flag 可在单次调用时覆盖此值。

--- a/docs-site/src/content/docs/zh-cn/usage/launchers-and-hotkeys.md
+++ b/docs-site/src/content/docs/zh-cn/usage/launchers-and-hotkeys.md
@@ -77,7 +77,7 @@ sivtr hotkey start --provider all
 sivtr hotkey start --provider claude
 ```
 
-支持的 provider 值是 `all`、`codex`、`claude`、`opencode` 和 `pi`。
+支持的 provider 值是 `all`、`codex`、`claude`、`opencode`、`pi`、`cursor`、`openclaw`、`grok`、`hermes`、`dsh`、`gemini`、`goose`、`qoder`、`qodercn` 和 `qwen`。
 
 按下热键后，daemon 会打开一个终端，在 daemon 工作目录中运行内部 picker 命令。Picker 会先尝试最新的非空当前 session，再回退到 session 列表。
 

--- a/docs-site/src/content/docs/zh-cn/usage/remote-access.md
+++ b/docs-site/src/content/docs/zh-cn/usage/remote-access.md
@@ -73,6 +73,31 @@ sivtr peer list
 sivtr peer forget <peer>
 ```
 
+## 群组（group）
+
+当两台以上设备需要长期共享记忆时，与其每对都做 `share` + `remote add`，不如组成一个**群组**：一组互相共享记忆的设备。每个成员贡献 workspace，成员自动同步。
+
+```bash
+# 组主（owner）在 A 机上：
+sivtr group create <name>        # 建组并贡献当前 workspace
+sivtr group invite <name> --expires 1d --max-uses 10   # 多设备 join 链接（stdout = bare key）
+
+# 成员在 B 机上：
+sivtr group join <invite>        # 加入并贡献自己的 workspace
+sivtr group list
+sivtr group members <name>
+sivtr group sync <name>          # 强制从 owner 拉一次成员清单
+```
+
+组由 owner 管理：`rename` 改名、`remove <group> <peer>` 踢人，owner 退出（`leave`）会解散整组。成员变更自动广播给每个成员，队友的记忆会直接出现在他们的 peer 名下，无需额外设置：
+
+```bash
+sivtr s <peer>:terminal --status failure --latest 5 --refs
+sivtr s <peer>:agent -m "decision" --latest 20 --refs
+```
+
+群组访问是只读的，默认脱敏密钥，与 share 一致。群组与一次性 share 相互独立：可以只用其中一种，也可以都用。
+
 ## 使用远端记忆
 
 remote 与本地 source 使用同一套 WorkSet 表面：
@@ -122,6 +147,8 @@ sivtr serve stop
 | `sivtr share` | 交互式 share（不出 invite） |
 | `sivtr share add\|list\|invite\|grants\|revoke...` | 管理 share |
 | `sivtr remote add\|list\|remove\|rename\|test` | 管理当前 workspace 的 remote |
+| `sivtr group create\|invite\|join\|list\|members\|remove\|rename\|leave\|sync` | 管理共享记忆群组 |
+| `sivtr origin rename` | 改本地 workspace 别名或远端 mount |
 | `sivtr peer list\|forget` | 管理已知 peer |
 | `sivtr serve ...` | 管理设备 daemon |
 | `sivtr ws list` | 列出本机 workspace 标签 |

--- a/docs-site/src/content/docs/zh-cn/usage/skills.md
+++ b/docs-site/src/content/docs/zh-cn/usage/skills.md
@@ -25,7 +25,7 @@ sivtr mcp install -y
 sivtr mcp install -p claude,cursor -l global
 ```
 
-这会把 `sivtr mcp serve` 写入已注册宿主配置（Claude Code、Cursor、Codex、OpenCode、OpenClaw、Grok、Hermes、Pi…）。MCP 工具：`sivtr_search`、`sivtr_show`、`sivtr_zoom`、`sivtr_filter`、`sivtr_status`（含 `ws` 本机 origin 标签和 remotes）。skill 仍负责教 *何时/如何* 取证；MCP 是结构化执行面。见 [CLI 参考](/zh-cn/reference/cli/#mcp)。
+这会把 `sivtr mcp serve` 写入已注册宿主配置（Claude Code、Cursor、Codex、OpenCode、OpenClaw、Grok、Hermes、Pi、Qoder/Qoder-CN、Gemini、Qwen、Goose…）。MCP 工具：`sivtr_search`、`sivtr_show`、`sivtr_zoom`、`sivtr_filter`、`sivtr_status`（含 `ws` 本机 origin 标签和 remotes）。skill 仍负责教 *何时/如何* 取证；MCP 是结构化执行面。见 [CLI 参考](/zh-cn/reference/cli/#mcp)。
 
 ## 为什么需要 skill
 


### PR DESCRIPTION
## Purpose

Mirror the English docs alignment (PRs #164/#165) into zh-cn.

## Changes

- cli.md: add group, origin, doctor, update, setup, zoom, work; expand mcp providers; drop stale single-buffer browser claim
- config-file.md: add [theme] mode, [mcp] idle_exit_secs
- keybindings.md: rewrite to current picker (folding, mouse, J/K, read/raw)
- remote-access.md: add Groups section + command map
- browse-and-select.md: remove dead single-buffer browser, document structure blocks
- capture-output.md / ai-sessions.md / launchers-and-hotkeys.md / skills.md / configuration.md: providers + theme/mcp

## Validation

- CI will run the Docs site job.