### PR TITLE
docs: sync skills provider list and release token note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,8 @@ How this project versions and releases changes. AI agents must follow this when 
 
 Merge gate for the Release PR: release-plz pushes its branch with `GITHUB_TOKEN`, so GitHub does not run CI on it and the required status checks never go green — only the maintainer bypass can merge it. (Optional: swap in a workflow-capable PAT secret to restore CI on the Release PR.)
 
+The tag step (`release-plz-release.yml`) pushes the `vX.Y.Z` tag with `RELEASE_PLZ_TOKEN` (a PAT). `GITHUB_TOKEN` pushes do not trigger other workflows, so the PAT is required for the tag push to fire `release.yml`. Both secrets must be set: `GITHUB_TOKEN` (auto) for the action's git-author step and `RELEASE_PLZ_TOKEN` for the tag push.
+
 ### Branch discipline
 
 - One branch per task; merge back to main within 2–3 days. No long-lived parallel branches.

--- a/skills/sivtr-memory/SKILL.md
+++ b/skills/sivtr-memory/SKILL.md
@@ -56,7 +56,7 @@ Mental model to keep in mind:
 - In shell pipelines, `@` means "read the WorkSet JSON from stdin". Do not pipe `--refs` text into `@`; either omit `--refs` in intermediate commands or use `@last` / `@name`.
 
 1. Convert the user's vague reference into a small query.
-2. Choose a source: `terminal`, `agent`, or a provider (`codex`, `claude`, `cursor`, `opencode`, `openclaw`, `grok`, `hermes`, `pi`, `qoder`), a WorkRef selector, an origin-prefixed source such as `desk:terminal` / `docs:agent`, or a WorkSet variable such as `@last` / `@name[1,3]`.
+2. Choose a source: `terminal`, `agent`, or a provider (`codex`, `claude`, `cursor`, `opencode`, `openclaw`, `grok`, `hermes`, `pi`, `qoder`, `qodercn`, `dsh`, `gemini`, `goose`, `qwen`), a WorkRef selector, an origin-prefixed source such as `desk:terminal` / `docs:agent`, or a WorkSet variable such as `@last` / `@name[1,3]`.
 3. Search is BM25-primary: a plain-text positional `QUERY` (no regex) ranks the whole source by relevance; `-m` / `--match` is an optional case-insensitive regex that bounds the set first, and the QUERY (or `--match` text alone) then ranks it. Use `--last` / `--since` for time windows, `-i` / `--in` for field filters, and `--kind` for part kinds (`prompt`, `command`, `user`, `assistant`, `tool`, `tool_call`, `tool_result`, `skill`, `thinking`, `output`, `error`).
    - Latest terminal error: `sivtr s terminal --status fail --latest 1 --save latest_failure --refs`
    - Broader terminal error scan: `sivtr s terminal "error" --latest 20 --save error_hits --refs` or `sivtr s terminal -m "Error|error|failed|fatal|not found|External command failed" --latest 20 --save error_hits --refs`

--- a/skills/sivtr-memory/references/commands.md
+++ b/skills/sivtr-memory/references/commands.md
@@ -10,7 +10,7 @@ Source forms:
 
 - `terminal`: terminal command records
 - `agent`: AI/agent conversation records from all providers
-- `codex`, `claude`, `cursor`, `opencode`, `openclaw`, `grok`, `hermes`, `pi`, `qoder`: one provider's conversation records
+- `codex`, `claude`, `cursor`, `opencode`, `openclaw`, `grok`, `hermes`, `pi`, `qoder`, `qodercn`, `dsh`, `gemini`, `goose`, `qwen`: one provider's conversation records
 - `terminal/<session>/<record>`, `<provider>/<session>/<turn>`, or `<provider>/<session>/<turn>/p<part>` for input/output part refs
 - `origin:body` for another local workspace name or a named remote, for example `desk:terminal`, `docs:codex/4`
 - `@last`, `@name`, `@name[1]`, `@name[1,3]`, `@name[1..5]`, `@name[1..3,8]`


### PR DESCRIPTION
## Purpose

Finish the docs alignment pass (skills + AGENTS.md).

## Changes

- skills/sivtr-memory/SKILL.md: full provider list (Dsh, Gemini, Goose, Qoder-CN, Qwen)
- skills/sivtr-memory/references/commands.md: same provider list
- AGENTS.md: document that the release tag is pushed with RELEASE_PLZ_TOKEN so release.yml fires (GITHUB_TOKEN pushes do not trigger workflows)

## Validation

- Docs build unaffected; AGENTS.md is repo-instruction only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving conversation records from Qwen and Goose providers.
  * Added Gemini as a supported provider source for conversation records.

* **Documentation**
  * Clarified release workflow requirements for version tags and automated release authentication.
  * Documented the credentials used for tagging and action-based Git operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->