### PR TITLE
feat(search): add all: scope for unified cross-origin retrieval

### DIFF
--- a/crates/sivtr-core/src/origin.rs
+++ b/crates/sivtr-core/src/origin.rs
@@ -92,6 +92,11 @@ impl OriginRegistry {
         self.entries.iter().map(|entry| &entry.origin)
     }
 
+    /// Entries (display origin + reach payload) in construction order.
+    pub fn entries(&self) -> impl Iterator<Item = &Entry> + '_ {
+        self.entries.iter()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }

--- a/skills/sivtr-memory/SKILL.md
+++ b/skills/sivtr-memory/SKILL.md
@@ -95,6 +95,7 @@ Source forms:
 - `terminal`, `agent`, `codex`, `claude`, `cursor`, `opencode`, `openclaw`, `grok`, `hermes`, `pi`, `qoder`
 - `terminal/<session>/<record>`, `<provider>/<session>/<turn>`, `<provider>/<session>/<turn>/p<part>`, and selector variants
 - `origin:body` for another local workspace or named remote, for example `desk:terminal/...`, `docs:codex/4`
+- `all:<src>` searches every origin as one corpus (all local workspaces plus the current workspace's remote mounts): `all:agent "workflow 最佳实践"`
 - `@last`, `@name`, `@name[1]`, `@name[1,3]`, `@name[1..5]`, `@name[1..3,8]`
 - `@` reads a WorkSet from stdin in shell pipelines
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -558,7 +558,8 @@ pub struct DiffArgs {
 
 #[derive(Args, Debug, Clone)]
 pub struct SearchArgs {
-    /// Source selector, e.g. terminal, agent, pi, pi/<session>/<turn>, terminal/<session>/<record>, @last, or @ctx[1,3]
+    /// Source selector, e.g. terminal, agent, pi, pi/<session>/<turn>, terminal/<session>/<record>, @last, or @ctx[1,3].
+    /// Prefix with `all:` (e.g. all:agent) to search every origin — all local workspaces plus the current workspace's remote mounts — as one corpus
     #[arg(value_name = "SOURCE")]
     pub source: String,
 

--- a/src/commands/memory/workset/source.rs
+++ b/src/commands/memory/workset/source.rs
@@ -6,7 +6,7 @@ use std::thread;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use sivtr_core::origin::Reach;
+use sivtr_core::origin::{Entry, Reach};
 use sivtr_core::query::{load_workspace_source, NO_RECORD_FOR_SELECTOR};
 use sivtr_core::record::{expand_source, WorkPath, WorkRecord, WorkRef};
 
@@ -40,6 +40,9 @@ pub struct QuerySource {
     /// Selector accepted by [`query`] (`codex`, `desk:terminal`, …).
     pub selector: String,
     pub transport: QueryTransport,
+    /// Local sources load from this root instead of the caller's cwd
+    /// (`None` = caller cwd). Lets one batch span many local workspaces.
+    pub root: Option<PathBuf>,
 }
 
 impl QuerySource {
@@ -47,6 +50,7 @@ impl QuerySource {
         Self {
             selector: selector.into(),
             transport: QueryTransport::Local,
+            root: None,
         }
     }
 
@@ -54,6 +58,22 @@ impl QuerySource {
         Self {
             selector: selector.into(),
             transport: QueryTransport::Remote,
+            root: None,
+        }
+    }
+
+    /// Build a source from a registry entry: local workspaces load from
+    /// their own root, remote mounts keep the `alias:path` selector the
+    /// peer-side dispatcher already understands. Adding an origin kind means
+    /// one new arm here — `query_many` then schedules it unchanged.
+    pub fn from_entry(entry: &Entry, source: &str) -> Self {
+        match &entry.reach {
+            Reach::Local { root } => Self {
+                selector: source.to_string(),
+                transport: QueryTransport::Local,
+                root: Some(PathBuf::from(root)),
+            },
+            Reach::Remote { .. } => Self::remote(format!("{}:{source}", entry.origin.name)),
         }
     }
 }
@@ -94,6 +114,9 @@ pub fn query(source: &str, filter: Filter, cwd: Option<&Path>) -> Result<WorkSet
         }
         if scope.eq_ignore_ascii_case("local") {
             return run_local(path, &cwd, filter);
+        }
+        if scope.eq_ignore_ascii_case("all") {
+            return run_all(path, &cwd, filter);
         }
         let scope = scope.to_ascii_lowercase();
 
@@ -137,12 +160,11 @@ pub fn query(source: &str, filter: Filter, cwd: Option<&Path>) -> Result<WorkSet
     run_local(&source, &cwd, filter)
 }
 
-/// Load many sources. Locals run first (fail hard); remotes run in parallel with
-/// a per-source timeout. Order of `results` matches `sources`.
-///
-/// This is the multi-source schedule layer shared by browse (and later search
-/// `--all`). Each remote still uses [`query`]; speedup comes from overlapping
-/// RTT and failing stuck peers without blocking the batch.
+/// Load many sources in parallel — local and remote share one scheduler.
+/// A local source may carry its own root ([`QuerySource::root`]) so one batch
+/// spans every local workspace; remotes run with a per-source timeout and
+/// out-of-order arrival, and a source's failure never drops the others.
+/// Order of `results` matches `sources`.
 pub fn query_many(
     sources: &[QuerySource],
     filter: Filter,
@@ -157,104 +179,67 @@ pub fn query_many(
         .map(Path::to_path_buf)
         .unwrap_or(std::env::current_dir().context("Failed to resolve current directory")?);
 
-    let mut results: Vec<Option<QuerySourceResult>> = sources.iter().map(|_| None).collect();
-
-    let mut remote_idxs = Vec::new();
-    for (idx, source) in sources.iter().enumerate() {
-        if source.transport == QueryTransport::Remote {
-            remote_idxs.push(idx);
-            continue;
-        }
-        match query(&source.selector, filter.clone(), Some(&cwd)) {
-            Ok(set) => results[idx] = Some(QuerySourceResult::Ok(set)),
-            Err(error) => {
-                let message = error.to_string();
-                // Empty selector is normal for browse; keep parity with single-source callers.
-                if message.starts_with(NO_RECORD_FOR_SELECTOR) {
-                    results[idx] = Some(QuerySourceResult::Ok(WorkSet::with_anchors(
-                        cwd.display().to_string(),
-                        Vec::new(),
-                        Vec::new(),
-                    )));
-                } else {
-                    return Err(error).context(format!("Failed to load `{}`", source.selector));
-                }
-            }
-        }
-    }
-
-    if remote_idxs.is_empty() {
-        return Ok(results
-            .into_iter()
-            .map(|slot| slot.expect("local result filled"))
-            .collect());
-    }
-
     let (tx, rx) = mpsc::channel();
-    let workers = remote_idxs.len();
-    for &idx in &remote_idxs {
-        let selector = sources[idx].selector.clone();
+    let mut pending = 0;
+    for (idx, source) in sources.iter().enumerate() {
+        let selector = source.selector.clone();
         let filter = filter.clone();
         let cwd = cwd.clone();
+        let root = source.root.clone();
+        let remote = source.transport == QueryTransport::Remote;
         let tx = tx.clone();
+        pending += 1;
         thread::spawn(move || {
-            let result = match query_remote_bounded(&selector, filter, &cwd, remote_timeout) {
-                Ok(set) => Ok(set),
-                Err(error) => {
-                    let message = error.to_string();
-                    if message.starts_with(NO_RECORD_FOR_SELECTOR) {
-                        Ok(WorkSet::with_anchors(
-                            cwd.display().to_string(),
-                            Vec::new(),
-                            Vec::new(),
-                        ))
-                    } else if is_timeout_error(&message) {
-                        Err("timeout".to_string())
-                    } else {
-                        Err(format!("{error:#}"))
-                    }
-                }
+            let result = if remote {
+                query_remote_bounded(&selector, filter, &cwd, remote_timeout)
+            } else {
+                query(&selector, filter, root.as_deref())
             };
-            let _ = tx.send((idx, result));
+            let normalized = normalize_source_result(result, &cwd);
+            let _ = tx.send((idx, normalized));
         });
     }
     drop(tx);
 
-    let mut remaining = workers;
+    let mut results: Vec<Option<QuerySourceResult>> = sources.iter().map(|_| None).collect();
+    let mut remaining = pending;
     while remaining > 0 {
-        match rx.recv_timeout(remote_timeout + Duration::from_secs(1)) {
-            Ok((idx, Ok(set))) => {
-                results[idx] = Some(QuerySourceResult::Ok(set));
+        match rx.recv() {
+            Ok((idx, result)) => {
+                results[idx] = Some(result);
                 remaining -= 1;
             }
-            Ok((idx, Err(message))) => {
-                results[idx] = Some(QuerySourceResult::Err(message));
-                remaining -= 1;
-            }
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                for &idx in &remote_idxs {
-                    if results[idx].is_none() {
-                        results[idx] = Some(QuerySourceResult::Err("timeout".to_string()));
-                    }
-                }
-                break;
-            }
-            Err(mpsc::RecvTimeoutError::Disconnected) => {
-                for &idx in &remote_idxs {
-                    if results[idx].is_none() {
-                        results[idx] =
-                            Some(QuerySourceResult::Err("load worker exited".to_string()));
-                    }
-                }
-                break;
-            }
+            Err(_) => break, // all senders dropped
         }
     }
 
     Ok(results
         .into_iter()
-        .map(|slot| slot.expect("every source has a result"))
+        .map(|slot| slot.unwrap_or(QuerySourceResult::Err("load worker exited".to_string())))
         .collect())
+}
+
+/// Canonical per-source outcome: an empty selector (no records for the
+/// source, e.g. a workspace without terminal logs) is an empty result, not an
+/// error — the batch keeps the rest. Timeouts report as `timeout`.
+fn normalize_source_result(result: Result<WorkSet>, cwd: &Path) -> QuerySourceResult {
+    match result {
+        Ok(set) => QuerySourceResult::Ok(set),
+        Err(error) => {
+            let message = error.to_string();
+            if message.starts_with(NO_RECORD_FOR_SELECTOR) {
+                QuerySourceResult::Ok(WorkSet::with_anchors(
+                    cwd.display().to_string(),
+                    Vec::new(),
+                    Vec::new(),
+                ))
+            } else if is_timeout_error(&message) {
+                QuerySourceResult::Err("timeout".to_string())
+            } else {
+                QuerySourceResult::Err(format!("{error:#}"))
+            }
+        }
+    }
 }
 
 fn query_remote_bounded(
@@ -335,6 +320,44 @@ fn run_local(source: &str, root: &Path, filter: Filter) -> Result<WorkSet> {
         WorkSet::with_anchors(root.display().to_string(), result.records, result.anchors),
         filter,
     )
+}
+
+/// Load `source` from every addressable origin (all local workspaces plus the
+/// current workspace's remote mounts), merge them into one corpus, then apply
+/// the filter once — so reachability limit and relevance ranking are global
+/// across origins, not per-origin.
+fn run_all(source: &str, cwd: &Path, filter: Filter) -> Result<WorkSet> {
+    // Passive enumeration, same as `ws list` / `sivtr_status`: mounts are
+    // listed only while the daemon is already running. `all:` never starts
+    // the daemon, so a pure-local query is not blocked on daemon startup.
+    let registry = crate::origins::collect(cwd)?;
+
+    let sources: Vec<QuerySource> = registry
+        .entries()
+        .map(|entry| QuerySource::from_entry(entry, source))
+        .collect();
+    let results = query_many(&sources, Filter::none(), Some(cwd), REMOTE_QUERY_TIMEOUT)
+        .with_context(|| format!("failed to load `{source}` from every origin"))?;
+
+    // Merge with per-ref dedup: a workref may appear in more than one origin
+    // (same provider session recorded from multiple checkouts).
+    let mut records: Vec<WorkRecord> = Vec::new();
+    let mut seen: HashSet<WorkRef> = HashSet::new();
+    for result in results {
+        let QuerySourceResult::Ok(set) = result else {
+            output::warning(format!(
+                "skipped an origin during `all:{source}`: {result:?}"
+            ));
+            continue;
+        };
+        for record in set.records {
+            if seen.insert(record.work_ref.whole()) {
+                records.push(record);
+            }
+        }
+    }
+
+    apply_loaded(WorkSet::new(cwd.display().to_string(), records), filter)
 }
 
 fn apply_loaded(set: WorkSet, filter: Filter) -> Result<WorkSet> {

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -14,7 +14,9 @@ use crate::commands::memory::workset::WorkSet;
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct SearchParams {
-    /// Source selector: terminal, agent, pi, desk:terminal, @last, ...
+    /// Source selector: terminal, agent, pi, desk:terminal, @last, or all:<src>
+    /// (e.g. all:agent searches every origin — all local workspaces plus the
+    /// current workspace's remote mounts — as one corpus).
     pub source: String,
     /// Plain-text query: BM25 ranks the source by these terms (no regex).
     /// With match_regex present, the regex bounds the set and this query ranks it.


### PR DESCRIPTION
## What

Add `all:<source>` as a unified cross-origin retrieval scope.

- `sivtr s all:terminal` / `all:agent` searches every origin (local workspaces, remote mounts) through one parallel scheduler
- `QuerySource::from_entry` becomes the single construction path; the old `local_in` fork is removed
- `query_many` schedules one thread per source; `run_all` collects passively (no daemon start needed)

## Why

One corpus across all origins: find cross-workspace discussions (e.g. project conventions, workflow best practices) without knowing which workspace holds them.

## Validation

- `cargo test --workspace`, clippy `-D warnings`, fmt all clean
- Manual: `sivtr s all:agent "query"` returns merged results across origins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `all:` source selectors to search across local workspaces and mounted remotes.
  * Searches now run across multiple sources concurrently while preserving result order.
  * Combined searches remove duplicate records and continue when individual sources fail.

* **Documentation**
  * Updated command-line and integration documentation to explain supported source selectors and `all:` search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->