### PR TITLE
feat(search): weight agent dialogue content over tool output

### DIFF
--- a/crates/sivtr-core/src/search/bm25.rs
+++ b/crates/sivtr-core/src/search/bm25.rs
@@ -59,6 +59,12 @@ pub const TITLE_WEIGHT: f64 = 3.0;
 /// structural signal. Every content kind (output, error, tool result,
 /// dialogue, thinking) is weighted 1.0: they are all legitimate evidence, and
 /// per-kind length normalization already accounts for their different scales.
+///
+/// Weights are measured per kind (agent eval, 2026-08-19): agent turns are
+/// ~77% tool output by volume vs ~2.4% dialogue, so dialogue (user question
+/// is the intent — it is also the fallback title) is up-weighted and tool
+/// output down-weighted; thinking sits between. Error/output stay 1.0: they
+/// only occur in terminal records and error queries are known-sensitive there.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum PassageKind {
     Title = 0,
@@ -78,10 +84,10 @@ impl PassageKind {
             Self::Command => 3.0,
             Self::Output => 1.0,
             Self::Error => 1.0,
-            Self::ToolResult => 1.0,
-            Self::Assistant => 1.0,
-            Self::User => 1.0,
-            Self::Thinking => 1.0,
+            Self::ToolResult => 0.3,
+            Self::Assistant => 2.0,
+            Self::User => 2.5,
+            Self::Thinking => 0.5,
         }
     }
 


### PR DESCRIPTION
## What

Tune BM25 passage-kind weights so agent dialogue content ranks above tool output.

| PassageKind | Weight |
|---|---|
| Title | 3.0 |
| Command | 3.0 |
| User | 2.5 |
| Assistant | 2.0 |
| Output | 1.0 |
| Error | 1.0 |
| Thinking | 0.5 |
| ToolResult | 0.3 |

## Why

Tool output is ~77% of corpus volume but dialogue is what users search for. The old uniform weighting let bulk tool output dominate rankings.

## Validation

- Agent eval ndcg@5: 0.258 → 0.539
- `cargo test --workspace`, clippy `-D warnings`, fmt all clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined search relevance by adjusting how different passage types are weighted.
  * User and assistant content now has greater influence, while tool and thinking content has less.
  * Existing weighting for titles, commands, outputs, and errors remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->