### PR TITLE
chore: gitignore agent eval snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ session_*.log
 
 # Retrieval eval snapshot (real personal records; never commit)
 /eval-snapshot.json
+/eval-snapshot-agent.json
+/eval-snapshot-agent-baseline.json
 
 # Git worktree checkouts (linked repos live under worktrees/, never commit them)
 /worktrees/


### PR DESCRIPTION
## What

Gitignore `eval-snapshot-*.json` artifacts so they never get committed.

## Why

Eval snapshots are machine-generated, machine-specific benchmark inputs; they are re-created on demand by `sivtr eval --create-snapshot`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added ignore rules for agent and baseline evaluation snapshot files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->