### PR TITLE
feat(search)!: unify terminal and agent sources behind a SessionSource trait

### DIFF
--- a/crates/sivtr-core/src/agents/claude.rs
+++ b/crates/sivtr-core/src/agents/claude.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 
 use crate::agents::{
     extract_content_text, list_recent_jsonl_sessions, parse_jsonl_meta, parse_jsonl_session,
-    pretty_json_value, push_block, AgentBlockKind, AgentProvider, AgentSession, AgentSessionInfo,
-    AgentSessionMeta, AgentSessionProvider,
+    pretty_json_value, push_block, AgentBlockKind, AgentProvider, AgentSession, AgentSessionMeta,
+    AgentSessionProvider, SessionInfo,
 };
 
 const PROVIDER_NAME: &str = "Claude";
@@ -18,7 +18,7 @@ impl AgentSessionProvider for ClaudeProvider {
         AgentProvider::Claude
     }
 
-    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
         list_recent_jsonl_sessions(
             PROVIDER_NAME,
             &claude_home().join("projects"),

--- a/crates/sivtr-core/src/agents/codex.rs
+++ b/crates/sivtr-core/src/agents/codex.rs
@@ -6,8 +6,8 @@ use std::path::{Path, PathBuf};
 use crate::agents::{
     extract_content_text, jsonl_files, list_recent_jsonl_sessions, normalize_path_for_match,
     parse_jsonl_meta, parse_jsonl_session, pretty_json_string, pretty_json_value, push_block,
-    push_tool_block, AgentBlockKind, AgentProvider, AgentSession, AgentSessionInfo,
-    AgentSessionMeta, AgentSessionProvider,
+    push_tool_block, AgentBlockKind, AgentProvider, AgentSession, AgentSessionMeta,
+    AgentSessionProvider, SessionInfo,
 };
 use crate::config::SivtrConfig;
 
@@ -21,7 +21,7 @@ impl AgentSessionProvider for CodexProvider {
         AgentProvider::Codex
     }
 
-    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
         let mut sessions = Vec::new();
 
         for root in configured_codex_session_dirs() {
@@ -329,7 +329,7 @@ fn local_session_files() -> Result<Vec<PathBuf>> {
     jsonl_files(&local_codex_sessions_dir())
 }
 
-fn list_recent_local_sessions(cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+fn list_recent_local_sessions(cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
     list_recent_jsonl_sessions(
         PROVIDER_NAME,
         &local_codex_sessions_dir(),

--- a/crates/sivtr-core/src/agents/cursor.rs
+++ b/crates/sivtr-core/src/agents/cursor.rs
@@ -7,7 +7,7 @@ use std::time::UNIX_EPOCH;
 use crate::agents::{
     extract_content_text, jsonl_files, list_recent_jsonl_sessions, parse_jsonl_meta,
     parse_jsonl_session, pretty_json_value, push_block, AgentBlockKind, AgentProvider,
-    AgentSession, AgentSessionInfo, AgentSessionMeta, AgentSessionProvider,
+    AgentSession, AgentSessionMeta, AgentSessionProvider, SessionInfo,
 };
 
 const PROVIDER_NAME: &str = "Cursor";
@@ -26,7 +26,7 @@ impl AgentSessionProvider for CursorProvider {
         AgentProvider::Cursor
     }
 
-    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
         let root = cursor_transcripts_root();
         if !root.exists() {
             return Ok(Vec::new());
@@ -48,7 +48,7 @@ impl AgentSessionProvider for CursorProvider {
                 .file_stem()
                 .and_then(|s| s.to_str())
                 .map(str::to_string);
-            sessions.push(AgentSessionInfo {
+            sessions.push(SessionInfo {
                 path,
                 id,
                 cwd: None,

--- a/crates/sivtr-core/src/agents/dsh.rs
+++ b/crates/sivtr-core/src/agents/dsh.rs
@@ -29,8 +29,8 @@ use std::path::{Path, PathBuf};
 
 use crate::agents::{
     extract_content_text, list_sessions_matching, pretty_json_string, push_block, push_tool_block,
-    AgentBlockKind, AgentProvider, AgentSession, AgentSessionInfo, AgentSessionMeta,
-    AgentSessionProvider,
+    AgentBlockKind, AgentProvider, AgentSession, AgentSessionMeta, AgentSessionProvider,
+    SessionInfo,
 };
 
 const PROVIDER_NAME: &str = "Dsh";
@@ -63,7 +63,7 @@ impl AgentSessionProvider for DshProvider {
         AgentProvider::Dsh
     }
 
-    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
         let root = sessions_root();
         list_sessions_matching(
             PROVIDER_NAME,

--- a/crates/sivtr-core/src/agents/gemini.rs
+++ b/crates/sivtr-core/src/agents/gemini.rs
@@ -21,7 +21,7 @@
 use crate::agents::{
     extract_content_text, list_chat_recording_sessions, pretty_json_value, push_block,
     push_parts_blocks, push_tool_block, AgentBlockKind, AgentProvider, AgentSession,
-    AgentSessionInfo, AgentSessionMeta, AgentSessionProvider,
+    AgentSessionMeta, AgentSessionProvider, SessionInfo,
 };
 use anyhow::{Context, Result};
 use serde_json::Value;
@@ -44,7 +44,7 @@ impl AgentSessionProvider for GeminiProvider {
         AgentProvider::Gemini
     }
 
-    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
         list_chat_recording_sessions(PROVIDER_NAME, &gemini_tmp_dir(), cwd, parse_session_meta)
     }
 

--- a/crates/sivtr-core/src/agents/goose.rs
+++ b/crates/sivtr-core/src/agents/goose.rs
@@ -23,7 +23,7 @@ use std::path::{Path, PathBuf};
 use crate::agents::{
     extract_content_text, filter_sessions_by_workspace, open_readonly_db, pretty_json_value,
     push_block, push_tool_block, system_time_from_unix_secs, AgentBlockKind, AgentProvider,
-    AgentSession, AgentSessionInfo, AgentSessionProvider,
+    AgentSession, AgentSessionProvider, SessionInfo,
 };
 
 const SESSION_PATH_PREFIX: &str = "goose-session-";
@@ -37,7 +37,7 @@ impl AgentSessionProvider for GooseProvider {
         AgentProvider::Goose
     }
 
-    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
         let db_path = goose_db_path();
         if !db_path.exists() {
             return Ok(Vec::new());
@@ -60,7 +60,7 @@ impl AgentSessionProvider for GooseProvider {
         let mut sessions = Vec::new();
         for row in rows {
             let (id, working_dir, name, updated_secs) = row?;
-            sessions.push(AgentSessionInfo {
+            sessions.push(SessionInfo {
                 modified: system_time_from_unix_secs(updated_secs as f64),
                 path: goose_session_path(&id),
                 id: Some(id),

--- a/crates/sivtr-core/src/agents/grok.rs
+++ b/crates/sivtr-core/src/agents/grok.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use crate::agents::{
     extract_content_text, list_sessions_matching, parse_jsonl_session, pretty_json_string,
     pretty_json_value, push_block, push_tool_block, AgentBlockKind, AgentProvider, AgentSession,
-    AgentSessionInfo, AgentSessionMeta, AgentSessionProvider,
+    AgentSessionMeta, AgentSessionProvider, SessionInfo,
 };
 
 const PROVIDER_NAME: &str = "Grok";
@@ -39,7 +39,7 @@ impl AgentSessionProvider for GrokProvider {
         AgentProvider::Grok
     }
 
-    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
         list_sessions_matching(
             PROVIDER_NAME,
             &grok_sessions_dir(),

--- a/crates/sivtr-core/src/agents/hermes.rs
+++ b/crates/sivtr-core/src/agents/hermes.rs
@@ -8,7 +8,7 @@ use crate::agents::{
     extract_content_text, filter_sessions_by_workspace, list_recent_jsonl_sessions,
     open_readonly_db, parse_jsonl_meta, parse_jsonl_session, pretty_json_string, pretty_json_value,
     push_block, system_time_from_unix_secs, AgentBlockKind, AgentProvider, AgentSession,
-    AgentSessionInfo, AgentSessionMeta, AgentSessionProvider,
+    AgentSessionMeta, AgentSessionProvider, SessionInfo,
 };
 
 const PROVIDER_NAME: &str = "Hermes";
@@ -31,7 +31,7 @@ impl AgentSessionProvider for HermesProvider {
         AgentProvider::Hermes
     }
 
-    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
         let mut sessions = Vec::new();
         sessions.extend(list_sqlite_sessions()?);
         // JSONL residual: keep sessions not already covered by state.db.
@@ -119,7 +119,7 @@ pub fn hermes_state_db_path() -> PathBuf {
     hermes_home().join(STATE_DB_NAME)
 }
 
-fn list_sqlite_sessions() -> Result<Vec<AgentSessionInfo>> {
+fn list_sqlite_sessions() -> Result<Vec<SessionInfo>> {
     let db_path = hermes_state_db_path();
     if !db_path.exists() {
         return Ok(Vec::new());
@@ -160,7 +160,7 @@ fn list_sqlite_sessions() -> Result<Vec<AgentSessionInfo>> {
             .or_else(|| default_title(source.as_deref(), model.as_deref()));
 
         let modified = system_time_from_unix_secs(ended_at.unwrap_or(started_at));
-        sessions.push(AgentSessionInfo {
+        sessions.push(SessionInfo {
             path: sqlite_session_path(&id),
             id: Some(id),
             cwd: non_empty_opt(cwd),

--- a/crates/sivtr-core/src/agents/jsonl.rs
+++ b/crates/sivtr-core/src/agents/jsonl.rs
@@ -8,8 +8,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 use super::model::{
-    workspace_matches_candidates, AgentSession, AgentSessionInfo, AgentSessionMeta,
-    WorkspaceMatchTarget,
+    workspace_matches_candidates, AgentSession, AgentSessionMeta, SessionInfo, WorkspaceMatchTarget,
 };
 
 /// Bump when the listing cache layout or meta parsing changes.
@@ -62,7 +61,7 @@ pub fn list_recent_jsonl_sessions(
     root: &Path,
     cwd: Option<&Path>,
     parse_meta: impl Fn(&Path) -> Result<AgentSessionMeta>,
-) -> Result<Vec<AgentSessionInfo>> {
+) -> Result<Vec<SessionInfo>> {
     collect_recent_sessions(provider, root, cwd, is_jsonl_leaf, parse_meta)
 }
 
@@ -75,7 +74,7 @@ pub fn list_sessions_matching(
     cwd: Option<&Path>,
     is_session_leaf: impl Fn(&Path, bool) -> bool,
     parse_meta: impl Fn(&Path) -> Result<AgentSessionMeta>,
-) -> Result<Vec<AgentSessionInfo>> {
+) -> Result<Vec<SessionInfo>> {
     collect_recent_sessions(provider, root, cwd, is_session_leaf, parse_meta)
 }
 
@@ -90,7 +89,7 @@ pub fn list_chat_recording_sessions(
     tmp_root: &Path,
     cwd: Option<&Path>,
     parse_meta: impl Fn(&Path) -> Result<AgentSessionMeta>,
-) -> Result<Vec<AgentSessionInfo>> {
+) -> Result<Vec<SessionInfo>> {
     collect_recent_sessions(provider, tmp_root, cwd, is_chat_recording_leaf, parse_meta)
 }
 
@@ -117,7 +116,7 @@ fn collect_recent_sessions(
     cwd: Option<&Path>,
     is_session_leaf: impl Fn(&Path, bool) -> bool,
     parse_meta: impl Fn(&Path) -> Result<AgentSessionMeta>,
-) -> Result<Vec<AgentSessionInfo>> {
+) -> Result<Vec<SessionInfo>> {
     if !root.exists() {
         return Ok(Vec::new());
     }
@@ -248,7 +247,7 @@ fn collect_recent_sessions(
 }
 
 fn push_session(
-    sessions: &mut Vec<AgentSessionInfo>,
+    sessions: &mut Vec<SessionInfo>,
     path: PathBuf,
     modified: SystemTime,
     meta: AgentSessionMeta,
@@ -261,7 +260,7 @@ fn push_session(
         }
     }
 
-    sessions.push(AgentSessionInfo {
+    sessions.push(SessionInfo {
         modified,
         path,
         id: meta.id,

--- a/crates/sivtr-core/src/agents/mod.rs
+++ b/crates/sivtr-core/src/agents/mod.rs
@@ -8,7 +8,7 @@
 use std::path::Path;
 
 use crate::session_source::SessionSource;
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 pub mod claude;
 pub mod codex;
@@ -282,11 +282,18 @@ impl SessionSource for AgentProvider {
     }
 
     fn list_sessions(&self, cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
-        self.session_provider().list_recent_sessions(cwd)
+        self.session_provider()
+            .list_recent_sessions(cwd)
+            .with_context(|| format!("Failed to list {} sessions", self.name()))
     }
 
     fn parse_file(&self, path: &Path) -> Result<Vec<WorkRecord>> {
-        let session = self.session_provider().parse_session_file(path)?;
+        let session = self
+            .session_provider()
+            .parse_session_file(path)
+            .with_context(|| {
+                format!("Failed to parse {} session {}", self.name(), path.display())
+            })?;
         Ok(WorkRecord::chat_turns(*self, &session))
     }
 }

--- a/crates/sivtr-core/src/agents/mod.rs
+++ b/crates/sivtr-core/src/agents/mod.rs
@@ -5,6 +5,11 @@
 //! - [`sqlite`]: readonly SQLite helpers (OpenCode/OpenClaw)
 //! - per-provider modules keep only storage paths + schema mapping
 
+use std::path::Path;
+
+use crate::session_source::SessionSource;
+use anyhow::Result;
+
 pub mod claude;
 pub mod codex;
 pub mod cursor;
@@ -266,5 +271,22 @@ impl AgentProvider {
     /// Comma-separated registered provider CLI names for help and errors.
     pub fn command_names_csv() -> String {
         Self::command_names().collect::<Vec<_>>().join(", ")
+    }
+}
+
+use crate::record::WorkRecord;
+
+impl SessionSource for AgentProvider {
+    fn namespace(&self) -> &'static str {
+        self.command_name()
+    }
+
+    fn list_sessions(&self, cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
+        self.session_provider().list_recent_sessions(cwd)
+    }
+
+    fn parse_file(&self, path: &Path) -> Result<Vec<WorkRecord>> {
+        let session = self.session_provider().parse_session_file(path)?;
+        Ok(WorkRecord::chat_turns(*self, &session))
     }
 }

--- a/crates/sivtr-core/src/agents/model.rs
+++ b/crates/sivtr-core/src/agents/model.rs
@@ -4,7 +4,6 @@ use serde_json::Value;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::time::SystemTime;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum AgentProvider {
@@ -113,14 +112,7 @@ pub struct AgentSession {
     pub blocks: Vec<AgentBlock>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AgentSessionInfo {
-    pub path: PathBuf,
-    pub id: Option<String>,
-    pub cwd: Option<String>,
-    pub title: Option<String>,
-    pub modified: SystemTime,
-}
+pub use crate::session_source::SessionInfo;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AgentSessionMeta {
@@ -195,7 +187,7 @@ impl AgentSelection {
 pub trait AgentSessionProvider {
     fn provider(&self) -> AgentProvider;
 
-    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>>;
+    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<SessionInfo>>;
 
     fn parse_session_file(&self, path: &Path) -> Result<AgentSession>;
 
@@ -396,9 +388,9 @@ pub fn normalize_path_for_match(path: &Path) -> String {
 ///   (commondir identity) as the target, or exactly matches the target path
 ///   when neither side is inside a git checkout
 pub fn filter_sessions_by_workspace(
-    sessions: Vec<AgentSessionInfo>,
+    sessions: Vec<SessionInfo>,
     cwd: Option<&Path>,
-) -> Vec<AgentSessionInfo> {
+) -> Vec<SessionInfo> {
     let Some(cwd) = cwd else {
         return sessions;
     };
@@ -529,6 +521,7 @@ mod tests {
     use super::*;
     use crate::test_fixtures::{make_repo, make_worktree};
     use std::fs;
+    use std::time::SystemTime;
 
     #[test]
     fn cwd_candidates_do_not_duplicate_the_primary_cwd() {
@@ -600,21 +593,21 @@ mod tests {
         make_repo(&repo);
 
         let sessions = vec![
-            AgentSessionInfo {
+            SessionInfo {
                 path: PathBuf::from("unbound"),
                 id: Some("u".into()),
                 cwd: None,
                 title: None,
                 modified: SystemTime::UNIX_EPOCH,
             },
-            AgentSessionInfo {
+            SessionInfo {
                 path: PathBuf::from("match"),
                 id: Some("m".into()),
                 cwd: Some(repo.to_string_lossy().into_owned()),
                 title: None,
                 modified: SystemTime::UNIX_EPOCH,
             },
-            AgentSessionInfo {
+            SessionInfo {
                 path: PathBuf::from("other"),
                 id: Some("o".into()),
                 cwd: Some(dir.path().join("other").to_string_lossy().into_owned()),
@@ -641,7 +634,7 @@ mod tests {
 
         // A session recorded in the main checkout shows up when browsing the
         // worktree, and one recorded in the worktree shows up from the main.
-        let main_session = vec![AgentSessionInfo {
+        let main_session = vec![SessionInfo {
             path: PathBuf::from("main-session"),
             id: Some("m".into()),
             cwd: Some(main.to_string_lossy().into_owned()),
@@ -653,7 +646,7 @@ mod tests {
             1
         );
 
-        let worktree_session = vec![AgentSessionInfo {
+        let worktree_session = vec![SessionInfo {
             path: PathBuf::from("wt-session"),
             id: Some("w".into()),
             cwd: Some(worktree.to_string_lossy().into_owned()),

--- a/crates/sivtr-core/src/agents/openclaw.rs
+++ b/crates/sivtr-core/src/agents/openclaw.rs
@@ -8,7 +8,7 @@ use std::time::UNIX_EPOCH;
 use crate::agents::{
     extract_content_text, filter_sessions_by_workspace, jsonl_files, open_readonly_db,
     pretty_json_value, push_block, system_time_from_millis, AgentBlockKind, AgentProvider,
-    AgentSession, AgentSessionInfo, AgentSessionProvider,
+    AgentSession, AgentSessionProvider, SessionInfo,
 };
 
 const SESSION_PATH_PREFIX: &str = "openclaw-session-";
@@ -31,7 +31,7 @@ impl AgentSessionProvider for OpenClawProvider {
         AgentProvider::OpenClaw
     }
 
-    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
         let mut sessions = Vec::new();
         sessions.extend(list_sqlite_sessions()?);
         sessions.extend(list_legacy_jsonl_sessions()?);
@@ -107,7 +107,7 @@ fn agent_db_path(agent_id: &str) -> Option<PathBuf> {
     )
 }
 
-fn list_sqlite_sessions() -> Result<Vec<AgentSessionInfo>> {
+fn list_sqlite_sessions() -> Result<Vec<SessionInfo>> {
     let root = agents_dir();
     if !root.exists() {
         return Ok(Vec::new());
@@ -131,7 +131,7 @@ fn list_sqlite_sessions() -> Result<Vec<AgentSessionInfo>> {
     Ok(out)
 }
 
-fn list_sessions_from_db(db_path: &Path, agent_id: &str) -> Result<Vec<AgentSessionInfo>> {
+fn list_sessions_from_db(db_path: &Path, agent_id: &str) -> Result<Vec<SessionInfo>> {
     let conn = open_readonly_db(db_path)?;
     // Current OpenClaw schema: session_entries(session_key, session_id, entry_json, updated_at, ...)
     let mut stmt = match conn.prepare(
@@ -179,7 +179,7 @@ fn list_sessions_from_db(db_path: &Path, agent_id: &str) -> Result<Vec<AgentSess
             .map(str::to_string)
             .or_else(|| Some(session_key.clone()));
 
-        sessions.push(AgentSessionInfo {
+        sessions.push(SessionInfo {
             path: openclaw_session_path(agent_id, &session_id),
             id: Some(session_id),
             cwd,
@@ -236,7 +236,7 @@ fn parse_sqlite_session(db_path: &Path, agent_id: &str, session_id: &str) -> Res
     Ok(session)
 }
 
-fn list_legacy_jsonl_sessions() -> Result<Vec<AgentSessionInfo>> {
+fn list_legacy_jsonl_sessions() -> Result<Vec<SessionInfo>> {
     let root = agents_dir();
     if !root.exists() {
         return Ok(Vec::new());
@@ -265,7 +265,7 @@ fn list_legacy_jsonl_sessions() -> Result<Vec<AgentSessionInfo>> {
             let modified = fs::metadata(&path)
                 .and_then(|meta| meta.modified())
                 .unwrap_or(UNIX_EPOCH);
-            out.push(AgentSessionInfo {
+            out.push(SessionInfo {
                 path,
                 id: Some(id),
                 cwd: None,

--- a/crates/sivtr-core/src/agents/opencode.rs
+++ b/crates/sivtr-core/src/agents/opencode.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use crate::agents::{
     extract_content_text, filter_sessions_by_workspace, open_readonly_db, pretty_json_value,
     push_block, system_time_from_millis, AgentBlockKind, AgentProvider, AgentSession,
-    AgentSessionInfo, AgentSessionProvider,
+    AgentSessionProvider, SessionInfo,
 };
 
 const PROVIDER_NAME: &str = "OpenCode";
@@ -36,7 +36,7 @@ impl AgentSessionProvider for OpenCodeProvider {
         AgentProvider::OpenCode
     }
 
-    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
         let db_path = self.db_path();
         if !db_path.exists() {
             return Ok(Vec::new());
@@ -57,7 +57,7 @@ impl AgentSessionProvider for OpenCodeProvider {
         let mut sessions = Vec::new();
         for row in rows {
             let (id, session_cwd, updated, title) = row?;
-            sessions.push(AgentSessionInfo {
+            sessions.push(SessionInfo {
                 modified: system_time_from_millis(updated),
                 path: opencode_session_path(&id),
                 id: Some(id),

--- a/crates/sivtr-core/src/agents/pi.rs
+++ b/crates/sivtr-core/src/agents/pi.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 
 use crate::agents::{
     extract_content_text, list_recent_jsonl_sessions, parse_jsonl_meta, parse_jsonl_session,
-    pretty_json_value, push_block, AgentBlockKind, AgentProvider, AgentSession, AgentSessionInfo,
-    AgentSessionMeta, AgentSessionProvider,
+    pretty_json_value, push_block, AgentBlockKind, AgentProvider, AgentSession, AgentSessionMeta,
+    AgentSessionProvider, SessionInfo,
 };
 
 const PROVIDER_NAME: &str = "Pi";
@@ -18,7 +18,7 @@ impl AgentSessionProvider for PiProvider {
         AgentProvider::Pi
     }
 
-    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
         list_recent_jsonl_sessions(PROVIDER_NAME, &pi_sessions_dir(), cwd, parse_session_meta)
     }
 

--- a/crates/sivtr-core/src/agents/qoder.rs
+++ b/crates/sivtr-core/src/agents/qoder.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use crate::agents::{
     extract_content_text, filter_sessions_by_workspace, parse_jsonl_meta, parse_jsonl_session,
     pretty_json_value, push_block, push_tool_block, AgentBlockKind, AgentProvider, AgentSession,
-    AgentSessionInfo, AgentSessionMeta, AgentSessionProvider,
+    AgentSessionMeta, AgentSessionProvider, SessionInfo,
 };
 
 const PROVIDER_NAME: &str = "Qoder";
@@ -34,7 +34,7 @@ impl AgentSessionProvider for QoderProvider {
         AgentProvider::Qoder
     }
 
-    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
         list_recent_sessions_in(&qoder_projects_dir(), cwd)
     }
 
@@ -48,7 +48,7 @@ impl AgentSessionProvider for QoderCnProvider {
         AgentProvider::QoderCn
     }
 
-    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
         list_recent_sessions_in(&qoder_cn_projects_dir(), cwd)
     }
 
@@ -59,7 +59,7 @@ impl AgentSessionProvider for QoderCnProvider {
 
 /// Scan `projects/<cwd-slug>/<session>.jsonl` under `root`, newest first.
 /// Shared by the global and CN Qoder providers; only `root` differs.
-fn list_recent_sessions_in(root: &Path, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+fn list_recent_sessions_in(root: &Path, cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
     if !root.exists() {
         return Ok(Vec::new());
     }
@@ -86,7 +86,7 @@ fn list_recent_sessions_in(root: &Path, cwd: Option<&Path>) -> Result<Vec<AgentS
                     let modified = fs::metadata(&path)
                         .and_then(|m| m.modified())
                         .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-                    sessions.push(AgentSessionInfo {
+                    sessions.push(SessionInfo {
                         path,
                         id: meta.id,
                         cwd: meta.cwd,

--- a/crates/sivtr-core/src/agents/qwen.rs
+++ b/crates/sivtr-core/src/agents/qwen.rs
@@ -20,8 +20,8 @@ use std::path::{Path, PathBuf};
 
 use crate::agents::{
     list_chat_recording_sessions, parse_jsonl_session, pretty_json_value, push_parts_blocks,
-    push_tool_block, AgentBlockKind, AgentProvider, AgentSession, AgentSessionInfo,
-    AgentSessionMeta, AgentSessionProvider,
+    push_tool_block, AgentBlockKind, AgentProvider, AgentSession, AgentSessionMeta,
+    AgentSessionProvider, SessionInfo,
 };
 
 const PROVIDER_NAME: &str = "Qwen";
@@ -37,7 +37,7 @@ impl AgentSessionProvider for QwenProvider {
         AgentProvider::Qwen
     }
 
-    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
         list_chat_recording_sessions(PROVIDER_NAME, &qwen_tmp_dir(), cwd, parse_session_meta)
     }
 

--- a/crates/sivtr-core/src/lib.rs
+++ b/crates/sivtr-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod query;
 pub mod record;
 pub mod search;
 pub mod session;
+pub mod session_source;
 pub mod time;
 pub mod workspace;
 

--- a/crates/sivtr-core/src/query/mod.rs
+++ b/crates/sivtr-core/src/query/mod.rs
@@ -595,7 +595,8 @@ mod tests {
             ],
         };
         let mut skipped = Vec::new();
-        let records = records_from_source(&source, &cwd, Some(10), &mut skipped).unwrap();
+        let records =
+            records_from_source(&source, &cwd, Some(10), &mut skipped).expect("load records");
 
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].session.id, "good");

--- a/crates/sivtr-core/src/query/mod.rs
+++ b/crates/sivtr-core/src/query/mod.rs
@@ -13,10 +13,8 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::ai::AgentProvider;
-#[cfg(test)]
-use crate::ai::AgentSessionProvider;
 use crate::record::{WorkPath, WorkRecord, WorkRecordIndex, WorkRef, WorkRefSelector};
-use crate::{session, workspace};
+use crate::session_source::{source_by_namespace, workspace_sources, SessionSource};
 
 /// Prefix of the error [`load_workspace_source`] raises when a selector
 /// matches no records. An empty source is a normal browse outcome (a
@@ -70,36 +68,28 @@ pub enum LoadMode {
     Full,
 }
 
-/// Cache namespace for terminal session logs (no `AgentProvider` exists).
-pub const TERMINAL_NAMESPACE: &str = "terminal";
-
-/// Build the record index for a workspace: terminal records plus agent records
-/// for the given providers, deduplicated and sorted newest-first.
+/// Build the record index for a workspace: discover sessions from each
+/// source (terminal, agent providers, …), deduplicate records, and sort
+/// newest-first.
 ///
-/// `recent_sessions` truncates how many recent agent sessions each provider
-/// contributes (terminal logs are always fully loaded for the workspace).
+/// `recent_sessions` truncates how many recent sessions each source
+/// contributes.
 pub fn load_workspace_records(
-    providers: &[AgentProvider],
+    sources: &[Box<dyn SessionSource>],
     cwd: &Path,
     recent_sessions: Option<usize>,
     mode: LoadMode,
 ) -> Result<QueryResult> {
     let mut tasks: Vec<(&'static str, PathBuf)> = Vec::new();
-    tasks.extend(
-        workspace::terminal_log_paths_for_workspace(cwd)?
-            .into_iter()
-            .map(|path| (TERMINAL_NAMESPACE, path)),
-    );
-    for provider in providers {
-        let source = provider.session_provider();
-        let mut sessions = source.list_recent_sessions(Some(cwd))?;
+    for source in sources {
+        let mut sessions = source.list_sessions(Some(cwd))?;
         if let Some(limit) = recent_sessions {
             sessions.truncate(limit);
         }
         tasks.extend(
             sessions
                 .into_iter()
-                .map(|info| (provider.name(), info.path)),
+                .map(|info| (source.namespace(), info.path)),
         );
     }
 
@@ -130,7 +120,8 @@ pub fn load_workspace_source(
             .provider()
             .map(|provider| vec![provider])
             .unwrap_or_else(all_agent_providers);
-        let result = load_workspace_records(&providers, cwd, None, mode)?;
+        let sources = workspace_sources(&providers);
+        let result = load_workspace_records(&sources, cwd, None, mode)?;
         let index = WorkRecordIndex::new(result.records);
         let record = index
             .resolve(&reference)
@@ -144,7 +135,9 @@ pub fn load_workspace_source(
     }
 
     let selector: WorkRefSelector = source.parse()?;
-    let result = load_workspace_records(&selector.providers(), cwd, None, mode)?;
+    let providers = selector.providers();
+    let sources = workspace_sources(&providers);
+    let result = load_workspace_records(&sources, cwd, None, mode)?;
     let mut records = Vec::new();
     let mut anchors = Vec::new();
 
@@ -190,26 +183,11 @@ pub fn load_session_records(
     if let Some(records) = load_cached_view(&cache_path, path) {
         return Ok(records);
     }
-    let records = parse_session_file(namespace, path)?;
+    let source = source_by_namespace(namespace)
+        .with_context(|| format!("unknown session namespace `{namespace}`"))?;
+    let records = source.parse_file(path)?;
     store_cached_session(namespace, path, &records);
     Ok(records)
-}
-
-/// Parse one session file into records, dispatching by source namespace:
-/// terminal logs vs provider transcripts.
-fn parse_session_file(namespace: &str, path: &Path) -> Result<Vec<WorkRecord>> {
-    if namespace == TERMINAL_NAMESPACE {
-        let entries = session::load_entries(path).context("Failed to read session log")?;
-        Ok(entries
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, entry)| WorkRecord::terminal(entry, path, idx))
-            .collect())
-    } else {
-        let provider = AgentProvider::from_name(namespace)
-            .with_context(|| format!("unknown session namespace `{namespace}`"))?;
-        parse_agent_session_file(provider, path).map_err(anyhow::Error::msg)
-    }
 }
 
 /// Load many session files in parallel, through the per-file cache, and
@@ -276,17 +254,6 @@ struct CachedAgentSession {
     mtime_nanos: u32,
     size: u64,
     records: Vec<WorkRecord>,
-}
-
-fn parse_agent_session_file(
-    provider: AgentProvider,
-    path: &Path,
-) -> Result<Vec<WorkRecord>, String> {
-    let source = provider.session_provider();
-    source
-        .parse_session_file(path)
-        .map(|session| WorkRecord::chat_turns(provider, &session))
-        .map_err(|error| format!("{error:#}"))
 }
 
 fn load_cached_view(cache_path: &Path, source: &Path) -> Option<Vec<WorkRecord>> {
@@ -358,33 +325,32 @@ fn without_parts(records: &[WorkRecord]) -> Vec<WorkRecord> {
 }
 
 /// Serial single-source parse path, kept for tests that drive a mocked
-/// `AgentSessionProvider` (the production path parses sessions in parallel).
+/// `SessionSource` (the production path parses sessions in parallel).
 #[cfg(test)]
-fn agent_records_from_source(
-    source: &dyn AgentSessionProvider,
+fn records_from_source(
+    source: &dyn SessionSource,
     cwd: &Path,
     recent_sessions: Option<usize>,
     skipped: &mut Vec<SkippedSession>,
 ) -> Result<Vec<WorkRecord>> {
     let mut records = Vec::new();
-    let mut sessions = source.list_recent_sessions(Some(cwd))?;
+    let mut sessions = source.list_sessions(Some(cwd))?;
     if let Some(limit) = recent_sessions {
         sessions.truncate(limit);
     }
 
     for info in sessions {
-        let session = match source.parse_session_file(&info.path) {
-            Ok(session) => session,
+        match source.parse_file(&info.path) {
+            Ok(session_records) => records.extend(session_records),
             Err(error) => {
                 skipped.push(SkippedSession {
-                    namespace: source.provider().name().to_string(),
+                    namespace: source.namespace().to_string(),
                     path: info.path,
                     error: format!("{error:#}"),
                 });
                 continue;
             }
-        };
-        records.extend(WorkRecord::chat_turns(source.provider(), &session));
+        }
     }
 
     Ok(records)
@@ -508,12 +474,11 @@ fn rewrite_record_session_display_id(record: &mut WorkRecord, display_id: &str) 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ai::{
-        AgentBlock, AgentBlockKind, AgentSession, AgentSessionInfo, AgentSessionProvider,
-    };
+    use crate::ai::{AgentBlock, AgentBlockKind, AgentSession};
     use crate::record::{
         WorkChannel, WorkPart, WorkPartData, WorkRecordKind, WorkSessionRef, WorkSource, WorkTime,
     };
+    use crate::session_source::SessionInfo;
     use anyhow::Result;
     use std::path::{Path, PathBuf};
     use std::time::{Duration, SystemTime};
@@ -613,14 +578,14 @@ mod tests {
         let cwd = PathBuf::from("/repo");
         let source = BrokenAgentSource {
             infos: vec![
-                AgentSessionInfo {
+                SessionInfo {
                     path: PathBuf::from("broken.jsonl"),
                     id: Some("broken".to_string()),
                     cwd: Some("/repo".to_string()),
                     title: Some("broken".to_string()),
                     modified: SystemTime::UNIX_EPOCH + Duration::from_secs(2),
                 },
-                AgentSessionInfo {
+                SessionInfo {
                     path: PathBuf::from("good.jsonl"),
                     id: Some("good".to_string()),
                     cwd: Some("/repo".to_string()),
@@ -630,34 +595,34 @@ mod tests {
             ],
         };
         let mut skipped = Vec::new();
-        let records = agent_records_from_source(&source, &cwd, Some(10), &mut skipped).unwrap();
+        let records = records_from_source(&source, &cwd, Some(10), &mut skipped).unwrap();
 
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].session.id, "good");
         assert_eq!(skipped.len(), 1);
         assert_eq!(skipped[0].path, PathBuf::from("broken.jsonl"));
-        assert_eq!(skipped[0].namespace, AgentProvider::Claude.name());
+        assert_eq!(skipped[0].namespace, "claude");
     }
 
     struct BrokenAgentSource {
-        infos: Vec<AgentSessionInfo>,
+        infos: Vec<SessionInfo>,
     }
 
-    impl AgentSessionProvider for BrokenAgentSource {
-        fn provider(&self) -> AgentProvider {
-            AgentProvider::Claude
+    impl SessionSource for BrokenAgentSource {
+        fn namespace(&self) -> &'static str {
+            "claude"
         }
 
-        fn list_recent_sessions(&self, _cwd: Option<&Path>) -> Result<Vec<AgentSessionInfo>> {
+        fn list_sessions(&self, _cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
             Ok(self.infos.clone())
         }
 
-        fn parse_session_file(&self, path: &Path) -> Result<AgentSession> {
+        fn parse_file(&self, path: &Path) -> Result<Vec<WorkRecord>> {
             if path == Path::new("broken.jsonl") {
                 anyhow::bail!("synthetic parse error")
             }
 
-            Ok(AgentSession {
+            let session = AgentSession {
                 path: path.to_path_buf(),
                 id: Some("good".to_string()),
                 cwd: Some("/repo".to_string()),
@@ -680,7 +645,8 @@ mod tests {
                         start_line: None,
                     },
                 ],
-            })
+            };
+            Ok(WorkRecord::chat_turns(AgentProvider::Claude, &session))
         }
     }
 

--- a/crates/sivtr-core/src/search/filter.rs
+++ b/crates/sivtr-core/src/search/filter.rs
@@ -91,10 +91,18 @@ impl Filter {
     }
 
     /// Whether applying this filter reads part text: per-line pattern and
-    /// exclude matching both scan `parts`, and BM25 ranking is built from
-    /// part text. Metadata-only bounds (time, status, kind, latest) do not.
+    /// exclude matching scan `parts`, BM25 ranking is built from part text,
+    /// parts-mode emits per-part hits, kind and field bounds match on
+    /// `part.kind()`, and input/output/command fields inspect part kinds.
+    /// Title/session bounds and the default content field with no pattern
+    /// stay metadata-only.
     pub fn needs_parts(&self) -> bool {
-        self.pattern.is_some() || self.exclude_regex.is_some() || self.rank.is_some()
+        self.pattern.is_some()
+            || self.exclude_regex.is_some()
+            || self.rank.is_some()
+            || self.mode == FilterMode::Parts
+            || self.kind.is_some()
+            || matches!(self.in_field, Field::Input | Field::Output | Field::Command)
     }
 
     /// Browse session list: newest-first, bounded by `latest` records.

--- a/crates/sivtr-core/src/session_source.rs
+++ b/crates/sivtr-core/src/session_source.rs
@@ -54,7 +54,10 @@ impl SessionSource for TerminalSource {
         };
         let mut infos = Vec::new();
         let paths = workspace::terminal_log_paths_for_workspace(cwd).with_context(|| {
-            format!("Failed to list terminal sessions for workspace {}", cwd.display())
+            format!(
+                "Failed to list terminal sessions for workspace {}",
+                cwd.display()
+            )
         })?;
         for path in paths {
             let modified = std::fs::metadata(&path)

--- a/crates/sivtr-core/src/session_source.rs
+++ b/crates/sivtr-core/src/session_source.rs
@@ -56,7 +56,7 @@ impl SessionSource for TerminalSource {
         for path in workspace::terminal_log_paths_for_workspace(cwd)? {
             let modified = std::fs::metadata(&path)
                 .and_then(|meta| meta.modified())
-                .unwrap_or(SystemTime::UNIX_EPOCH);
+                .with_context(|| format!("Failed to stamp terminal log {}", path.display()))?;
             infos.push(SessionInfo {
                 path,
                 id: None,

--- a/crates/sivtr-core/src/session_source.rs
+++ b/crates/sivtr-core/src/session_source.rs
@@ -1,0 +1,100 @@
+//! Unified conversation sources: terminal logs and agent providers behind one
+//! discovery/parse interface.
+//!
+//! Every source (the terminal, each agent provider, any future conversation
+//! store) implements [`SessionSource`]; the query layer consumes only this
+//! trait — no terminal/agent branches. Providers keep their internal
+//! [`crate::agents::AgentSessionProvider`] contract for parsing;
+//! [`AgentProvider`] adapts it.
+
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use anyhow::{Context, Result};
+
+use crate::agents::AgentProvider;
+use crate::record::WorkRecord;
+use crate::{session, workspace};
+
+/// Metadata for one discovered session file: enough to filter, sort, and
+/// address records without parsing the file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionInfo {
+    pub path: PathBuf,
+    pub id: Option<String>,
+    pub cwd: Option<String>,
+    pub title: Option<String>,
+    pub modified: SystemTime,
+}
+
+/// A conversation source.
+pub trait SessionSource {
+    /// Cache namespace and selector prefix (`"terminal"`, `"codex"`, …).
+    fn namespace(&self) -> &'static str;
+
+    /// Discover session files, workspace-filtered when `cwd` is given.
+    fn list_sessions(&self, cwd: Option<&Path>) -> Result<Vec<SessionInfo>>;
+
+    /// Parse one session file into records.
+    fn parse_file(&self, path: &Path) -> Result<Vec<WorkRecord>>;
+}
+
+/// Terminal session logs. One namespace: users switch shells inside one
+/// terminal session, so per-shell identity carries no signal.
+pub struct TerminalSource;
+
+impl SessionSource for TerminalSource {
+    fn namespace(&self) -> &'static str {
+        "terminal"
+    }
+
+    fn list_sessions(&self, cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
+        let Some(cwd) = cwd else {
+            return Ok(Vec::new());
+        };
+        let mut infos = Vec::new();
+        for path in workspace::terminal_log_paths_for_workspace(cwd)? {
+            let modified = std::fs::metadata(&path)
+                .and_then(|meta| meta.modified())
+                .unwrap_or(SystemTime::UNIX_EPOCH);
+            infos.push(SessionInfo {
+                path,
+                id: None,
+                cwd: None,
+                title: None,
+                modified,
+            });
+        }
+        Ok(infos)
+    }
+
+    fn parse_file(&self, path: &Path) -> Result<Vec<WorkRecord>> {
+        let entries = session::load_entries(path).context("Failed to read session log")?;
+        Ok(entries
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, entry)| WorkRecord::terminal(entry, path, idx))
+            .collect())
+    }
+}
+
+/// The source list for a workspace query: the terminal plus the given agent
+/// providers.
+pub fn workspace_sources(providers: &[AgentProvider]) -> Vec<Box<dyn SessionSource>> {
+    let mut sources: Vec<Box<dyn SessionSource>> = vec![Box::new(TerminalSource)];
+    sources.extend(
+        providers
+            .iter()
+            .map(|provider| Box::new(*provider) as Box<dyn SessionSource>),
+    );
+    sources
+}
+
+/// Look up a source by its namespace (`"terminal"`, `"codex"`, …).
+pub fn source_by_namespace(namespace: &str) -> Option<Box<dyn SessionSource>> {
+    if namespace == TerminalSource.namespace() {
+        return Some(Box::new(TerminalSource));
+    }
+    AgentProvider::from_command_name(namespace)
+        .map(|provider| Box::new(provider) as Box<dyn SessionSource>)
+}

--- a/crates/sivtr-core/src/session_source.rs
+++ b/crates/sivtr-core/src/session_source.rs
@@ -53,7 +53,10 @@ impl SessionSource for TerminalSource {
             return Ok(Vec::new());
         };
         let mut infos = Vec::new();
-        for path in workspace::terminal_log_paths_for_workspace(cwd)? {
+        let paths = workspace::terminal_log_paths_for_workspace(cwd).with_context(|| {
+            format!("Failed to list terminal sessions for workspace {}", cwd.display())
+        })?;
+        for path in paths {
             let modified = std::fs::metadata(&path)
                 .and_then(|meta| meta.modified())
                 .with_context(|| format!("Failed to stamp terminal log {}", path.display()))?;

--- a/src/commands/memory/records.rs
+++ b/src/commands/memory/records.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use sivtr_core::ai::AgentProvider;
 use sivtr_core::query::{load_workspace_records, LoadMode};
 use sivtr_core::record::WorkRecordIndex;
+use sivtr_core::session_source::workspace_sources;
 
 use crate::output;
 
@@ -18,7 +19,8 @@ pub(crate) fn current_work_record_index(
     cwd: &Path,
     recent_sessions: Option<usize>,
 ) -> Result<WorkRecordIndex> {
-    let result = load_workspace_records(providers, cwd, recent_sessions, LoadMode::Light)?;
+    let sources = workspace_sources(providers);
+    let result = load_workspace_records(&sources, cwd, recent_sessions, LoadMode::Light)?;
     warn_skipped(&result.skipped);
     Ok(result.into_index())
 }

--- a/src/commands/memory/show.rs
+++ b/src/commands/memory/show.rs
@@ -103,27 +103,17 @@ pub fn run(args: &ShowArgs) -> Result<workset::WorkSet> {
 /// Render a WorkSet. Content formats (everything but bare refs) materialize
 /// part text first, so a light-loaded set renders fully.
 pub fn print_workset(set: &mut workset::WorkSet, format: WorkSetOutputFormat) -> Result<()> {
+    if format != WorkSetOutputFormat::Refs {
+        set.materialize_parts()?;
+    }
     match format {
-        WorkSetOutputFormat::Full => {
-            set.materialize_parts()?;
-            print_full(set)?;
-        }
+        WorkSetOutputFormat::Full => print_full(set)?,
         WorkSetOutputFormat::WorkSet => {
-            set.materialize_parts()?;
             println!("{}", serde_json::to_string_pretty(set)?);
         }
-        WorkSetOutputFormat::Compact => {
-            set.materialize_parts()?;
-            print_compact(set)?;
-        }
-        WorkSetOutputFormat::Timeline => {
-            set.materialize_parts()?;
-            print_timeline(set)?;
-        }
-        WorkSetOutputFormat::Md => {
-            set.materialize_parts()?;
-            print_markdown(set)?;
-        }
+        WorkSetOutputFormat::Compact => print_compact(set)?,
+        WorkSetOutputFormat::Timeline => print_timeline(set)?,
+        WorkSetOutputFormat::Md => print_markdown(set)?,
         WorkSetOutputFormat::Refs => print_refs(set),
     }
     Ok(())

--- a/src/commands/memory/workset/mod.rs
+++ b/src/commands/memory/workset/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use store::{cleanup_saved, delete_saved, list_saved, load_saved, save
 use anyhow::{bail, Context, Result};
 use chrono::{SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
-use sivtr_core::query::{load_session_records, LoadMode, TERMINAL_NAMESPACE};
+use sivtr_core::query::{load_session_records, LoadMode};
 use sivtr_core::record::{WorkPath, WorkRecord, WorkRef};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
@@ -55,8 +55,8 @@ pub enum WorkSetSelection {
 /// to pick the right cache view when re-loading full records.
 fn session_namespace(path: &WorkPath) -> Option<&'static str> {
     match path {
-        WorkPath::Agent { provider, .. } => Some(provider.name()),
-        WorkPath::Terminal { .. } => Some(TERMINAL_NAMESPACE),
+        WorkPath::Agent { provider, .. } => Some(provider.command_name()),
+        WorkPath::Terminal { .. } => Some("terminal"),
     }
 }
 

--- a/src/commands/memory/workset/mod.rs
+++ b/src/commands/memory/workset/mod.rs
@@ -108,9 +108,8 @@ impl WorkSet {
             let Some(namespace) = namespace else {
                 continue;
             };
-            let Ok(full) = load_session_records(namespace, Path::new(path), LoadMode::Full) else {
-                continue;
-            };
+            let full = load_session_records(namespace, Path::new(path), LoadMode::Full)
+                .with_context(|| format!("Failed to load full session {path} for {namespace}"))?;
             for index in indices {
                 if let Some(record) = self.records.get_mut(*index) {
                     if let Some(full_record) = full

--- a/src/commands/memory/workset/source.rs
+++ b/src/commands/memory/workset/source.rs
@@ -73,7 +73,14 @@ pub enum QuerySourceResult {
 /// full load; pure metadata queries stay light and callers materialize part
 /// text on demand.
 pub fn query(source: &str, filter: Filter, cwd: Option<&Path>) -> Result<WorkSet> {
-    let mode = load_mode_for(&filter);
+    // Bounds that read part text (pattern, exclude, BM25 ranking) need a full
+    // load; metadata-only filters stay light and callers materialize part
+    // text on demand.
+    let mode = if filter.needs_parts() {
+        LoadMode::Full
+    } else {
+        LoadMode::Light
+    };
     if source == "@" {
         return apply_loaded(read_stdin()?, filter);
     }
@@ -341,16 +348,6 @@ fn run_local(source: &str, root: &Path, filter: Filter, mode: LoadMode) -> Resul
         WorkSet::with_anchors(root.display().to_string(), result.records, result.anchors),
         filter,
     )
-}
-
-/// Pick the load mode from the filter: bounds that read part text need a
-/// full load, metadata-only filters stay light.
-fn load_mode_for(filter: &Filter) -> LoadMode {
-    if filter.needs_parts() {
-        LoadMode::Full
-    } else {
-        LoadMode::Light
-    }
 }
 
 fn apply_loaded(set: WorkSet, filter: Filter) -> Result<WorkSet> {


### PR DESCRIPTION
## What

Unify terminal logs and agent providers behind one `SessionSource` trait so the query layer has no terminal/agent branches.

- New `crates/sivtr-core/src/session_source.rs`: `SessionSource` trait (`namespace` / `list_sessions` / `parse_file`), `TerminalSource`, `workspace_sources()`, `source_by_namespace()`
- `AgentProvider` implements `SessionSource` (adapts its internal `AgentSessionProvider` contract, kept for `find_*` lookups used by filter/codex/grok)
- `AgentSessionInfo` renamed `SessionInfo`; `TERMINAL_NAMESPACE` removed; `load_workspace_records` takes sources instead of providers
- `parse_session_file` namespace dispatch deleted; `load_session_records` resolves the source via `source_by_namespace`

## Why

New conversation sources (any future terminal-like or agent-like store) only implement one trait and automatically get parallel loading, caching, light/full views, and origin addressing. Terminal is one namespace — users switch shells inside one terminal session, so per-shell identity carries no signal.

## Validation

- `cargo test --workspace` (652 tests), clippy `-D warnings`, fmt clean
- Release benchmark after stacking with `perf/search-index-cache`: relevance 1.26s, browse 0.99s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified session discovery across terminal and supported AI agent conversations.
  * Workspace queries can now combine sessions from multiple sources consistently.
  * Added session metadata, including titles, working directories, modification times, and identifiers.
  * Improved automatic handling of session formats and source selection.

* **Improvements**
  * Memory views avoid repeating work when generating multiple output formats.
  * Queries load only the session detail required by the selected filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->