### PR TITLE
docs: document single-track release cadence (PATCH prompt, MINOR batched)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -12,9 +12,9 @@ on:
   push:
     branches:
       - main
-  # Manual trigger: open the MINOR Release PR for accumulated feat commits.
-  # feat does not open a Release PR automatically (release_commits = "^(fix)[(:]");
-  # run this workflow when the batched features are ready to ship.
+  # Manual trigger: re-run the Release-PR job on demand (e.g. to pick up
+  # commits that landed after the PR was opened, or after a push event was
+  # skipped). Normal cadence is push-driven; see AGENTS.md "Release cadence".
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -12,6 +12,10 @@ on:
   push:
     branches:
       - main
+  # Manual trigger: open the MINOR Release PR for accumulated feat commits.
+  # feat does not open a Release PR automatically (release_commits = "^(fix)[(:]");
+  # run this workflow when the batched features are ready to ship.
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,8 +138,11 @@ How this project versions and releases changes. AI agents must follow this when 
 
 #### Release cadence
 
-- **PATCH (fix) — automatic.** `release_commits` matches only `fix`, so any `fix:` merged to `main` opens a Release PR immediately; merge it to ship the hotfix.
-- **MINOR (feat) — batched, agent-triggered.** `feat:` / `feat!` never open a Release PR on their own; they accumulate in `CHANGELOG.md` `[Unreleased]`. When enough features have piled up (rule of thumb: 3+ `feat` commits, or 2+ weeks since the last MINOR), run `gh workflow run release-plz.yml` to open the MINOR Release PR for the accumulated batch, review it, then merge. Do not batch so long that hotfix PATCH releases pile up inside one MINOR (see Common traps).
+Single track: `release_commits` matches `feat|fix`, so any of them merged to `main` opens a Release PR and later `feat`/`fix` accumulate in it (the version is not bumped again). Merging the Release PR is the release; the cadence is a merge-timing decision, not a config one:
+
+- **PATCH (fix) — ship promptly.** When the open Release PR only contains `fix:` commits (version bumps to `0.x.y`), merge it soon after CI passes so hotfixes land without waiting on features.
+- **MINOR (feat) — batch.** When the open Release PR contains `feat:` / `feat!` commits (version bumps to `0.x.0`), hold it until enough features have piled up (rule of thumb: 3+ `feat` commits, or 2+ weeks since the last MINOR), then merge. Do not batch so long that hotfix PATCH releases pile up inside one MINOR (see Common traps).
+- Either way, re-run `gh workflow run release-plz.yml` (`workflow_dispatch`) to refresh the Release PR if the push event missed it.
 
 1. `feat:` → MINOR (`0.4.1` → `0.5.0`); `fix:` → PATCH (`0.4.1` → `0.4.2`); `feat!` / `BREAKING CHANGE` → still MINOR in `0.x`, flagged as breaking in the changelog; `chore` / `docs` / `ci` / `refactor` / `test` / `perf` / `build` → no version bump.
    - Only `feat`/`fix` commits open a Release PR (`release_commits` in `release-plz.toml`); non-versioned work rides along with the next release instead of shipping its own.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,11 @@ How this project versions and releases changes. AI agents must follow this when 
 
 [release-plz](https://release-plz.dev) drives versioning, changelog, and tagging (`release-plz.toml` + `.github/workflows/release-plz*.yml`). On every push to `main` it keeps a **Release PR** up to date: it bumps `[workspace.package]` version, syncs the `sivtr-core` pin and `Cargo.lock`, and drafts a Keep a Changelog section in `CHANGELOG.md` from Conventional Commit squash titles. Merging that PR is the release.
 
+#### Release cadence
+
+- **PATCH (fix) — automatic.** `release_commits` matches only `fix`, so any `fix:` merged to `main` opens a Release PR immediately; merge it to ship the hotfix.
+- **MINOR (feat) — batched, agent-triggered.** `feat:` / `feat!` never open a Release PR on their own; they accumulate in `CHANGELOG.md` `[Unreleased]`. When enough features have piled up (rule of thumb: 3+ `feat` commits, or 2+ weeks since the last MINOR), run `gh workflow run release-plz.yml` to open the MINOR Release PR for the accumulated batch, review it, then merge. Do not batch so long that hotfix PATCH releases pile up inside one MINOR (see Common traps).
+
 1. `feat:` → MINOR (`0.4.1` → `0.5.0`); `fix:` → PATCH (`0.4.1` → `0.4.2`); `feat!` / `BREAKING CHANGE` → still MINOR in `0.x`, flagged as breaking in the changelog; `chore` / `docs` / `ci` / `refactor` / `test` / `perf` / `build` → no version bump.
    - Only `feat`/`fix` commits open a Release PR (`release_commits` in `release-plz.toml`); non-versioned work rides along with the next release instead of shipping its own.
    - semver-check runs only on `sivtr-core` (the published library). `sivtr` is a binary; its internal API changes never inflate the version — breaking changes there are signaled by `feat!` / `BREAKING CHANGE` commits.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,10 +1,12 @@
 # release-plz drives version bumps, the changelog, and tagging.
 #
 # Version strategy (0.x):
-# - Only `feat`/`fix` commits open a Release PR (`release_commits`); docs,
-#   perf, chore, refactor, ci, test do NOT bump a version on their own — they
-#   ride along with the next feature/fix release, so the version moves only
-#   when real functionality ships.
+# - Only `fix` commits open a Release PR automatically (`release_commits`):
+#   PATCH releases ship on demand as hotfixes land. `feat` commits do NOT
+#   open a Release PR — they accumulate in [Unreleased] until an agent or
+#   maintainer runs `gh workflow run release-plz.yml` to open the next MINOR
+#   Release PR (see AGENTS.md "Release cadence"). This keeps MINOR releases
+#   batched instead of shipping one per feature.
 # - `feat` bumps MINOR and `fix` bumps PATCH in 0.x
 #   (`features_always_increment_minor` keeps feature work visible as a MINOR
 #   even before 1.0). `feat!` / `BREAKING CHANGE` also bump MINOR in 0.x.
@@ -31,7 +33,7 @@ publish = false
 release_always = false
 pr_labels = ["release"]
 features_always_increment_minor = true
-release_commits = "^(feat|fix)[(:]"
+release_commits = "^(fix)[(:]"
 
 [[package]]
 name = "sivtr-core"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,12 +1,15 @@
 # release-plz drives version bumps, the changelog, and tagging.
 #
 # Version strategy (0.x):
-# - Only `fix` commits open a Release PR automatically (`release_commits`):
-#   PATCH releases ship on demand as hotfixes land. `feat` commits do NOT
-#   open a Release PR — they accumulate in [Unreleased] until an agent or
-#   maintainer runs `gh workflow run release-plz.yml` to open the next MINOR
-#   Release PR (see AGENTS.md "Release cadence"). This keeps MINOR releases
-#   batched instead of shipping one per feature.
+# - `feat`/`fix` commits open a Release PR (`release_commits`); docs, perf,
+#   chore, refactor, ci, test do NOT bump a version on their own — they ride
+#   along with the next feature/fix release, so the version moves only when
+#   real functionality ships.
+# - Once a Release PR is open, later `feat`/`fix` commits accumulate in it
+#   (the version is not bumped again); merging it is what publishes. The
+#   release cadence — merge PATCH PRs immediately, hold MINOR PRs until
+#   enough features accumulate — is a process decision, not a config one;
+#   see AGENTS.md "Release cadence".
 # - `feat` bumps MINOR and `fix` bumps PATCH in 0.x
 #   (`features_always_increment_minor` keeps feature work visible as a MINOR
 #   even before 1.0). `feat!` / `BREAKING CHANGE` also bump MINOR in 0.x.
@@ -33,7 +36,7 @@ publish = false
 release_always = false
 pr_labels = ["release"]
 features_always_increment_minor = true
-release_commits = "^(fix)[(:]"
+release_commits = "^(feat|fix)[(:]"
 
 [[package]]
 name = "sivtr-core"


### PR DESCRIPTION
Document the release cadence decision: single track (feat/fix both open the Release PR, later commits accumulate in it), with merge timing as the control - PATCH PRs merge promptly, MINOR PRs are held until enough features batch (3+ feat or 2+ weeks). Also add workflow_dispatch so the Release-PR job can be re-run on demand.

Config stays at release_commits = `^(feat|fix)[(:]`; the cadence is a process rule in AGENTS.md, not a config change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to manually trigger the release workflow on demand.

* **Documentation**
  * Documented release cadence guidance for patch and minor releases.
  * Clarified how subsequent fixes and features are grouped into an open release.

* **Chores**
  * Improved release workflow flexibility by supporting both automatic and manual runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->