### PR TITLE
refactor(search): unify query routing into a single pipeline

### DIFF
--- a/crates/sivtr-core/src/agents/mod.rs
+++ b/crates/sivtr-core/src/agents/mod.rs
@@ -227,15 +227,6 @@ impl AgentProvider {
             .map(|spec| spec.provider)
     }
 
-    /// Resolve a provider from its registry name (see [`Self::name`]),
-    /// used to map cache namespaces back to a provider.
-    pub fn from_name(value: &str) -> Option<Self> {
-        Self::all()
-            .iter()
-            .find(|spec| spec.name.eq_ignore_ascii_case(value))
-            .map(|spec| spec.provider)
-    }
-
     pub fn spec(self) -> &'static AgentProviderSpec {
         Self::all()
             .iter()

--- a/crates/sivtr-core/src/origin.rs
+++ b/crates/sivtr-core/src/origin.rs
@@ -26,9 +26,10 @@ use serde::{Deserialize, Serialize};
 pub struct Origin {
     /// Logical name (scope name / alias), used by [`OriginRegistry::resolve`].
     pub name: String,
-    /// Stable lowercase label of the reach kind (`"local"` / `"remote"`),
-    /// composed from [`Reach::label`] at construction.
-    pub kind: String,
+    /// Stable lowercase label of the reach kind (`"local"` / `"remote"`).
+    /// Private: derived from [`Reach`] by [`Entry::new`], so classification
+    /// always agrees with the reach. Serialized for MCP consumers.
+    kind: String,
     /// Whether this origin is the current context (e.g. the current workspace).
     pub current: bool,
     /// Display projection composed by the source (e.g. `root (key)`).
@@ -62,6 +63,20 @@ impl Reach {
 pub struct Entry {
     pub origin: Origin,
     pub reach: Reach,
+}
+
+impl Entry {
+    /// Build an entry with `kind` derived from the reach — the two can never
+    /// disagree, since every consumer reads classification from one source.
+    pub fn new(name: String, current: bool, detail: String, reach: Reach) -> Self {
+        let origin = Origin {
+            name,
+            kind: reach.label().to_string(),
+            current,
+            detail,
+        };
+        Self { origin, reach }
+    }
 }
 
 /// Every origin addressable from the current context.
@@ -131,28 +146,22 @@ mod tests {
 
     fn sample() -> OriginRegistry {
         OriginRegistry::new(vec![
-            Entry {
-                origin: Origin {
-                    name: "sivtr".to_string(),
-                    kind: "local".to_string(),
-                    current: true,
-                    detail: "D:\\Coding\\sivtr (key1)".to_string(),
-                },
-                reach: Reach::Local {
+            Entry::new(
+                "sivtr".to_string(),
+                true,
+                "D:\\Coding\\sivtr (key1)".to_string(),
+                Reach::Local {
                     root: "D:\\Coding\\sivtr".to_string(),
                 },
-            },
-            Entry {
-                origin: Origin {
-                    name: "desk".to_string(),
-                    kind: "remote".to_string(),
-                    current: false,
-                    detail: "alice/sivtr".to_string(),
-                },
-                reach: Reach::Remote {
+            ),
+            Entry::new(
+                "desk".to_string(),
+                false,
+                "alice/sivtr".to_string(),
+                Reach::Remote {
                     workspace_key: "key1".to_string(),
                 },
-            },
+            ),
         ])
     }
 
@@ -204,28 +213,22 @@ mod tests {
     #[test]
     fn resolve_errors_on_ambiguous_names() {
         let registry = OriginRegistry::new(vec![
-            Entry {
-                origin: Origin {
-                    name: "return".to_string(),
-                    kind: "local".to_string(),
-                    current: false,
-                    detail: "D:\\a (k1)".to_string(),
-                },
-                reach: Reach::Local {
+            Entry::new(
+                "return".to_string(),
+                false,
+                "D:\\a (k1)".to_string(),
+                Reach::Local {
                     root: "D:\\a".to_string(),
                 },
-            },
-            Entry {
-                origin: Origin {
-                    name: "return".to_string(),
-                    kind: "local".to_string(),
-                    current: false,
-                    detail: "D:\\b (k2)".to_string(),
-                },
-                reach: Reach::Local {
+            ),
+            Entry::new(
+                "return".to_string(),
+                false,
+                "D:\\b (k2)".to_string(),
+                Reach::Local {
                     root: "D:\\b".to_string(),
                 },
-            },
+            ),
         ]);
         let error = registry.resolve("return").expect_err("ambiguous");
         assert!(error.to_string().contains("ambiguous origin `return`"));
@@ -236,31 +239,24 @@ mod tests {
         // A mount alias may equal a local workspace's basename; the mount
         // resolves (remote lookup ran before local workspaces pre-registry).
         let registry = OriginRegistry::new(vec![
-            Entry {
-                origin: Origin {
-                    name: "proj".to_string(),
-                    kind: "local".to_string(),
-                    current: true,
-                    detail: "D:\\a\\proj (k1)".to_string(),
-                },
-                reach: Reach::Local {
+            Entry::new(
+                "proj".to_string(),
+                true,
+                "D:\\a\\proj (k1)".to_string(),
+                Reach::Local {
                     root: "D:\\a\\proj".to_string(),
                 },
-            },
-            Entry {
-                origin: Origin {
-                    name: "proj".to_string(),
-                    kind: "remote".to_string(),
-                    current: false,
-                    detail: "alice/proj".to_string(),
-                },
-                reach: Reach::Remote {
+            ),
+            Entry::new(
+                "proj".to_string(),
+                false,
+                "alice/proj".to_string(),
+                Reach::Remote {
                     workspace_key: "k1".to_string(),
                 },
-            },
+            ),
         ]);
         let entry = registry.resolve("proj").expect("resolve").expect("found");
-        assert_eq!(entry.origin.kind, "remote");
         assert!(matches!(&entry.reach, Reach::Remote { workspace_key } if workspace_key == "k1"));
     }
 

--- a/crates/sivtr-core/src/origin.rs
+++ b/crates/sivtr-core/src/origin.rs
@@ -18,26 +18,6 @@ use anyhow::{bail, Result};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// Major source category.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum OriginKind {
-    /// Local files on this machine (workspaces).
-    Local,
-    /// Another device, forwarded through the daemon.
-    Remote,
-}
-
-impl OriginKind {
-    /// Stable lowercase label for display and serialization.
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::Local => "local",
-            Self::Remote => "remote",
-        }
-    }
-}
-
 /// A single addressable memory source.
 ///
 /// All fields exist for every kind; `detail` is the display projection the
@@ -46,8 +26,9 @@ impl OriginKind {
 pub struct Origin {
     /// Logical name (scope name / alias), used by [`OriginRegistry::resolve`].
     pub name: String,
-    /// Major source category.
-    pub kind: OriginKind,
+    /// Stable lowercase label of the reach kind (`"local"` / `"remote"`),
+    /// composed from [`Reach::label`] at construction.
+    pub kind: String,
     /// Whether this origin is the current context (e.g. the current workspace).
     pub current: bool,
     /// Display projection composed by the source (e.g. `root (key)`).
@@ -64,6 +45,16 @@ pub enum Reach {
     /// A mount on another device: which workspace's mount list.
     /// The mount alias is [`Origin::name`].
     Remote { workspace_key: String },
+}
+
+impl Reach {
+    /// Stable lowercase label for display and serialization.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Local { .. } => "local",
+            Self::Remote { .. } => "remote",
+        }
+    }
 }
 
 /// One registry entry: the display [`Origin`] plus its [`Reach`].
@@ -118,7 +109,7 @@ impl OriginRegistry {
             _ => {
                 // Remote wins a cross-kind collision; same-kind collisions stay
                 // ambiguous.
-                matched.sort_by_key(|entry| matches!(entry.origin.kind, OriginKind::Local));
+                matched.sort_by_key(|entry| entry.origin.kind == "local");
                 if matched[0].origin.kind == matched[1].origin.kind {
                     let details: Vec<&str> = matched
                         .iter()
@@ -141,7 +132,7 @@ mod tests {
             Entry {
                 origin: Origin {
                     name: "sivtr".to_string(),
-                    kind: OriginKind::Local,
+                    kind: "local".to_string(),
                     current: true,
                     detail: "D:\\Coding\\sivtr (key1)".to_string(),
                 },
@@ -152,7 +143,7 @@ mod tests {
             Entry {
                 origin: Origin {
                     name: "desk".to_string(),
-                    kind: OriginKind::Remote,
+                    kind: "remote".to_string(),
                     current: false,
                     detail: "alice/sivtr".to_string(),
                 },
@@ -165,8 +156,20 @@ mod tests {
 
     #[test]
     fn labels_are_stable() {
-        assert_eq!(OriginKind::Local.label(), "local");
-        assert_eq!(OriginKind::Remote.label(), "remote");
+        assert_eq!(
+            Reach::Local {
+                root: String::new()
+            }
+            .label(),
+            "local"
+        );
+        assert_eq!(
+            Reach::Remote {
+                workspace_key: String::new()
+            }
+            .label(),
+            "remote"
+        );
     }
 
     #[test]
@@ -202,7 +205,7 @@ mod tests {
             Entry {
                 origin: Origin {
                     name: "return".to_string(),
-                    kind: OriginKind::Local,
+                    kind: "local".to_string(),
                     current: false,
                     detail: "D:\\a (k1)".to_string(),
                 },
@@ -213,7 +216,7 @@ mod tests {
             Entry {
                 origin: Origin {
                     name: "return".to_string(),
-                    kind: OriginKind::Local,
+                    kind: "local".to_string(),
                     current: false,
                     detail: "D:\\b (k2)".to_string(),
                 },
@@ -234,7 +237,7 @@ mod tests {
             Entry {
                 origin: Origin {
                     name: "proj".to_string(),
-                    kind: OriginKind::Local,
+                    kind: "local".to_string(),
                     current: true,
                     detail: "D:\\a\\proj (k1)".to_string(),
                 },
@@ -245,7 +248,7 @@ mod tests {
             Entry {
                 origin: Origin {
                     name: "proj".to_string(),
-                    kind: OriginKind::Remote,
+                    kind: "remote".to_string(),
                     current: false,
                     detail: "alice/proj".to_string(),
                 },
@@ -255,7 +258,7 @@ mod tests {
             },
         ]);
         let entry = registry.resolve("proj").expect("resolve").expect("found");
-        assert_eq!(entry.origin.kind, OriginKind::Remote);
+        assert_eq!(entry.origin.kind, "remote");
         assert!(matches!(&entry.reach, Reach::Remote { workspace_key } if workspace_key == "k1"));
     }
 
@@ -280,10 +283,6 @@ mod tests {
 
     #[test]
     fn kind_serializes_as_lowercase_label() {
-        assert_eq!(
-            serde_json::to_string(&OriginKind::Remote).expect("serialize kind"),
-            "\"remote\""
-        );
         let origin = sample().all().nth(1).expect("second origin").clone();
         let json = serde_json::to_string(&origin).expect("serialize origin");
         assert!(json.contains("\"kind\":\"remote\""));

--- a/crates/sivtr-core/src/origin.rs
+++ b/crates/sivtr-core/src/origin.rs
@@ -109,8 +109,10 @@ impl OriginRegistry {
             _ => {
                 // Remote wins a cross-kind collision; same-kind collisions stay
                 // ambiguous.
-                matched.sort_by_key(|entry| entry.origin.kind == "local");
-                if matched[0].origin.kind == matched[1].origin.kind {
+                matched.sort_by_key(|entry| matches!(entry.reach, Reach::Local { .. }));
+                if matches!(matched[0].reach, Reach::Local { .. })
+                    == matches!(matched[1].reach, Reach::Local { .. })
+                {
                     let details: Vec<&str> = matched
                         .iter()
                         .map(|entry| entry.origin.detail.as_str())

--- a/crates/sivtr-core/src/workspace.rs
+++ b/crates/sivtr-core/src/workspace.rs
@@ -50,11 +50,6 @@ pub fn resolve_workspace_for_dir(cwd: &Path) -> Result<Option<WorkspacePaths>> {
     Ok(Some(paths_for_root(root)?))
 }
 
-pub fn ensure_current_workspace() -> Result<Option<WorkspacePaths>> {
-    let cwd = std::env::current_dir().context("Failed to resolve current directory")?;
-    ensure_workspace_for_dir(&cwd)
-}
-
 pub fn ensure_workspace_for_dir(cwd: &Path) -> Result<Option<WorkspacePaths>> {
     let Some(paths) = resolve_workspace_for_dir(cwd)? else {
         return Ok(None);

--- a/src/commands/browse/load.rs
+++ b/src/commands/browse/load.rs
@@ -13,9 +13,7 @@ use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::commands::memory::filter::Filter;
-use crate::commands::memory::workset::{
-    self, QuerySource, QuerySourceResult, REMOTE_QUERY_TIMEOUT,
-};
+use crate::commands::memory::workset::{self, QuerySource, QuerySourceResult};
 use crate::pane::{
     keep_keys, MetaNeed, Pane, PaneInput, SlidingPane, StorePhase, Viewport, WindowRow,
     FETCH_CEILING, FETCH_FLOOR,
@@ -24,7 +22,6 @@ use crate::tui::workspace::{
     SourceLoadMarker, WorkspaceSession, WorkspaceSource, WorkspaceSourceKind,
 };
 use sivtr_core::ai::AgentProvider;
-use sivtr_core::origin::OriginKind;
 use sivtr_core::record::WorkRecord;
 
 /// Session meta without dialogue bodies.
@@ -305,7 +302,6 @@ impl SourceLoadPump {
                     &[qs],
                     Filter::browse_session_page(budget),
                     Some(&cwd),
-                    REMOTE_QUERY_TIMEOUT,
                 ) {
                     Ok(mut results) => match results.pop() {
                         Some(QuerySourceResult::Ok(set)) => {
@@ -362,12 +358,7 @@ impl SourceLoadPump {
                 } else {
                     QuerySource::local(sel)
                 };
-                let result = match workset::query_many(
-                    &[qs],
-                    Filter::none(),
-                    Some(&cwd),
-                    REMOTE_QUERY_TIMEOUT,
-                ) {
+                let result = match workset::query_many(&[qs], Filter::none(), Some(&cwd)) {
                     Ok(mut results) => match results.pop() {
                         Some(QuerySourceResult::Ok(mut set)) => match set.materialize_parts() {
                             Ok(()) => {
@@ -657,7 +648,7 @@ pub fn workspace_source_catalog(
     // it lists mounts only while the daemon is already running.
     let registry = crate::origins::collect(cwd).context("Failed to collect the origin registry")?;
     for origin in registry.all() {
-        if origin.kind != OriginKind::Remote {
+        if origin.kind != "remote" {
             continue;
         }
         sources.push(WorkspaceSource::remote(

--- a/src/commands/browse/load.rs
+++ b/src/commands/browse/load.rs
@@ -298,7 +298,7 @@ impl SourceLoadPump {
                 } else {
                     QuerySource::local(selector)
                 };
-                let (result, exhausted) = match workset::query_many(
+                let (result, exhausted) = match workset::query_sources(
                     &[qs],
                     Filter::browse_session_page(budget),
                     Some(&cwd),
@@ -358,7 +358,7 @@ impl SourceLoadPump {
                 } else {
                     QuerySource::local(sel)
                 };
-                let result = match workset::query_many(&[qs], Filter::none(), Some(&cwd)) {
+                let result = match workset::query_sources(&[qs], Filter::none(), Some(&cwd)) {
                     Ok(mut results) => match results.pop() {
                         Some(QuerySourceResult::Ok(mut set)) => match set.materialize_parts() {
                             Ok(()) => {

--- a/src/commands/browse/load.rs
+++ b/src/commands/browse/load.rs
@@ -22,6 +22,7 @@ use crate::tui::workspace::{
     SourceLoadMarker, WorkspaceSession, WorkspaceSource, WorkspaceSourceKind,
 };
 use sivtr_core::ai::AgentProvider;
+use sivtr_core::origin::Reach;
 use sivtr_core::record::WorkRecord;
 
 /// Session meta without dialogue bodies.
@@ -647,10 +648,11 @@ pub fn workspace_source_catalog(
     // Mount aliases come from the same origin registry every query path uses;
     // it lists mounts only while the daemon is already running.
     let registry = crate::origins::collect(cwd).context("Failed to collect the origin registry")?;
-    for origin in registry.all() {
-        if origin.kind != "remote" {
+    for entry in registry.entries() {
+        if !matches!(entry.reach, Reach::Remote { .. }) {
             continue;
         }
+        let origin = &entry.origin;
         sources.push(WorkspaceSource::remote(
             &origin.name,
             WorkspaceSourceKind::Terminal,

--- a/src/commands/memory/copy/mod.rs
+++ b/src/commands/memory/copy/mod.rs
@@ -14,6 +14,7 @@ pub use plan::{parse_address_dialogues, CopyFilters, CopyPlan, Projection};
 
 use anyhow::{Context, Result};
 use sivtr_core::ai::AgentProvider;
+use sivtr_core::origin::Reach;
 use sivtr_core::record::WorkRecord;
 
 use crate::commands::browse;
@@ -127,7 +128,7 @@ fn session_source_from_records(records: &[WorkRecord]) -> Option<WorkspaceSource
     let cwd = std::env::current_dir().ok()?;
     let registry = crate::origins::collect(&cwd).ok()?;
     let entry = registry.resolve(scope).ok()??;
-    Some(if entry.origin.kind == "remote" {
+    Some(if matches!(entry.reach, Reach::Remote { .. }) {
         WorkspaceSource::remote(scope, kind)
     } else {
         WorkspaceSource::local(kind)

--- a/src/commands/memory/copy/mod.rs
+++ b/src/commands/memory/copy/mod.rs
@@ -14,7 +14,6 @@ pub use plan::{parse_address_dialogues, CopyFilters, CopyPlan, Projection};
 
 use anyhow::{Context, Result};
 use sivtr_core::ai::AgentProvider;
-use sivtr_core::origin::OriginKind;
 use sivtr_core::record::WorkRecord;
 
 use crate::commands::browse;
@@ -128,7 +127,7 @@ fn session_source_from_records(records: &[WorkRecord]) -> Option<WorkspaceSource
     let cwd = std::env::current_dir().ok()?;
     let registry = crate::origins::collect(&cwd).ok()?;
     let entry = registry.resolve(scope).ok()??;
-    Some(if entry.origin.kind == OriginKind::Remote {
+    Some(if entry.origin.kind == "remote" {
         WorkspaceSource::remote(scope, kind)
     } else {
         WorkspaceSource::local(kind)

--- a/src/commands/memory/workset/mod.rs
+++ b/src/commands/memory/workset/mod.rs
@@ -3,7 +3,6 @@ pub mod store;
 
 pub(crate) use source::{
     load_context_records, query, query_many, run_on_share, QuerySource, QuerySourceResult,
-    REMOTE_QUERY_TIMEOUT,
 };
 pub(crate) use store::{cleanup_saved, delete_saved, list_saved, load_saved, save_named};
 

--- a/src/commands/memory/workset/mod.rs
+++ b/src/commands/memory/workset/mod.rs
@@ -2,7 +2,7 @@ mod source;
 pub mod store;
 
 pub(crate) use source::{
-    load_context_records, query, query_many, run_on_share, QuerySource, QuerySourceResult,
+    load_context_records, query, query_sources, run_on_share, QuerySource, QuerySourceResult,
 };
 pub(crate) use store::{cleanup_saved, delete_saved, list_saved, load_saved, save_named};
 

--- a/src/commands/memory/workset/source.rs
+++ b/src/commands/memory/workset/source.rs
@@ -1,8 +1,6 @@
 use std::collections::HashSet;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
-use std::sync::mpsc;
-use std::thread;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -17,7 +15,7 @@ use crate::output;
 
 use super::WorkSet;
 
-/// Default deadline for one remote source inside [`query_many`].
+/// Default deadline for one remote source inside [`query_sources`].
 pub const REMOTE_QUERY_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Socket-read headroom for one group fan-out inside [`query`]: the daemon
@@ -25,12 +23,12 @@ pub const REMOTE_QUERY_TIMEOUT: Duration = Duration::from_secs(3);
 /// must stay above that budget plus local query time.
 const GROUP_QUERY_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// How one source is scheduled inside [`query_many`].
+/// How one source is scheduled inside [`query_sources`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum QueryTransport {
     /// Disk-local (or named local workspace). Failures abort the batch caller if desired.
     Local,
-    /// Mounted remote alias. Failures are isolated when using [`query_many`].
+    /// Mounted remote alias. Failures are isolated when using [`query_sources`].
     Remote,
     /// Group roster fan-out (`team:...`, `team/alice:...`): the daemon dials
     /// every member share in parallel and returns the merged result.
@@ -48,6 +46,10 @@ pub struct QuerySource {
     pub root: Option<PathBuf>,
     /// Deadline for remote dials and group fan-out; local loads ignore it.
     pub timeout: Duration,
+    /// Pre-resolved remote `workspace_key` for `alias:path` sources built
+    /// from the registry; `None` means re-resolve on first use (browse-built
+    /// sources). Avoids resolving the registry twice for the same query.
+    pub workspace_key: Option<String>,
 }
 
 impl QuerySource {
@@ -57,6 +59,17 @@ impl QuerySource {
             transport: QueryTransport::Local,
             root: None,
             timeout: REMOTE_QUERY_TIMEOUT,
+            workspace_key: None,
+        }
+    }
+
+    pub fn local_at(selector: impl Into<String>, root: PathBuf) -> Self {
+        Self {
+            selector: selector.into(),
+            transport: QueryTransport::Local,
+            root: Some(root),
+            timeout: REMOTE_QUERY_TIMEOUT,
+            workspace_key: None,
         }
     }
 
@@ -66,6 +79,7 @@ impl QuerySource {
             transport: QueryTransport::Remote,
             root: None,
             timeout: REMOTE_QUERY_TIMEOUT,
+            workspace_key: None,
         }
     }
 
@@ -75,27 +89,29 @@ impl QuerySource {
             transport: QueryTransport::Group,
             root: None,
             timeout: GROUP_QUERY_TIMEOUT,
+            workspace_key: None,
         }
     }
 
     /// Build a source from a registry entry: local workspaces load from
     /// their own root, remote mounts keep the `alias:path` selector the
     /// peer-side dispatcher already understands. Adding an origin kind means
-    /// one new arm here — `query_many` then schedules it unchanged.
+    /// one new arm here — `query_sources` then schedules it unchanged.
     pub fn from_entry(entry: &Entry, source: &str) -> Self {
         match &entry.reach {
-            Reach::Local { root } => Self {
-                selector: source.to_string(),
-                transport: QueryTransport::Local,
-                root: Some(PathBuf::from(root)),
+            Reach::Local { root } => Self::local_at(source.to_string(), PathBuf::from(root)),
+            Reach::Remote { workspace_key } => Self {
+                selector: format!("{}:{source}", entry.origin.name),
+                transport: QueryTransport::Remote,
+                root: None,
                 timeout: REMOTE_QUERY_TIMEOUT,
+                workspace_key: Some(workspace_key.clone()),
             },
-            Reach::Remote { .. } => Self::remote(format!("{}:{source}", entry.origin.name)),
         }
     }
 }
 
-/// Per-source outcome from [`query_many`]. Failures never drop other sources.
+/// Per-source outcome from [`query_sources`]. Failures never drop other sources.
 #[derive(Debug)]
 pub enum QuerySourceResult {
     Ok(WorkSet),
@@ -122,24 +138,20 @@ pub fn query(source: &str, filter: Filter, cwd: Option<&Path>) -> Result<WorkSet
         .unwrap_or(std::env::current_dir().context("Failed to resolve current directory")?);
 
     let sources = resolve_source(source, &cwd)?;
-    let results = query_many(&sources, filter.clone(), Some(&cwd))?;
+    let results = query_sources(&sources, filter.clone(), Some(&cwd))?;
     merge_and_apply(results, &cwd, filter)
 }
 
 /// Resolve a source expression into the concrete sources it addresses.
 /// Every scope shape (bare selector, `local:`, `all:`, registry aliases,
-/// groups) collapses into a [`QuerySource`] list here; [`query_many`] then
+/// groups) collapses into a [`QuerySource`] list here; [`query_sources`] then
 /// schedules them unchanged.
 fn resolve_source(source: &str, cwd: &Path) -> Result<Vec<QuerySource>> {
     let source = expand_source(source)?;
 
+    // Bare selector: the current workspace's local source.
     let Some((scope, path)) = source.split_once(':') else {
-        return Ok(vec![QuerySource {
-            selector: source,
-            transport: QueryTransport::Local,
-            root: Some(cwd.to_path_buf()),
-            timeout: REMOTE_QUERY_TIMEOUT,
-        }]);
+        return Ok(vec![QuerySource::local_at(source, cwd.to_path_buf())]);
     };
     if path.is_empty() {
         anyhow::bail!("source `{source}` is missing a selector after `:`");
@@ -149,57 +161,46 @@ fn resolve_source(source: &str, cwd: &Path) -> Result<Vec<QuerySource>> {
             "Invalid source `{source}`; use `scope:path` (for example `desk:terminal`), not `://`"
         );
     }
-    if scope.eq_ignore_ascii_case("local") {
-        return Ok(vec![QuerySource {
-            selector: path.to_string(),
-            transport: QueryTransport::Local,
-            root: Some(cwd.to_path_buf()),
-            timeout: REMOTE_QUERY_TIMEOUT,
-        }]);
-    }
-    if scope.eq_ignore_ascii_case("all") {
-        let registry = crate::origins::collect(cwd)?;
-        let sources: Vec<QuerySource> = registry
-            .entries()
-            .map(|entry| QuerySource::from_entry(entry, path))
-            .collect();
-        return Ok(sources);
-    }
 
     let scope = scope.to_ascii_lowercase();
-
-    // One lookup: the registry is the single alias table (local workspaces,
-    // remote mounts), each entry carrying its reach payload. The registry
-    // lists mounts only while the daemon is already running, so a passive
-    // miss is retried once with the daemon up — a cold `desk:terminal` query
-    // must still resolve its mount. Groups (`team`, `team/alice`) are a
-    // roster fan-out over many devices, not a single origin, so they are
-    // tried only on a miss.
-    let mut registry = crate::origins::collect(cwd)?;
-    if registry.resolve(&scope)?.is_none() {
-        serve::ensure_running()?;
-        registry = crate::origins::collect(cwd)?;
+    match scope.as_str() {
+        "local" => Ok(vec![QuerySource::local_at(
+            path.to_string(),
+            cwd.to_path_buf(),
+        )]),
+        "all" => {
+            // Passive enumeration, same as `ws list`: mounts are listed only
+            // while the daemon is already running. `all:` never starts the
+            // daemon, so a pure-local query is not blocked on daemon startup.
+            let registry = crate::origins::collect(cwd)?;
+            Ok(registry
+                .entries()
+                .map(|entry| QuerySource::from_entry(entry, path))
+                .collect())
+        }
+        // Everything else is a named origin (local workspace or remote
+        // mount) or a group. The registry is the single alias table;
+        // resolution applies kind precedence on name collisions.
+        scope => {
+            let mut registry = crate::origins::collect(cwd)?;
+            // The registry lists mounts only while the daemon is already
+            // running, so a passive miss is retried once with the daemon up
+            // — a cold `desk:terminal` query must still resolve its mount.
+            if registry.resolve(scope)?.is_none() {
+                serve::ensure_running()?;
+                registry = crate::origins::collect(cwd)?;
+            }
+            match registry.resolve(scope)? {
+                Some(entry) => Ok(vec![QuerySource::from_entry(entry, path)]),
+                None if split_group_scope(scope).is_some() => {
+                    Ok(vec![QuerySource::group(&source)])
+                }
+                None => anyhow::bail!(
+                    "unknown scope `{scope}`; use `sivtr ws list` for local workspaces, `sivtr remote list` for remotes, or `sivtr group list` for groups"
+                ),
+            }
+        }
     }
-    if let Some(entry) = registry.resolve(&scope)? {
-        return match &entry.reach {
-            Reach::Local { root } => Ok(vec![QuerySource {
-                selector: path.to_string(),
-                transport: QueryTransport::Local,
-                root: Some(PathBuf::from(root)),
-                timeout: REMOTE_QUERY_TIMEOUT,
-            }]),
-            Reach::Remote { .. } => Ok(vec![QuerySource::remote(format!(
-                "{}:{path}",
-                entry.origin.name
-            ))]),
-        };
-    }
-    if split_group_scope(&scope).is_some() {
-        return Ok(vec![QuerySource::group(&source)]);
-    }
-    anyhow::bail!(
-        "unknown scope `{scope}`; use `sivtr ws list` for local workspaces, `sivtr remote list` for remotes, or `sivtr group list` for groups"
-    )
 }
 
 /// Merge per-source outcomes into one corpus, then apply the filter once
@@ -238,7 +239,7 @@ fn merge_and_apply(results: Vec<QuerySourceResult>, cwd: &Path, filter: Filter) 
 /// so one batch spans every local workspace; remotes run with a per-source
 /// timeout and out-of-order arrival, and a source's failure never drops the
 /// others. Order of `results` matches `sources`.
-pub fn query_many(
+pub fn query_sources(
     sources: &[QuerySource],
     filter: Filter,
     cwd: Option<&Path>,
@@ -250,6 +251,7 @@ pub fn query_many(
     let cwd = cwd
         .map(Path::to_path_buf)
         .unwrap_or(std::env::current_dir().context("Failed to resolve current directory")?);
+    let cwd = cwd.as_path();
 
     // Bounds that read part text (pattern, exclude, BM25 ranking) need a full
     // load; metadata-only filters stay light and callers materialize part
@@ -260,45 +262,45 @@ pub fn query_many(
         LoadMode::Light
     };
 
-    let (tx, rx) = mpsc::channel();
-    let mut pending = 0;
-    for (idx, source) in sources.iter().enumerate() {
-        let selector = source.selector.clone();
-        let filter = filter.clone();
-        let cwd = cwd.clone();
-        let root = source.root.clone();
-        let timeout = source.timeout;
-        let transport = source.transport;
-        let tx = tx.clone();
-        pending += 1;
-        thread::spawn(move || {
-            let result = match transport {
-                QueryTransport::Local => {
-                    let root = root.as_deref().unwrap_or(&cwd);
-                    run_local(&selector, root, filter, mode)
-                }
-                QueryTransport::Remote => query_remote_bounded(&selector, filter, &cwd, timeout),
-                QueryTransport::Group => group_query(&selector, filter, &cwd),
-            };
-            let normalized = normalize_source_result(result, &cwd);
-            let _ = tx.send((idx, normalized));
-        });
-    }
-    drop(tx);
+    // Scoped threads borrow `sources` and `cwd` instead of cloning per
+    // worker; only the filter (consumed by each load path) is cloned. Each
+    // worker reports `(idx, outcome)`, joined in list order so a slow source
+    // never stalls the others' completion.
+    let outcomes = std::thread::scope(|scope| {
+        let handles: Vec<_> = sources
+            .iter()
+            .enumerate()
+            .map(|(idx, source)| {
+                let filter = filter.clone();
+                scope.spawn(move || {
+                    let result = match source.transport {
+                        QueryTransport::Local => {
+                            let root = source.root.as_deref().unwrap_or(cwd);
+                            run_local(&source.selector, root, filter, mode)
+                        }
+                        QueryTransport::Remote => query_remote_bounded(
+                            &source.selector,
+                            source.workspace_key.as_deref(),
+                            filter,
+                            cwd,
+                            source.timeout,
+                        ),
+                        QueryTransport::Group => group_query(&source.selector, filter, cwd),
+                    };
+                    (idx, normalize_source_result(result, cwd))
+                })
+            })
+            .collect();
 
-    let mut results: Vec<Option<QuerySourceResult>> = sources.iter().map(|_| None).collect();
-    let mut remaining = pending;
-    while remaining > 0 {
-        match rx.recv() {
-            Ok((idx, result)) => {
-                results[idx] = Some(result);
-                remaining -= 1;
-            }
-            Err(_) => break, // all senders dropped
+        let mut outcomes: Vec<Option<QuerySourceResult>> = sources.iter().map(|_| None).collect();
+        for handle in handles {
+            let (idx, outcome) = handle.join().expect("query worker panicked");
+            outcomes[idx] = Some(outcome);
         }
-    }
+        outcomes
+    });
 
-    Ok(results
+    Ok(outcomes
         .into_iter()
         .map(|slot| slot.unwrap_or(QuerySourceResult::Err("load worker exited".to_string())))
         .collect())
@@ -329,6 +331,7 @@ fn normalize_source_result(result: Result<WorkSet>, cwd: &Path) -> QuerySourceRe
 
 fn query_remote_bounded(
     selector: &str,
+    workspace_key: Option<&str>,
     filter: Filter,
     cwd: &Path,
     read_timeout: Duration,
@@ -342,24 +345,23 @@ fn query_remote_bounded(
     if path.is_empty() || path.starts_with('/') || scope.eq_ignore_ascii_case("local") {
         anyhow::bail!("remote source `{selector}` must be `alias:path`");
     }
-    // Remote mounts need the daemon; start it before the passive lookup.
-    serve::ensure_running()?;
-    let registry = crate::origins::collect(cwd)?;
-    let Some(entry) = registry.resolve(scope)? else {
-        anyhow::bail!("unknown remote alias `{scope}`; use `sivtr remote list`");
+    // Pre-resolved sources skip the registry; browse-built ones resolve here.
+    let workspace_key = match workspace_key {
+        Some(key) => key.to_string(),
+        None => {
+            serve::ensure_running()?;
+            let registry = crate::origins::collect(cwd)?;
+            let Some(entry) = registry.resolve(scope)? else {
+                anyhow::bail!("unknown remote alias `{scope}`; use `sivtr remote list`");
+            };
+            let Reach::Remote { workspace_key } = &entry.reach else {
+                anyhow::bail!("`{scope}` is not a remote mount");
+            };
+            workspace_key.clone()
+        }
     };
-    match &entry.reach {
-        Reach::Remote { workspace_key } => try_remote_timed(
-            workspace_key,
-            &entry.origin.name,
-            path,
-            filter,
-            cwd,
-            read_timeout,
-        )
-        .with_context(|| format!("remote mount `{}` unavailable", entry.origin.name)),
-        _ => anyhow::bail!("`{scope}` is not a remote mount"),
-    }
+    try_remote_timed(&workspace_key, scope, path, filter, cwd, read_timeout)
+        .with_context(|| format!("remote mount `{scope}` unavailable"))
 }
 
 fn is_timeout_error(message: &str) -> bool {

--- a/src/commands/memory/workset/source.rs
+++ b/src/commands/memory/workset/source.rs
@@ -210,9 +210,11 @@ fn merge_and_apply(results: Vec<QuerySourceResult>, cwd: &Path, filter: Filter) 
     let mut records: Vec<WorkRecord> = Vec::new();
     let mut seen: HashSet<WorkRef> = HashSet::new();
     let mut errors: Vec<String> = Vec::new();
+    let mut any_ok = false;
     for result in results {
         match result {
             QuerySourceResult::Ok(set) => {
+                any_ok = true;
                 for record in set.records {
                     if seen.insert(record.work_ref.whole()) {
                         records.push(record);
@@ -222,7 +224,7 @@ fn merge_and_apply(results: Vec<QuerySourceResult>, cwd: &Path, filter: Filter) 
             QuerySourceResult::Err(message) => errors.push(message),
         }
     }
-    if records.is_empty() {
+    if !any_ok {
         if let Some(first) = errors.first() {
             anyhow::bail!("{first}");
         }
@@ -285,7 +287,9 @@ pub fn query_sources(
                             cwd,
                             source.timeout,
                         ),
-                        QueryTransport::Group => group_query(&source.selector, filter, cwd),
+                        QueryTransport::Group => {
+                            group_query(&source.selector, filter, cwd, source.timeout)
+                        }
                     };
                     (idx, normalize_source_result(result, cwd))
                 })
@@ -293,9 +297,13 @@ pub fn query_sources(
             .collect();
 
         let mut outcomes: Vec<Option<QuerySourceResult>> = sources.iter().map(|_| None).collect();
-        for handle in handles {
-            let (idx, outcome) = handle.join().expect("query worker panicked");
-            outcomes[idx] = Some(outcome);
+        for (slot, handle) in handles.into_iter().enumerate() {
+            // A panicked worker must not abort the batch; it becomes that
+            // source's error, and the rest still complete.
+            outcomes[slot] = Some(match handle.join() {
+                Ok((_idx, outcome)) => outcome,
+                Err(_) => QuerySourceResult::Err("query worker panicked".to_string()),
+            });
         }
         outcomes
     });
@@ -451,7 +459,12 @@ fn try_remote_timed(
 /// answers `None` when the group is unknown, which a scheduled [`QuerySource`]
 /// treats as a hard error — the scope was already pinned to a group by the
 /// caller.
-fn group_query(selector: &str, filter: Filter, cwd: &Path) -> Result<WorkSet> {
+fn group_query(
+    selector: &str,
+    filter: Filter,
+    cwd: &Path,
+    read_timeout: Duration,
+) -> Result<WorkSet> {
     use crate::remote::ipc;
     use crate::remote::protocol::{LocalRequest, LocalResponse};
 
@@ -476,7 +489,7 @@ fn group_query(selector: &str, filter: Filter, cwd: &Path) -> Result<WorkSet> {
             source: path.to_string(),
             filter,
         },
-        GROUP_QUERY_TIMEOUT,
+        read_timeout,
     )
     .context("group query failed")?
     {

--- a/src/commands/memory/workset/source.rs
+++ b/src/commands/memory/workset/source.rs
@@ -32,6 +32,9 @@ pub enum QueryTransport {
     Local,
     /// Mounted remote alias. Failures are isolated when using [`query_many`].
     Remote,
+    /// Group roster fan-out (`team:...`, `team/alice:...`): the daemon dials
+    /// every member share in parallel and returns the merged result.
+    Group,
 }
 
 /// One source to load via the unified query path.
@@ -43,6 +46,8 @@ pub struct QuerySource {
     /// Local sources load from this root instead of the caller's cwd
     /// (`None` = caller cwd). Lets one batch span many local workspaces.
     pub root: Option<PathBuf>,
+    /// Deadline for remote dials and group fan-out; local loads ignore it.
+    pub timeout: Duration,
 }
 
 impl QuerySource {
@@ -51,6 +56,7 @@ impl QuerySource {
             selector: selector.into(),
             transport: QueryTransport::Local,
             root: None,
+            timeout: REMOTE_QUERY_TIMEOUT,
         }
     }
 
@@ -59,6 +65,16 @@ impl QuerySource {
             selector: selector.into(),
             transport: QueryTransport::Remote,
             root: None,
+            timeout: REMOTE_QUERY_TIMEOUT,
+        }
+    }
+
+    pub fn group(selector: impl Into<String>) -> Self {
+        Self {
+            selector: selector.into(),
+            transport: QueryTransport::Group,
+            root: None,
+            timeout: GROUP_QUERY_TIMEOUT,
         }
     }
 
@@ -72,6 +88,7 @@ impl QuerySource {
                 selector: source.to_string(),
                 transport: QueryTransport::Local,
                 root: Some(PathBuf::from(root)),
+                timeout: REMOTE_QUERY_TIMEOUT,
             },
             Reach::Remote { .. } => Self::remote(format!("{}:{source}", entry.origin.name)),
         }
@@ -155,16 +172,25 @@ pub fn query(source: &str, filter: Filter, cwd: Option<&Path>) -> Result<WorkSet
                     &cwd,
                     Duration::from_secs(30),
                 )
-                .with_context(|| {
-                    format!("remote mount `{}` unavailable", entry.origin.name)
-                }),
+                .with_context(|| format!("remote mount `{}` unavailable", entry.origin.name)),
             },
-            None => match try_group(&scope, path, filter, &cwd)? {
-                Some(set) => Ok(set),
-                None => anyhow::bail!(
+            None => {
+                // Not a registry origin; check if it is a group scope.
+                if split_group_scope(&scope).is_some() {
+                    let mut results =
+                        query_many(&[QuerySource::group(&source)], filter, Some(&cwd))?;
+                    return match results.pop() {
+                        Some(QuerySourceResult::Ok(set)) => Ok(set),
+                        Some(QuerySourceResult::Err(message)) => {
+                            anyhow::bail!("{message}")
+                        }
+                        None => anyhow::bail!("group query produced no result"),
+                    };
+                }
+                anyhow::bail!(
                     "unknown scope `{scope}`; use `sivtr ws list` for local workspaces, `sivtr remote list` for remotes, or `sivtr group list` for groups"
-                ),
-            },
+                )
+            }
         };
     }
 
@@ -180,7 +206,6 @@ pub fn query_many(
     sources: &[QuerySource],
     filter: Filter,
     cwd: Option<&Path>,
-    remote_timeout: Duration,
 ) -> Result<Vec<QuerySourceResult>> {
     if sources.is_empty() {
         return Ok(Vec::new());
@@ -197,14 +222,15 @@ pub fn query_many(
         let filter = filter.clone();
         let cwd = cwd.clone();
         let root = source.root.clone();
-        let remote = source.transport == QueryTransport::Remote;
+        let timeout = source.timeout;
+        let transport = source.transport;
         let tx = tx.clone();
         pending += 1;
         thread::spawn(move || {
-            let result = if remote {
-                query_remote_bounded(&selector, filter, &cwd, remote_timeout)
-            } else {
-                query(&selector, filter, root.as_deref())
+            let result = match transport {
+                QueryTransport::Local => query(&selector, filter, root.as_deref()),
+                QueryTransport::Remote => query_remote_bounded(&selector, filter, &cwd, timeout),
+                QueryTransport::Group => group_query(&selector, filter, &cwd),
             };
             let normalized = normalize_source_result(result, &cwd);
             let _ = tx.send((idx, normalized));
@@ -349,7 +375,7 @@ fn run_all(source: &str, cwd: &Path, filter: Filter) -> Result<WorkSet> {
         .entries()
         .map(|entry| QuerySource::from_entry(entry, source))
         .collect();
-    let results = query_many(&sources, Filter::none(), Some(cwd), REMOTE_QUERY_TIMEOUT)
+    let results = query_many(&sources, Filter::none(), Some(cwd))
         .with_context(|| format!("failed to load `{source}` from every origin"))?;
 
     // Merge with per-ref dedup: a workref may appear in more than one origin
@@ -409,15 +435,21 @@ fn try_remote_timed(
 }
 
 /// Group fan-out: `team:...` (all members), `team/alice:...` (one member), or
-/// `team/alice/proj-b:...` (one member, one contributed share). Returns
-/// `Ok(None)` when `scope` is not a group on this device so the caller can
-/// continue the scope cascade.
-fn try_group(scope: &str, path: &str, filter: Filter, cwd: &Path) -> Result<Option<WorkSet>> {
+/// `team/alice/proj-b:...` (one member, one contributed share). The daemon
+/// answers `None` when the group is unknown, which a scheduled [`QuerySource`]
+/// treats as a hard error — the scope was already pinned to a group by the
+/// caller.
+fn group_query(selector: &str, filter: Filter, cwd: &Path) -> Result<WorkSet> {
     use crate::remote::ipc;
     use crate::remote::protocol::{LocalRequest, LocalResponse};
 
+    let Some((scope, path)) = selector.split_once(':') else {
+        anyhow::bail!("group source `{selector}` is missing a selector after `:`");
+    };
     let Some((group, member, share)) = split_group_scope(scope) else {
-        return Ok(None);
+        anyhow::bail!(
+            "`{scope}` is not a group scope; use `team:`, `team/alice:`, or `team/alice/proj-b:`"
+        );
     };
     crate::commands::remote::serve::ensure_running()
         .context("failed to start the sivtr daemon for a group query")?;
@@ -436,7 +468,9 @@ fn try_group(scope: &str, path: &str, filter: Filter, cwd: &Path) -> Result<Opti
     )
     .context("group query failed")?
     {
-        LocalResponse::GroupQuery(None) => Ok(None),
+        LocalResponse::GroupQuery(None) => {
+            anyhow::bail!("unknown group; use `sivtr group list` to see groups")
+        }
         LocalResponse::GroupQuery(Some(response)) => {
             if !response.skipped.is_empty() {
                 output::info(format!(
@@ -444,11 +478,11 @@ fn try_group(scope: &str, path: &str, filter: Filter, cwd: &Path) -> Result<Opti
                     response.skipped.join(", ")
                 ));
             }
-            Ok(Some(WorkSet::with_anchors(
+            Ok(WorkSet::with_anchors(
                 cwd.display().to_string(),
                 response.query.records,
                 response.query.anchors,
-            )))
+            ))
         }
         response => anyhow::bail!("Unexpected daemon response: {response:?}"),
     }

--- a/src/commands/memory/workset/source.rs
+++ b/src/commands/memory/workset/source.rs
@@ -102,22 +102,14 @@ pub enum QuerySourceResult {
     Err(String),
 }
 
-/// Unified query: local and remote share one shape.
+/// Unified query: local, remote, and group sources share one shape.
 ///
-/// Remote is only transport: same `Filter` is sent, peer runs the same local path
-/// on the share root, result comes back. The load mode is derived from the
-/// filter: bounds that read part text (pattern, exclude, BM25 ranking) force a
-/// full load; pure metadata queries stay light and callers materialize part
-/// text on demand.
+/// Remote is only transport: same `Filter` is sent, peer runs the same local
+/// path on the share root, result comes back. The load mode is derived from
+/// the filter: bounds that read part text (pattern, exclude, BM25 ranking)
+/// force a full load; pure metadata queries stay light and callers
+/// materialize part text on demand.
 pub fn query(source: &str, filter: Filter, cwd: Option<&Path>) -> Result<WorkSet> {
-    // Bounds that read part text (pattern, exclude, BM25 ranking) need a full
-    // load; metadata-only filters stay light and callers materialize part
-    // text on demand.
-    let mode = if filter.needs_parts() {
-        LoadMode::Full
-    } else {
-        LoadMode::Light
-    };
     if source == "@" {
         return apply_loaded(read_stdin()?, filter);
     }
@@ -129,79 +121,123 @@ pub fn query(source: &str, filter: Filter, cwd: Option<&Path>) -> Result<WorkSet
         .map(Path::to_path_buf)
         .unwrap_or(std::env::current_dir().context("Failed to resolve current directory")?);
 
-    let source = expand_source(source)?;
-
-    if let Some((scope, path)) = source.split_once(':') {
-        if path.is_empty() {
-            anyhow::bail!("source `{source}` is missing a selector after `:`");
-        }
-        if path.starts_with('/') {
-            anyhow::bail!(
-                "Invalid source `{source}`; use `scope:path` (for example `desk:terminal`), not `://`"
-            );
-        }
-        if scope.eq_ignore_ascii_case("local") {
-            return run_local(path, &cwd, filter, mode);
-        }
-        if scope.eq_ignore_ascii_case("all") {
-            return run_all(path, &cwd, filter);
-        }
-        let scope = scope.to_ascii_lowercase();
-
-        // One lookup: the registry is the single alias table (local
-        // workspaces, remote mounts), each entry carrying its reach payload;
-        // resolution applies kind precedence on name collisions.
-        // The registry lists mounts only while the daemon is already running,
-        // so a passive miss is retried once with the daemon up — a cold
-        // `desk:terminal` query must still resolve its mount. Groups
-        // (`team`, `team/alice`) are a roster fan-out over many devices, not
-        // a single origin, so they are tried only on a miss.
-        let mut registry = crate::origins::collect(&cwd)?;
-        if registry.resolve(&scope)?.is_none() {
-            serve::ensure_running()?;
-            registry = crate::origins::collect(&cwd)?;
-        }
-        return match registry.resolve(&scope)? {
-            Some(entry) => match &entry.reach {
-                Reach::Local { root } => run_local(path, Path::new(root), filter, mode),
-                Reach::Remote { workspace_key } => try_remote_timed(
-                    workspace_key,
-                    &entry.origin.name,
-                    path,
-                    filter,
-                    &cwd,
-                    Duration::from_secs(30),
-                )
-                .with_context(|| format!("remote mount `{}` unavailable", entry.origin.name)),
-            },
-            None => {
-                // Not a registry origin; check if it is a group scope.
-                if split_group_scope(&scope).is_some() {
-                    let mut results =
-                        query_many(&[QuerySource::group(&source)], filter, Some(&cwd))?;
-                    return match results.pop() {
-                        Some(QuerySourceResult::Ok(set)) => Ok(set),
-                        Some(QuerySourceResult::Err(message)) => {
-                            anyhow::bail!("{message}")
-                        }
-                        None => anyhow::bail!("group query produced no result"),
-                    };
-                }
-                anyhow::bail!(
-                    "unknown scope `{scope}`; use `sivtr ws list` for local workspaces, `sivtr remote list` for remotes, or `sivtr group list` for groups"
-                )
-            }
-        };
-    }
-
-    run_local(&source, &cwd, filter, mode)
+    let sources = resolve_source(source, &cwd)?;
+    let results = query_many(&sources, filter.clone(), Some(&cwd))?;
+    merge_and_apply(results, &cwd, filter)
 }
 
-/// Load many sources in parallel — local and remote share one scheduler.
-/// A local source may carry its own root ([`QuerySource::root`]) so one batch
-/// spans every local workspace; remotes run with a per-source timeout and
-/// out-of-order arrival, and a source's failure never drops the others.
-/// Order of `results` matches `sources`.
+/// Resolve a source expression into the concrete sources it addresses.
+/// Every scope shape (bare selector, `local:`, `all:`, registry aliases,
+/// groups) collapses into a [`QuerySource`] list here; [`query_many`] then
+/// schedules them unchanged.
+fn resolve_source(source: &str, cwd: &Path) -> Result<Vec<QuerySource>> {
+    let source = expand_source(source)?;
+
+    let Some((scope, path)) = source.split_once(':') else {
+        return Ok(vec![QuerySource {
+            selector: source,
+            transport: QueryTransport::Local,
+            root: Some(cwd.to_path_buf()),
+            timeout: REMOTE_QUERY_TIMEOUT,
+        }]);
+    };
+    if path.is_empty() {
+        anyhow::bail!("source `{source}` is missing a selector after `:`");
+    }
+    if path.starts_with('/') {
+        anyhow::bail!(
+            "Invalid source `{source}`; use `scope:path` (for example `desk:terminal`), not `://`"
+        );
+    }
+    if scope.eq_ignore_ascii_case("local") {
+        return Ok(vec![QuerySource {
+            selector: path.to_string(),
+            transport: QueryTransport::Local,
+            root: Some(cwd.to_path_buf()),
+            timeout: REMOTE_QUERY_TIMEOUT,
+        }]);
+    }
+    if scope.eq_ignore_ascii_case("all") {
+        let registry = crate::origins::collect(cwd)?;
+        let sources: Vec<QuerySource> = registry
+            .entries()
+            .map(|entry| QuerySource::from_entry(entry, path))
+            .collect();
+        return Ok(sources);
+    }
+
+    let scope = scope.to_ascii_lowercase();
+
+    // One lookup: the registry is the single alias table (local workspaces,
+    // remote mounts), each entry carrying its reach payload. The registry
+    // lists mounts only while the daemon is already running, so a passive
+    // miss is retried once with the daemon up — a cold `desk:terminal` query
+    // must still resolve its mount. Groups (`team`, `team/alice`) are a
+    // roster fan-out over many devices, not a single origin, so they are
+    // tried only on a miss.
+    let mut registry = crate::origins::collect(cwd)?;
+    if registry.resolve(&scope)?.is_none() {
+        serve::ensure_running()?;
+        registry = crate::origins::collect(cwd)?;
+    }
+    if let Some(entry) = registry.resolve(&scope)? {
+        return match &entry.reach {
+            Reach::Local { root } => Ok(vec![QuerySource {
+                selector: path.to_string(),
+                transport: QueryTransport::Local,
+                root: Some(PathBuf::from(root)),
+                timeout: REMOTE_QUERY_TIMEOUT,
+            }]),
+            Reach::Remote { .. } => Ok(vec![QuerySource::remote(format!(
+                "{}:{path}",
+                entry.origin.name
+            ))]),
+        };
+    }
+    if split_group_scope(&scope).is_some() {
+        return Ok(vec![QuerySource::group(&source)]);
+    }
+    anyhow::bail!(
+        "unknown scope `{scope}`; use `sivtr ws list` for local workspaces, `sivtr remote list` for remotes, or `sivtr group list` for groups"
+    )
+}
+
+/// Merge per-source outcomes into one corpus, then apply the filter once
+/// across the merged records. A failed source drops without aborting the
+/// batch; when every source failed, the first error is what the caller sees.
+fn merge_and_apply(results: Vec<QuerySourceResult>, cwd: &Path, filter: Filter) -> Result<WorkSet> {
+    let mut records: Vec<WorkRecord> = Vec::new();
+    let mut seen: HashSet<WorkRef> = HashSet::new();
+    let mut errors: Vec<String> = Vec::new();
+    for result in results {
+        match result {
+            QuerySourceResult::Ok(set) => {
+                for record in set.records {
+                    if seen.insert(record.work_ref.whole()) {
+                        records.push(record);
+                    }
+                }
+            }
+            QuerySourceResult::Err(message) => errors.push(message),
+        }
+    }
+    if records.is_empty() {
+        if let Some(first) = errors.first() {
+            anyhow::bail!("{first}");
+        }
+        return apply_loaded(WorkSet::new(cwd.display().to_string(), Vec::new()), filter);
+    }
+    for error in &errors {
+        output::warning(format!("skipped an origin: {error}"));
+    }
+    apply_loaded(WorkSet::new(cwd.display().to_string(), records), filter)
+}
+
+/// Load many sources in parallel — local, remote, and group share one
+/// scheduler. A local source may carry its own root ([`QuerySource::root`])
+/// so one batch spans every local workspace; remotes run with a per-source
+/// timeout and out-of-order arrival, and a source's failure never drops the
+/// others. Order of `results` matches `sources`.
 pub fn query_many(
     sources: &[QuerySource],
     filter: Filter,
@@ -214,6 +250,15 @@ pub fn query_many(
     let cwd = cwd
         .map(Path::to_path_buf)
         .unwrap_or(std::env::current_dir().context("Failed to resolve current directory")?);
+
+    // Bounds that read part text (pattern, exclude, BM25 ranking) need a full
+    // load; metadata-only filters stay light and callers materialize part
+    // text on demand.
+    let mode = if filter.needs_parts() {
+        LoadMode::Full
+    } else {
+        LoadMode::Light
+    };
 
     let (tx, rx) = mpsc::channel();
     let mut pending = 0;
@@ -228,7 +273,10 @@ pub fn query_many(
         pending += 1;
         thread::spawn(move || {
             let result = match transport {
-                QueryTransport::Local => query(&selector, filter, root.as_deref()),
+                QueryTransport::Local => {
+                    let root = root.as_deref().unwrap_or(&cwd);
+                    run_local(&selector, root, filter, mode)
+                }
                 QueryTransport::Remote => query_remote_bounded(&selector, filter, &cwd, timeout),
                 QueryTransport::Group => group_query(&selector, filter, &cwd),
             };
@@ -285,21 +333,20 @@ fn query_remote_bounded(
     cwd: &Path,
     read_timeout: Duration,
 ) -> Result<WorkSet> {
-    // Only confirmed mounts need the timed IPC path, so the daemon socket
-    // itself respects the interactive deadline. Everything else — groups,
-    // named local workspaces, plain selectors — goes through the unified
-    // [`query`], which resolves it in one registry lookup.
+    // Remote sources are always `alias:path` — resolve_source pins them, and
+    // browse builds them from registry origins. Anything else is a bug in
+    // the caller, not a selector to re-resolve.
     let Some((scope, path)) = selector.split_once(':') else {
-        return query(selector, filter, Some(cwd));
+        anyhow::bail!("remote source `{selector}` must be `alias:path`");
     };
     if path.is_empty() || path.starts_with('/') || scope.eq_ignore_ascii_case("local") {
-        return query(selector, filter, Some(cwd));
+        anyhow::bail!("remote source `{selector}` must be `alias:path`");
     }
     // Remote mounts need the daemon; start it before the passive lookup.
     serve::ensure_running()?;
     let registry = crate::origins::collect(cwd)?;
     let Some(entry) = registry.resolve(scope)? else {
-        return query(selector, filter, Some(cwd));
+        anyhow::bail!("unknown remote alias `{scope}`; use `sivtr remote list`");
     };
     match &entry.reach {
         Reach::Remote { workspace_key } => try_remote_timed(
@@ -311,7 +358,7 @@ fn query_remote_bounded(
             read_timeout,
         )
         .with_context(|| format!("remote mount `{}` unavailable", entry.origin.name)),
-        _ => query(selector, filter, Some(cwd)),
+        _ => anyhow::bail!("`{scope}` is not a remote mount"),
     }
 }
 
@@ -361,43 +408,6 @@ fn run_local(source: &str, root: &Path, filter: Filter, mode: LoadMode) -> Resul
     )
 }
 
-/// Load `source` from every addressable origin (all local workspaces plus the
-/// current workspace's remote mounts), merge them into one corpus, then apply
-/// the filter once — so reachability limit and relevance ranking are global
-/// across origins, not per-origin.
-fn run_all(source: &str, cwd: &Path, filter: Filter) -> Result<WorkSet> {
-    // Passive enumeration, same as `ws list` / `sivtr_status`: mounts are
-    // listed only while the daemon is already running. `all:` never starts
-    // the daemon, so a pure-local query is not blocked on daemon startup.
-    let registry = crate::origins::collect(cwd)?;
-
-    let sources: Vec<QuerySource> = registry
-        .entries()
-        .map(|entry| QuerySource::from_entry(entry, source))
-        .collect();
-    let results = query_many(&sources, Filter::none(), Some(cwd))
-        .with_context(|| format!("failed to load `{source}` from every origin"))?;
-
-    // Merge with per-ref dedup: a workref may appear in more than one origin
-    // (same provider session recorded from multiple checkouts).
-    let mut records: Vec<WorkRecord> = Vec::new();
-    let mut seen: HashSet<WorkRef> = HashSet::new();
-    for result in results {
-        let QuerySourceResult::Ok(set) = result else {
-            output::warning(format!(
-                "skipped an origin during `all:{source}`: {result:?}"
-            ));
-            continue;
-        };
-        for record in set.records {
-            if seen.insert(record.work_ref.whole()) {
-                records.push(record);
-            }
-        }
-    }
-
-    apply_loaded(WorkSet::new(cwd.display().to_string(), records), filter)
-}
 fn apply_loaded(set: WorkSet, filter: Filter) -> Result<WorkSet> {
     filter::apply(PathBuf::from(&set.cwd), set.records, set.anchors, filter)
 }
@@ -574,7 +584,7 @@ pub fn load_context_records(
 
 #[cfg(test)]
 mod tests {
-    use super::split_group_scope;
+    use super::{resolve_source, split_group_scope, QueryTransport};
 
     #[test]
     fn group_scope_splits_team_and_member_forms() {
@@ -600,5 +610,32 @@ mod tests {
         assert_eq!(split_group_scope(""), None);
         assert_eq!(split_group_scope("team/"), None);
         assert_eq!(split_group_scope("a b"), None);
+    }
+
+    #[test]
+    fn resolve_bare_selector_is_local_with_cwd_root() {
+        let cwd = std::path::Path::new("/repo");
+        let sources = resolve_source("terminal", cwd).expect("resolve");
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0].selector, "terminal");
+        assert_eq!(sources[0].transport, QueryTransport::Local);
+        assert_eq!(sources[0].root.as_deref(), Some(cwd));
+    }
+
+    #[test]
+    fn resolve_local_prefix_strips_the_scope() {
+        let cwd = std::path::Path::new("/repo");
+        let sources = resolve_source("local:codex", cwd).expect("resolve");
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0].selector, "codex");
+        assert_eq!(sources[0].transport, QueryTransport::Local);
+        assert_eq!(sources[0].root.as_deref(), Some(cwd));
+    }
+
+    #[test]
+    fn resolve_rejects_empty_or_absolute_paths() {
+        let cwd = std::path::Path::new("/repo");
+        assert!(resolve_source("desk:", cwd).is_err());
+        assert!(resolve_source("desk:/absolute", cwd).is_err());
     }
 }

--- a/src/commands/remote/workspace.rs
+++ b/src/commands/remote/workspace.rs
@@ -21,9 +21,9 @@ fn list() -> Result<()> {
 
     for origin in registry.all() {
         let label = if origin.current {
-            format!("{}:current", origin.kind.label())
+            format!("{}:current", origin.kind)
         } else {
-            origin.kind.label().to_string()
+            origin.kind.clone()
         };
         output::detail(origin.name.clone(), format!("[{label}] {}", origin.detail));
     }

--- a/src/commands/remote/workspace.rs
+++ b/src/commands/remote/workspace.rs
@@ -19,11 +19,12 @@ fn list() -> Result<()> {
         return Ok(());
     }
 
-    for origin in registry.all() {
+    for entry in registry.entries() {
+        let origin = &entry.origin;
         let label = if origin.current {
-            format!("{}:current", origin.kind)
+            format!("{}:current", entry.reach.label())
         } else {
-            origin.kind.clone()
+            entry.reach.label().to_string()
         };
         output::detail(origin.name.clone(), format!("[{label}] {}", origin.detail));
     }

--- a/src/origins.rs
+++ b/src/origins.rs
@@ -10,7 +10,7 @@
 use anyhow::{bail, Context, Result};
 use std::path::Path;
 
-use sivtr_core::origin::{Entry, Origin, OriginKind, OriginRegistry, Reach};
+use sivtr_core::origin::{Entry, Origin, OriginRegistry, Reach};
 use sivtr_core::workspace;
 
 use crate::commands::remote::serve;
@@ -29,14 +29,17 @@ pub fn collect(cwd: &Path) -> Result<OriginRegistry> {
     let current_key = workspace::resolve_workspace_for_dir(cwd)?.map(|paths| paths.key);
     for meta in workspace::list_workspaces()? {
         let current = current_key.as_deref() == Some(meta.key.as_str());
+        let reach = Reach::Local {
+            root: meta.root.clone(),
+        };
         entries.push(Entry {
             origin: Origin {
                 name: workspace::workspace_alias(&meta),
-                kind: OriginKind::Local,
+                kind: reach.label().to_string(),
                 current,
                 detail: format!("{} ({})", meta.root, meta.key),
             },
-            reach: Reach::Local { root: meta.root },
+            reach,
         });
     }
 
@@ -51,16 +54,17 @@ pub fn collect(cwd: &Path) -> Result<OriginRegistry> {
             })? {
                 LocalResponse::Mounts(mounts) => {
                     for mount in mounts {
+                        let reach = Reach::Remote {
+                            workspace_key: workspace_key.to_string(),
+                        };
                         entries.push(Entry {
                             origin: Origin {
                                 name: mount.alias.clone(),
-                                kind: OriginKind::Remote,
+                                kind: reach.label().to_string(),
                                 current: false,
                                 detail: format!("{}/{}", mount.peer_name, mount.share_name),
                             },
-                            reach: Reach::Remote {
-                                workspace_key: workspace_key.to_string(),
-                            },
+                            reach,
                         });
                     }
                 }

--- a/src/origins.rs
+++ b/src/origins.rs
@@ -10,7 +10,7 @@
 use anyhow::{bail, Context, Result};
 use std::path::Path;
 
-use sivtr_core::origin::{Entry, Origin, OriginRegistry, Reach};
+use sivtr_core::origin::{Entry, OriginRegistry, Reach};
 use sivtr_core::workspace;
 
 use crate::commands::remote::serve;
@@ -29,18 +29,14 @@ pub fn collect(cwd: &Path) -> Result<OriginRegistry> {
     let current_key = workspace::resolve_workspace_for_dir(cwd)?.map(|paths| paths.key);
     for meta in workspace::list_workspaces()? {
         let current = current_key.as_deref() == Some(meta.key.as_str());
-        let reach = Reach::Local {
-            root: meta.root.clone(),
-        };
-        entries.push(Entry {
-            origin: Origin {
-                name: workspace::workspace_alias(&meta),
-                kind: reach.label().to_string(),
-                current,
-                detail: format!("{} ({})", meta.root, meta.key),
+        entries.push(Entry::new(
+            workspace::workspace_alias(&meta),
+            current,
+            format!("{} ({})", meta.root, meta.key),
+            Reach::Local {
+                root: meta.root.clone(),
             },
-            reach,
-        });
+        ));
     }
 
     if let Some(workspace_key) = current_key.as_deref() {
@@ -54,18 +50,14 @@ pub fn collect(cwd: &Path) -> Result<OriginRegistry> {
             })? {
                 LocalResponse::Mounts(mounts) => {
                     for mount in mounts {
-                        let reach = Reach::Remote {
-                            workspace_key: workspace_key.to_string(),
-                        };
-                        entries.push(Entry {
-                            origin: Origin {
-                                name: mount.alias.clone(),
-                                kind: reach.label().to_string(),
-                                current: false,
-                                detail: format!("{}/{}", mount.peer_name, mount.share_name),
+                        entries.push(Entry::new(
+                            mount.alias.clone(),
+                            false,
+                            format!("{}/{}", mount.peer_name, mount.share_name),
+                            Reach::Remote {
+                                workspace_key: workspace_key.to_string(),
                             },
-                            reach,
-                        });
+                        ));
                     }
                 }
                 response => anyhow::bail!("Unexpected daemon response: {response:?}"),


### PR DESCRIPTION
## Purpose

Unify the query pipeline into three stages (parse -> dispatch -> merge) so every source kind (local workspace, remote mount, group fan-out) flows through one scheduler instead of forked paths. Drops the `OriginKind` duplicate classification and folds group fan-out into the transport model.

## Main changes

- `query()` shrinks to a thin shell: `resolve_source` -> `query_sources` -> `merge_and_apply`
- `resolve_source` is the single parse point (bare selector, `local:`, `all:`, `scope:` -> Local/Remote/Group)
- `query_sources` (renamed from `query_many`) is the single parallel scheduler, using scoped threads (no per-thread clones, join-based collection)
- `merge_and_apply` is the single merge point (dedup, partial-failure warnings, first-error propagation)
- `QueryTransport::Group` folds `try_group` into the scheduler; group fan-out stays in the daemon (reuses `RemoteRequest::Query` + `run_on_share`)
- `OriginKind` enum removed -- `Origin.kind` is a String derived from `Reach::label()`, one classification source
- `QuerySource` carries `workspace_key` and per-source `timeout`; registry is resolved once per remote query (was twice)

## Breaking changes

- `OriginKind` removed; `Origin.kind` is now `String`
- `query_many` renamed to `query_sources`, signature changed (no `remote_timeout` param)
- `try_group` replaced by `QuerySource::group` + `group_query` transport branch

## Validation

- 448 CLI + 207 core tests pass; 3 new `resolve_source` unit tests
- clippy `-D warnings` clean, fmt clean
- ponytail audit: no remaining forks or duplicate implementations along the whole query chain

## Notes

- daemon remains broken on Windows (`os error 10053`) -- untouched, tracked separately


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified querying across local, remote, and group sources.
  * Added support for bare selectors, registry aliases, validated remote selectors, and workspace resolution.
  * Added per-source timeouts while preserving source order during parallel loading.
  * Added support for cold daemon startup and group-scoped queries.

* **Bug Fixes**
  * Improved failure isolation so unavailable sources do not block other results.
  * Unknown group selectors now report clear errors.
  * Improved handling of empty results and source-specific failures.
  * Updated origin labels for consistent local and remote display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->