### PR TITLE
fix(search): keep metadata-only records in browse queries

### DIFF
--- a/crates/sivtr-core/src/search/filter.rs
+++ b/crates/sivtr-core/src/search/filter.rs
@@ -493,13 +493,12 @@ fn record_anchor_hits(
     }
 
     // A metadata-only record (light view with empty `parts`, as browse
-    // session lists load) matches an unrestricted content query — no
-    // pattern, no kind bound, default field. Without this, empty parts can
-    // never match, so session lists come back empty once the meta cache is
-    // warm.
+    // session lists load) matches an unrestricted content query — one that
+    // reads no part text (no pattern, exclude, rank, or kind bound).
+    // Without this, empty parts can never match, so session lists come back
+    // empty once the meta cache is warm.
     if record.parts.is_empty()
-        && filter.kind.is_none()
-        && pattern.is_none()
+        && !filter.needs_parts()
         && filter.in_field == Field::Content
     {
         return vec![hit(anchor.clone())];

--- a/crates/sivtr-core/src/search/filter.rs
+++ b/crates/sivtr-core/src/search/filter.rs
@@ -497,10 +497,7 @@ fn record_anchor_hits(
     // reads no part text (no pattern, exclude, rank, or kind bound).
     // Without this, empty parts can never match, so session lists come back
     // empty once the meta cache is warm.
-    if record.parts.is_empty()
-        && !filter.needs_parts()
-        && filter.in_field == Field::Content
-    {
+    if record.parts.is_empty() && !filter.needs_parts() && filter.in_field == Field::Content {
         return vec![hit(anchor.clone())];
     }
 

--- a/crates/sivtr-core/src/search/filter.rs
+++ b/crates/sivtr-core/src/search/filter.rs
@@ -492,6 +492,19 @@ fn record_anchor_hits(
             .collect();
     }
 
+    // A metadata-only record (light view with empty `parts`, as browse
+    // session lists load) matches an unrestricted content query — no
+    // pattern, no kind bound, default field. Without this, empty parts can
+    // never match, so session lists come back empty once the meta cache is
+    // warm.
+    if record.parts.is_empty()
+        && filter.kind.is_none()
+        && pattern.is_none()
+        && filter.in_field == Field::Content
+    {
+        return vec![hit(anchor.clone())];
+    }
+
     let matched_meta = filter.kind.is_none()
         && filter.in_field == Field::All
         && meta_matches(record, Field::All, pattern);
@@ -835,6 +848,35 @@ mod tests {
             .expect("search");
         assert_eq!(hits[0].anchor.to_string(), "terminal/s1/2");
         assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn browse_keeps_metadata_only_records_with_empty_parts() {
+        // Light session views (browse meta queries) carry empty `parts`; an
+        // unrestricted browse query must still match them, or session lists
+        // come back empty once the meta cache is warm.
+        let mut meta_only = record("s1", 1, "a", "x");
+        meta_only.parts.clear();
+        let records = vec![meta_only];
+        let hits = Searcher::new(&records)
+            .search(
+                &Filter::browse_session_page(100),
+                &anchors(&records),
+                Path::new("."),
+            )
+            .expect("search");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].anchor.to_string(), "terminal/s1/1");
+
+        // A pattern still never matches an empty-part record.
+        let filter = Filter {
+            pattern: Some("KUBECTL".into()),
+            ..Filter::browse_session_page(100)
+        };
+        let hits = Searcher::new(&records)
+            .search(&filter, &anchors(&records), Path::new("."))
+            .expect("search");
+        assert!(hits.is_empty());
     }
 
     #[test]

--- a/src/commands/browse/load.rs
+++ b/src/commands/browse/load.rs
@@ -5,7 +5,6 @@
 //! only fulfills those requests over workset.
 
 use anyhow::{Context, Result};
-use chrono::{DateTime, Utc};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
@@ -747,9 +746,7 @@ fn session_search_title(session_id: &str, records: &[WorkRecord]) -> String {
 
 fn record_modified(record: &WorkRecord) -> Option<SystemTime> {
     let stamp = record.time.primary_at()?;
-    let dt = DateTime::parse_from_rfc3339(stamp)
-        .ok()
-        .map(|dt| dt.with_timezone(&Utc))?;
+    let dt = sivtr_core::time::parse_timestamp(stamp)?;
     let secs = dt.timestamp().max(0) as u64;
     let nanos = dt.timestamp_subsec_nanos();
     Some(UNIX_EPOCH + Duration::from_secs(secs) + Duration::from_nanos(nanos.into()))


### PR DESCRIPTION
## Purpose

Browse session lists (TUI sessions pane, `sivtr search <source>`) came back empty for agent sources once the session meta cache was warm; only the actively-written session appeared intermittently and vanished after refresh.

## Root cause

Since the light/full session views (#179), browse meta queries load records in Light mode with empty `parts`. In `record_anchor_hits`, the default `Field::Content` only matches via part text, and metadata matching requires `in_field == Field::All` — so a metadata-only record never matched. Only freshly-parsed records (parts present, e.g. the session being written right now) passed the filter.

## Change

- `record_anchor_hits`: an unrestricted content query (no pattern, no kind bound, default field) now matches metadata-only records (empty `parts`).
- Regression test `browse_keeps_metadata_only_records_with_empty_parts` (empty-part record matches a browse query; a pattern still never matches it).

## Validation

- Reproduced deterministically before the fix: `query_sources` returned 3 records on 1/8 runs, 0 otherwise; `load_workspace_source` always returned 645 (34 sessions).
- After the fix: 10/10 runs stable at 645 records; `sivtr search grok/pi/codex --latest 5` stable across repeated runs.
- `cargo test -p sivtr-core search::`: 39 passed. `cargo fmt` / `cargo clippy -D warnings` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Unrestricted content searches now include metadata-only records when no text-based filter is applied.
  - Searches using patterns, exclusions, ranking, type, or part-mode filters correctly exclude records without searchable text.
  - Browse results continue to display modification times correctly with improved timestamp handling across supported timestamps.
- **Tests**
  - Added regression coverage for unrestricted browsing and patterned searches to help prevent related search-result regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->