### PR TITLE
feat(agents): add ZCode agent provider

### DIFF
--- a/crates/sivtr-core/src/agents/mod.rs
+++ b/crates/sivtr-core/src/agents/mod.rs
@@ -26,6 +26,7 @@ pub mod pi;
 pub mod qoder;
 pub mod qwen;
 pub mod sqlite;
+pub mod zcode;
 
 pub use jsonl::{
     jsonl_files, list_chat_recording_sessions, list_recent_jsonl_sessions, list_sessions_matching,
@@ -157,6 +158,14 @@ const AGENT_PROVIDER_SPECS: &[AgentProviderSpec] = &[
         current_session_id_env: None,
         factory: qwen_provider,
     },
+    AgentProviderSpec {
+        provider: AgentProvider::Zcode,
+        name: "ZCode",
+        command_name: "zcode",
+        current_transcript_env: None,
+        current_session_id_env: None,
+        factory: zcode_provider,
+    },
 ];
 
 fn codex_provider() -> Box<dyn AgentSessionProvider> {
@@ -213,6 +222,10 @@ fn goose_provider() -> Box<dyn AgentSessionProvider> {
 
 fn qwen_provider() -> Box<dyn AgentSessionProvider> {
     Box::new(crate::agents::qwen::QwenProvider)
+}
+
+fn zcode_provider() -> Box<dyn AgentSessionProvider> {
+    Box::new(crate::agents::zcode::ZcodeProvider)
 }
 
 impl AgentProvider {

--- a/crates/sivtr-core/src/agents/model.rs
+++ b/crates/sivtr-core/src/agents/model.rs
@@ -21,6 +21,7 @@ pub enum AgentProvider {
     Qoder,
     QoderCn,
     Qwen,
+    Zcode,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/sivtr-core/src/agents/zcode.rs
+++ b/crates/sivtr-core/src/agents/zcode.rs
@@ -75,22 +75,28 @@ fn list_sessions(cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
     }
 
     let conn = open_readonly_db(&db_path)?;
-    let mut stmt = conn.prepare(
-        "select id, title, directory, time_updated from session \
-         where time_archived is null order by time_updated desc",
-    )?;
-    let rows = stmt.query_map([], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, String>(1)?,
-            row.get::<_, String>(2)?,
-            row.get::<_, i64>(3)?,
-        ))
-    })?;
+    let mut stmt = conn
+        .prepare(
+            "select id, title, directory, time_updated from session \
+             where time_archived is null order by time_updated desc",
+        )
+        .context("Failed to list ZCode sessions")?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, i64>(3)?,
+            ))
+        })
+        .context("Failed to read ZCode session rows")?;
 
     let mut sessions = Vec::new();
     for row in rows {
-        let (id, title, directory, time_updated) = row?;
+        let (id, title, directory, time_updated) = row.with_context(|| {
+            format!("Failed to read ZCode session row in {}", db_path.display())
+        })?;
         sessions.push(SessionInfo {
             path: session_path(&id),
             id: Some(display_id(&id).to_string()),
@@ -111,7 +117,8 @@ fn parse_session(row_id: &str) -> Result<AgentSession> {
             [row_id],
             |row| Ok((row.get(0)?, row.get(1)?)),
         )
-        .optional()?;
+        .optional()
+        .context("Failed to query ZCode session header")?;
     let Some((title, directory)) = header else {
         anyhow::bail!("no ZCode session row for id {row_id}");
     };
@@ -124,23 +131,30 @@ fn parse_session(row_id: &str) -> Result<AgentSession> {
         blocks: Vec::new(),
     };
 
-    let mut stmt = conn.prepare(
-        "select m.data, p.data, p.time_created from part p \
-         join message m on m.id = p.message_id \
-         where p.session_id = ?1 order by m.sequence, p.sequence",
-    )?;
-    let rows = stmt.query_map([row_id], |row| {
-        Ok((
-            row.get::<_, String>(0)?,
-            row.get::<_, String>(1)?,
-            row.get::<_, i64>(2)?,
-        ))
-    })?;
+    let mut stmt = conn
+        .prepare(
+            "select m.data, p.data, p.time_created from part p \
+             join message m on m.id = p.message_id \
+             where p.session_id = ?1 order by m.sequence, p.sequence",
+        )
+        .context("Failed to query ZCode session parts")?;
+    let rows = stmt
+        .query_map([row_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+            ))
+        })
+        .context("Failed to read ZCode session parts")?;
 
     for row in rows {
-        let (message_json, part_json, time_created) = row?;
-        let message: Value = serde_json::from_str(&message_json).unwrap_or(Value::Null);
-        let part: Value = serde_json::from_str(&part_json).unwrap_or(Value::Null);
+        let (message_json, part_json, time_created) =
+            row.with_context(|| format!("Failed to read ZCode session {row_id} part row"))?;
+        let message: Value = serde_json::from_str(&message_json)
+            .with_context(|| format!("Invalid ZCode message JSON in session {row_id}"))?;
+        let part: Value = serde_json::from_str(&part_json)
+            .with_context(|| format!("Invalid ZCode part JSON in session {row_id}"))?;
         apply_part(&mut session, &message, &part, time_created);
     }
 
@@ -194,18 +208,14 @@ fn apply_tool_part(session: &mut AgentSession, part: &Value, timestamp: Option<S
             pretty_json_value(input),
         );
     }
-    if let Some(output) = state
-        .get("output")
-        .or_else(|| state.get("error"))
-        .and_then(Value::as_str)
-    {
-        push_block(
-            session,
-            AgentBlockKind::ToolOutput,
-            timestamp,
-            label,
-            output,
-        );
+    if let Some(output) = state.get("output").or_else(|| state.get("error")) {
+        // Structured tool results (objects/arrays) are rendered as JSON so
+        // they stay in the transcript instead of being dropped by as_str.
+        let text = match output.as_str() {
+            Some(text) => text.to_string(),
+            None => pretty_json_value(output),
+        };
+        push_block(session, AgentBlockKind::ToolOutput, timestamp, label, text);
     }
 }
 
@@ -241,8 +251,9 @@ mod tests {
 
     fn write_db(dir: &Path) {
         let db = dir.join("cli").join("db").join("db.sqlite");
-        std::fs::create_dir_all(db.parent().unwrap()).unwrap();
-        let conn = Connection::open(&db).unwrap();
+        std::fs::create_dir_all(db.parent().expect("db has a parent"))
+            .expect("create ZCode db directory");
+        let conn = Connection::open(&db).expect("open test ZCode db");
         conn.execute_batch(
             r#"
             create table session (
@@ -282,7 +293,7 @@ mod tests {
                 ('p7', 'm2', 'sess_uuid-1', 7000, '{"type":"text","text":"system reminder","synthetic":true}', 5);
             "#,
         )
-        .unwrap();
+        .expect("seed test ZCode db");
     }
 
     #[test]
@@ -295,24 +306,31 @@ mod tests {
     #[test]
     fn session_path_round_trips_id() {
         let path = session_path("sess_uuid-1");
-        assert_eq!(session_id_from_path(&path).unwrap(), "sess_uuid-1");
+        assert_eq!(
+            session_id_from_path(&path).expect("round-trip a session id"),
+            "sess_uuid-1"
+        );
     }
 
     #[test]
     fn lists_and_parses_zcode_sessions() {
         let _guard = env_lock();
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().expect("create temp dir");
         let original = std::env::var_os("ZCODE_HOME");
         std::env::set_var("ZCODE_HOME", dir.path());
         write_db(dir.path());
 
-        let sessions = ZcodeProvider.list_recent_sessions(None).unwrap();
+        let sessions = ZcodeProvider
+            .list_recent_sessions(None)
+            .expect("list ZCode sessions");
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].id.as_deref(), Some("uuid-1"));
         assert_eq!(sessions[0].cwd.as_deref(), Some("D:/Coding/alpha"));
         assert_eq!(sessions[0].title.as_deref(), Some("First task"));
 
-        let session = ZcodeProvider.parse_session_file(&sessions[0].path).unwrap();
+        let session = ZcodeProvider
+            .parse_session_file(&sessions[0].path)
+            .expect("parse ZCode session");
         assert_eq!(session.id.as_deref(), Some("uuid-1"));
         let kinds: Vec<_> = session.blocks.iter().map(|b| b.kind).collect();
         assert_eq!(
@@ -343,12 +361,12 @@ mod tests {
     #[test]
     fn missing_session_row_errors() {
         let _guard = env_lock();
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().expect("create temp dir");
         let original = std::env::var_os("ZCODE_HOME");
         std::env::set_var("ZCODE_HOME", dir.path());
         let error = ZcodeProvider
             .parse_session_file(&session_path("sess_missing"))
-            .unwrap_err();
+            .expect_err("missing session row must error");
         assert!(format!("{error:#}").contains("Failed to load"));
         match original {
             Some(value) => std::env::set_var("ZCODE_HOME", value),

--- a/crates/sivtr-core/src/agents/zcode.rs
+++ b/crates/sivtr-core/src/agents/zcode.rs
@@ -1,0 +1,358 @@
+use anyhow::{Context, Result};
+use rusqlite::OptionalExtension;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+
+use crate::agents::{
+    filter_sessions_by_workspace, open_readonly_db, pretty_json_value, push_block,
+    system_time_from_millis, AgentBlockKind, AgentProvider, AgentSession, AgentSessionProvider,
+    SessionInfo,
+};
+
+const SESSION_PATH_PREFIX: &str = "zcode-session-";
+const SESSION_PATH_SUFFIX: &str = ".json";
+const SESSION_ID_PREFIX: &str = "sess_";
+
+/// ZCode session provider.
+///
+/// Sessions live in `~/.zcode/cli/db/db.sqlite`:
+/// - `session`: one row per session — `id` (`sess_<uuid>`), `title`,
+///   `directory`, `time_updated` (epoch ms), `time_archived` (null = active)
+/// - `message`: one row per turn — `sequence`, `data.role` is `user` or
+///   `assistant`
+/// - `part`: transcript content — `sequence`, `data.type` is `text`,
+///   `reasoning`, `tool`, `step-start`, or `step-finish`. Tool payloads carry
+///   `state.input` (object) plus `state.output` (completed) or `state.error`
+///   (failed). Parts with `"synthetic": true` are system reminders injected
+///   into the model context, not user dialogue.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ZcodeProvider;
+
+impl AgentSessionProvider for ZcodeProvider {
+    fn provider(&self) -> AgentProvider {
+        AgentProvider::Zcode
+    }
+
+    fn list_recent_sessions(&self, cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
+        list_sessions(cwd)
+    }
+
+    fn parse_session_file(&self, path: &Path) -> Result<AgentSession> {
+        let session_id = session_id_from_path(path)?;
+        parse_session(&session_id).with_context(|| {
+            format!(
+                "Failed to load {} session {session_id}",
+                AgentProvider::Zcode.name()
+            )
+        })
+    }
+}
+
+pub fn zcode_home() -> PathBuf {
+    if let Ok(path) = std::env::var("ZCODE_HOME") {
+        if !path.trim().is_empty() {
+            return PathBuf::from(path);
+        }
+    }
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".zcode")
+}
+
+fn zcode_db_path() -> PathBuf {
+    zcode_home().join("cli").join("db").join("db.sqlite")
+}
+
+/// Drop the constant `sess_` prefix so session refs read `zcode/573eff56/1`.
+fn display_id(row_id: &str) -> &str {
+    row_id.strip_prefix(SESSION_ID_PREFIX).unwrap_or(row_id)
+}
+
+fn list_sessions(cwd: Option<&Path>) -> Result<Vec<SessionInfo>> {
+    let db_path = zcode_db_path();
+    if !db_path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let conn = open_readonly_db(&db_path)?;
+    let mut stmt = conn.prepare(
+        "select id, title, directory, time_updated from session \
+         where time_archived is null order by time_updated desc",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+            row.get::<_, i64>(3)?,
+        ))
+    })?;
+
+    let mut sessions = Vec::new();
+    for row in rows {
+        let (id, title, directory, time_updated) = row?;
+        sessions.push(SessionInfo {
+            path: session_path(&id),
+            id: Some(display_id(&id).to_string()),
+            cwd: Some(directory),
+            title: Some(title),
+            modified: system_time_from_millis(time_updated),
+        });
+    }
+    Ok(filter_sessions_by_workspace(sessions, cwd))
+}
+
+fn parse_session(row_id: &str) -> Result<AgentSession> {
+    let conn = open_readonly_db(&zcode_db_path())?;
+
+    let header: Option<(String, String)> = conn
+        .query_row(
+            "select title, directory from session where id = ?1 limit 1",
+            [row_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .optional()?;
+    let Some((title, directory)) = header else {
+        anyhow::bail!("no ZCode session row for id {row_id}");
+    };
+
+    let mut session = AgentSession {
+        path: session_path(row_id),
+        id: Some(display_id(row_id).to_string()),
+        cwd: Some(directory),
+        title: Some(title),
+        blocks: Vec::new(),
+    };
+
+    let mut stmt = conn.prepare(
+        "select m.data, p.data, p.time_created from part p \
+         join message m on m.id = p.message_id \
+         where p.session_id = ?1 order by m.sequence, p.sequence",
+    )?;
+    let rows = stmt.query_map([row_id], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, i64>(2)?,
+        ))
+    })?;
+
+    for row in rows {
+        let (message_json, part_json, time_created) = row?;
+        let message: Value = serde_json::from_str(&message_json).unwrap_or(Value::Null);
+        let part: Value = serde_json::from_str(&part_json).unwrap_or(Value::Null);
+        apply_part(&mut session, &message, &part, time_created);
+    }
+
+    Ok(session)
+}
+
+fn apply_part(session: &mut AgentSession, message: &Value, part: &Value, time_created: i64) {
+    if part.get("synthetic").and_then(Value::as_bool) == Some(true) {
+        return;
+    }
+    let timestamp = Some(time_created.to_string());
+
+    match part.get("type").and_then(Value::as_str) {
+        Some("text") => {
+            let kind = match message.get("role").and_then(Value::as_str) {
+                Some("user") => AgentBlockKind::User,
+                Some("assistant") => AgentBlockKind::Assistant,
+                _ => return,
+            };
+            push_block(
+                session,
+                kind,
+                timestamp,
+                None,
+                part.get("text").and_then(Value::as_str).unwrap_or_default(),
+            );
+        }
+        Some("reasoning") => push_block(
+            session,
+            AgentBlockKind::Thinking,
+            timestamp,
+            None,
+            part.get("text").and_then(Value::as_str).unwrap_or_default(),
+        ),
+        Some("tool") => apply_tool_part(session, part, timestamp),
+        // step-start / step-finish are turn markers, not dialogue.
+        _ => {}
+    }
+}
+
+fn apply_tool_part(session: &mut AgentSession, part: &Value, timestamp: Option<String>) {
+    let label = part.get("tool").and_then(Value::as_str).map(str::to_string);
+    let state = part.get("state").unwrap_or(&Value::Null);
+
+    if let Some(input) = state.get("input") {
+        push_block(
+            session,
+            AgentBlockKind::ToolCall,
+            timestamp.clone(),
+            label.clone(),
+            pretty_json_value(input),
+        );
+    }
+    if let Some(output) = state
+        .get("output")
+        .or_else(|| state.get("error"))
+        .and_then(Value::as_str)
+    {
+        push_block(
+            session,
+            AgentBlockKind::ToolOutput,
+            timestamp,
+            label,
+            output,
+        );
+    }
+}
+
+fn session_path(row_id: &str) -> PathBuf {
+    PathBuf::from(format!(
+        "{SESSION_PATH_PREFIX}{row_id}{SESSION_PATH_SUFFIX}"
+    ))
+}
+
+fn session_id_from_path(path: &Path) -> Result<String> {
+    let invalid = || format!("Invalid ZCode session path {}", path.display());
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .with_context(invalid)?;
+    name.strip_prefix(SESSION_PATH_PREFIX)
+        .and_then(|rest| rest.strip_suffix(SESSION_PATH_SUFFIX))
+        .filter(|id| !id.is_empty())
+        .map(str::to_string)
+        .with_context(invalid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{session_id_from_path, session_path, ZcodeProvider};
+    use crate::agents::{AgentBlockKind, AgentProvider, AgentSessionProvider};
+    use rusqlite::Connection;
+    use std::path::Path;
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        crate::test_env_lock()
+    }
+
+    fn write_db(dir: &Path) {
+        let db = dir.join("cli").join("db").join("db.sqlite");
+        std::fs::create_dir_all(db.parent().unwrap()).unwrap();
+        let conn = Connection::open(&db).unwrap();
+        conn.execute_batch(
+            r#"
+            create table session (
+                id text primary key,
+                title text not null,
+                directory text not null,
+                time_updated integer not null,
+                time_archived integer
+            );
+            create table message (
+                id text primary key,
+                session_id text not null,
+                time_created integer not null,
+                data text not null,
+                sequence integer
+            );
+            create table part (
+                id text primary key,
+                message_id text not null,
+                session_id text not null,
+                time_created integer not null,
+                data text not null,
+                sequence integer
+            );
+            insert into session (id, title, directory, time_updated) values
+                ('sess_uuid-1', 'First task', 'D:/Coding/alpha', 2000);
+            insert into message (id, session_id, time_created, data, sequence) values
+                ('m1', 'sess_uuid-1', 1000, '{"role":"user"}', 0),
+                ('m2', 'sess_uuid-1', 2000, '{"role":"assistant"}', 1);
+            insert into part (id, message_id, session_id, time_created, data, sequence) values
+                ('p1', 'm1', 'sess_uuid-1', 1000, '{"type":"text","text":"hello zcode"}', 0),
+                ('p2', 'm2', 'sess_uuid-1', 2000, '{"type":"reasoning","text":"thinking"}', 0),
+                ('p3', 'm2', 'sess_uuid-1', 3000, '{"type":"text","text":"working"}', 1),
+                ('p4', 'm2', 'sess_uuid-1', 4000, '{"type":"tool","tool":"Bash","state":{"status":"completed","input":{"command":"ls"},"output":"files"}}', 2),
+                ('p5', 'm2', 'sess_uuid-1', 5000, '{"type":"tool","tool":"Read","state":{"status":"error","input":{"file_path":"a.rs"},"error":"too large"}}', 3),
+                ('p6', 'm2', 'sess_uuid-1', 6000, '{"type":"step-finish","reason":"tool-calls"}', 4),
+                ('p7', 'm2', 'sess_uuid-1', 7000, '{"type":"text","text":"system reminder","synthetic":true}', 5);
+            "#,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn provider_name_is_zcode() {
+        assert_eq!(AgentProvider::Zcode.name(), "ZCode");
+        assert_eq!(AgentProvider::Zcode.command_name(), "zcode");
+        assert_eq!(ZcodeProvider.provider(), AgentProvider::Zcode);
+    }
+
+    #[test]
+    fn session_path_round_trips_id() {
+        let path = session_path("sess_uuid-1");
+        assert_eq!(session_id_from_path(&path).unwrap(), "sess_uuid-1");
+    }
+
+    #[test]
+    fn lists_and_parses_zcode_sessions() {
+        let _guard = env_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let original = std::env::var_os("ZCODE_HOME");
+        std::env::set_var("ZCODE_HOME", dir.path());
+        write_db(dir.path());
+
+        let sessions = ZcodeProvider.list_recent_sessions(None).unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].id.as_deref(), Some("uuid-1"));
+        assert_eq!(sessions[0].cwd.as_deref(), Some("D:/Coding/alpha"));
+        assert_eq!(sessions[0].title.as_deref(), Some("First task"));
+
+        let session = ZcodeProvider.parse_session_file(&sessions[0].path).unwrap();
+        assert_eq!(session.id.as_deref(), Some("uuid-1"));
+        let kinds: Vec<_> = session.blocks.iter().map(|b| b.kind).collect();
+        assert_eq!(
+            kinds,
+            vec![
+                AgentBlockKind::User,
+                AgentBlockKind::Thinking,
+                AgentBlockKind::Assistant,
+                AgentBlockKind::ToolCall,
+                AgentBlockKind::ToolOutput,
+                AgentBlockKind::ToolCall,
+                AgentBlockKind::ToolOutput,
+            ]
+        );
+        assert_eq!(session.blocks[0].text, "hello zcode");
+        assert_eq!(session.blocks[0].timestamp.as_deref(), Some("1000"));
+        assert_eq!(session.blocks[3].label.as_deref(), Some("Bash"));
+        assert_eq!(session.blocks[3].text, "{\n  \"command\": \"ls\"\n}");
+        assert_eq!(session.blocks[4].text, "files");
+        assert_eq!(session.blocks[6].text, "too large");
+
+        match original {
+            Some(value) => std::env::set_var("ZCODE_HOME", value),
+            None => std::env::remove_var("ZCODE_HOME"),
+        }
+    }
+
+    #[test]
+    fn missing_session_row_errors() {
+        let _guard = env_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let original = std::env::var_os("ZCODE_HOME");
+        std::env::set_var("ZCODE_HOME", dir.path());
+        let error = ZcodeProvider
+            .parse_session_file(&session_path("sess_missing"))
+            .unwrap_err();
+        assert!(format!("{error:#}").contains("Failed to load"));
+        match original {
+            Some(value) => std::env::set_var("ZCODE_HOME", value),
+            None => std::env::remove_var("ZCODE_HOME"),
+        }
+    }
+}

--- a/src/commands/system/mcp.rs
+++ b/src/commands/system/mcp.rs
@@ -1123,8 +1123,9 @@ mod tests {
     fn mcp_host_registry_covers_every_managed_provider() {
         // dsh configures MCP clients as plugin rows in the harness profile's
         // `cordis.patch.yml`, not a standalone file, so it has no managed
-        // host entry here; it must fail loudly, never panic.
-        let unmanaged: &[AgentProvider] = &[AgentProvider::Dsh];
+        // host entry here; it must fail loudly, never panic. ZCode has no
+        // managed MCP config surface yet, so it is unmanaged for now too.
+        let unmanaged: &[AgentProvider] = &[AgentProvider::Dsh, AgentProvider::Zcode];
         let managed: Vec<AgentProvider> = AgentProvider::all()
             .iter()
             .map(|spec| spec.provider)

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -113,7 +113,7 @@ pub(crate) const fn provider_colors(provider: AgentProvider) -> ProviderColors {
         },
         AgentProvider::Hermes => ProviderColors {
             dark: Color::Rgb(250, 204, 21), // yellow-400
-            light: Color::Rgb(202, 138, 4), // yellow-600
+            light: Color::Rgb(161, 98, 7),  // yellow-700
             ansi: Color::LightYellow,
             ansi_light: Color::DarkGray,
         },
@@ -160,8 +160,8 @@ pub(crate) const fn provider_colors(provider: AgentProvider) -> ProviderColors {
             ansi_light: Color::Magenta,
         },
         AgentProvider::Zcode => ProviderColors {
-            dark: Color::Rgb(163, 230, 53),  // lime-400
-            light: Color::Rgb(101, 163, 13), // lime-600
+            dark: Color::Rgb(163, 230, 53), // lime-400
+            light: Color::Rgb(63, 98, 18),  // lime-800
             ansi: Color::LightGreen,
             ansi_light: Color::DarkGray,
         },
@@ -603,6 +603,38 @@ mod tests {
         }
         for spec in AgentProvider::all() {
             assert_dark_foreground(spec.name, provider_colors(spec.provider).ansi_light);
+        }
+    }
+
+    #[test]
+    fn light_theme_colors_keep_contrast_on_white() {
+        // Light-palette label colors render on a white terminal background;
+        // each must clear WCAG AA for large text / UI components (3:1).
+        // Expose the exact floor here so a new provider cannot silently ship
+        // an unreadable light color.
+        let contrast = |color: Color| {
+            let Color::Rgb(r, g, b) = color else {
+                return f64::INFINITY;
+            };
+            let linear = |channel: u8| {
+                let value = channel as f64 / 255.0;
+                if value <= 0.04045 {
+                    value / 12.92
+                } else {
+                    ((value + 0.055) / 1.055).powf(2.4)
+                }
+            };
+            let luminance = 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b);
+            (1.0 + 0.05) / (luminance + 0.05)
+        };
+        for spec in AgentProvider::all() {
+            let light = provider_colors(spec.provider).light;
+            assert!(
+                contrast(light) >= 3.0,
+                "{} light color {light:?} has contrast {:.1}:1 on white; darken it",
+                spec.name,
+                contrast(light)
+            );
         }
     }
 

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -160,10 +160,10 @@ pub(crate) const fn provider_colors(provider: AgentProvider) -> ProviderColors {
             ansi_light: Color::Magenta,
         },
         AgentProvider::Zcode => ProviderColors {
-            dark: Color::Rgb(129, 140, 248), // indigo-400
-            light: Color::Rgb(79, 70, 229),  // indigo-600
-            ansi: Color::LightBlue,
-            ansi_light: Color::Blue,
+            dark: Color::Rgb(163, 230, 53),  // lime-400
+            light: Color::Rgb(101, 163, 13), // lime-600
+            ansi: Color::LightGreen,
+            ansi_light: Color::DarkGray,
         },
     }
 }
@@ -524,11 +524,17 @@ mod tests {
 
     #[test]
     fn provider_colors_cover_every_agent_with_distinct_schemes() {
+        let mut seen_dark = std::collections::HashSet::new();
         for spec in AgentProvider::all() {
             let colors = provider_colors(spec.provider);
             assert_ne!(
                 colors.dark, colors.light,
                 "{} must have a light variant distinct from its dark one",
+                spec.name
+            );
+            assert!(
+                seen_dark.insert(colors.dark),
+                "{} collides with another provider's dark color",
                 spec.name
             );
         }

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -159,6 +159,12 @@ pub(crate) const fn provider_colors(provider: AgentProvider) -> ProviderColors {
             ansi: Color::LightMagenta,
             ansi_light: Color::Magenta,
         },
+        AgentProvider::Zcode => ProviderColors {
+            dark: Color::Rgb(129, 140, 248), // indigo-400
+            light: Color::Rgb(79, 70, 229),  // indigo-600
+            ansi: Color::LightBlue,
+            ansi_light: Color::Blue,
+        },
     }
 }
 

--- a/src/tui/workspace/model.rs
+++ b/src/tui/workspace/model.rs
@@ -62,6 +62,7 @@ impl WorkspaceSourceKind {
             Self::Agent(AgentProvider::Gemini) => "gmi",
             Self::Agent(AgentProvider::Goose) => "gse",
             Self::Agent(AgentProvider::Qwen) => "qwn",
+            Self::Agent(AgentProvider::Zcode) => "zcd",
         }
     }
 


### PR DESCRIPTION
## Purpose

Register ZCode as an agent provider so its sessions appear in `sivtr search zcode`, the TUI source pane, and shared memory — alongside Codex, Claude, Grok, Pi, etc.

## Change

- `AgentProvider::Zcode` registry entry (`command_name` = `zcode`) in `agents/mod.rs` / `agents/model.rs`.
- `crates/sivtr-core/src/agents/zcode.rs`: session discovery + parsing from the ZCode SQLite store (`~/.zcode/cli/db/db.sqlite`), with `ZCODE_HOME` override; text/reasoning/tool parts mapped to blocks, synthetic reminders skipped.
- TUI: source badge `zcd` + theme colors.
- MCP coverage test: ZCode added to the unmanaged list (no managed MCP config surface yet, same as dsh).

## Validation

- `cargo test -p sivtr-core zcode`: 4 passed (parse, list, path round-trip, missing-row error).
- `cargo test -p sivtr mcp::`: 11 passed.
- `cargo fmt` / `cargo clippy -D warnings` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Zcode agent provider.
  * Browse recent Zcode sessions associated with a workspace.
  * View session transcripts, reasoning, tool activity, and structured tool results.
  * Support custom Zcode home directories.

* **Improvements**
  * Added a distinct “zcd” workspace badge and updated Zcode provider colors for better visual identification.
  * Improved handling and display of session errors and metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->