### PR TITLE
fix(update): fetch latest release via redirect

### DIFF
--- a/src/commands/system/update.rs
+++ b/src/commands/system/update.rs
@@ -27,15 +27,18 @@ pub fn latest_version() -> Result<String> {
         .call()
         .context("cannot reach GitHub")?;
 
-    let path = response.get_uri().path();
-    let tag = release_tag_from_path(path)
-        .with_context(|| format!("unexpected release redirect target: {path}"))?;
-    Ok(tag.to_string())
+    Ok(release_tag_from_path(response.get_uri().path())?.to_string())
 }
 
-fn release_tag_from_path(path: &str) -> Option<&str> {
-    let tag = path.rsplit_once("/releases/tag/")?.1;
-    (!tag.is_empty() && !tag.contains('/')).then_some(tag)
+fn release_tag_from_path(path: &str) -> Result<&str> {
+    let tag = path
+        .rsplit_once("/releases/tag/")
+        .with_context(|| format!("release redirect path is missing /releases/tag/: {path}"))?
+        .1;
+    if tag.is_empty() || tag.contains('/') {
+        bail!("release redirect path contains an invalid tag: {path}");
+    }
+    Ok(tag)
 }
 
 pub fn execute() -> Result<()> {
@@ -245,10 +248,10 @@ mod tests {
     #[test]
     fn tag_from_redirect_path() {
         assert_eq!(
-            release_tag_from_path("/Ariestar/sivtr/releases/tag/v0.6.0"),
-            Some("v0.6.0")
+            release_tag_from_path("/Ariestar/sivtr/releases/tag/v0.6.0").expect("valid tag"),
+            "v0.6.0"
         );
-        assert_eq!(release_tag_from_path("/Ariestar/sivtr/releases/tag/"), None);
-        assert_eq!(release_tag_from_path("/Ariestar/sivtr"), None);
+        assert!(release_tag_from_path("/Ariestar/sivtr/releases/tag/").is_err());
+        assert!(release_tag_from_path("/Ariestar/sivtr").is_err());
     }
 }

--- a/src/commands/system/update.rs
+++ b/src/commands/system/update.rs
@@ -8,27 +8,33 @@ use sha2::{Digest, Sha256};
 use std::path::Path;
 use std::time::Duration;
 
+use ureq::ResponseExt;
+
 use crate::output;
 
 const REPO: &str = "Ariestar/sivtr";
 const CHECK_TIMEOUT: Duration = Duration::from_secs(5);
 const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Latest published release tag from the GitHub API, e.g. `v0.4.0`.
+/// Latest published release tag, e.g. `v0.6.0`.
+///
+/// Follows the `releases/latest` redirect to `/releases/tag/<tag>`, avoiding
+/// the rate-limited GitHub API entirely.  No GitHub CLI required.
 pub fn latest_version() -> Result<String> {
-    let url = format!("https://api.github.com/repos/{REPO}/releases/latest");
-    let mut response = agent(CHECK_TIMEOUT)
-        .get(&url)
+    let response = agent(CHECK_TIMEOUT)
+        .get("https://github.com/Ariestar/sivtr/releases/latest")
         .header("User-Agent", "sivtr-update")
         .call()
-        .context("cannot reach GitHub API")?;
-    let body = response
-        .body_mut()
-        .read_to_vec()
-        .context("failed to read GitHub API response")?;
-    let release: Release =
-        serde_json::from_slice(&body).context("failed to parse GitHub release metadata")?;
-    Ok(release.tag_name)
+        .context("cannot reach GitHub")?;
+
+    let tag = response
+        .get_uri()
+        .path()
+        .rsplit('/')
+        .next()
+        .context("invalid redirect URL from GitHub")?;
+
+    Ok(tag.to_string())
 }
 
 pub fn execute() -> Result<()> {
@@ -204,11 +210,6 @@ fn parse_version(version: &str) -> Option<(u64, u64, u64)> {
     Some((major, minor, patch))
 }
 
-#[derive(serde::Deserialize)]
-struct Release {
-    tag_name: String,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -238,5 +239,13 @@ mod tests {
             Some("abc".to_string())
         );
         assert_eq!(checksum_for(sums, "missing.zip"), None);
+    }
+
+    #[test]
+    fn tag_from_redirect_path() {
+        let path = "/Ariestar/sivtr/releases/tag/v0.6.0";
+        assert_eq!(path.rsplit('/').next(), Some("v0.6.0"));
+        let malformed = "https://github.com/Ariestar/sivtr";
+        assert_eq!(malformed.rsplit('/').next(), Some("sivtr"));
     }
 }

--- a/src/commands/system/update.rs
+++ b/src/commands/system/update.rs
@@ -27,14 +27,15 @@ pub fn latest_version() -> Result<String> {
         .call()
         .context("cannot reach GitHub")?;
 
-    let tag = response
-        .get_uri()
-        .path()
-        .rsplit('/')
-        .next()
-        .context("invalid redirect URL from GitHub")?;
-
+    let path = response.get_uri().path();
+    let tag = release_tag_from_path(path)
+        .with_context(|| format!("unexpected release redirect target: {path}"))?;
     Ok(tag.to_string())
+}
+
+fn release_tag_from_path(path: &str) -> Option<&str> {
+    let tag = path.rsplit_once("/releases/tag/")?.1;
+    (!tag.is_empty() && !tag.contains('/')).then_some(tag)
 }
 
 pub fn execute() -> Result<()> {
@@ -243,9 +244,11 @@ mod tests {
 
     #[test]
     fn tag_from_redirect_path() {
-        let path = "/Ariestar/sivtr/releases/tag/v0.6.0";
-        assert_eq!(path.rsplit('/').next(), Some("v0.6.0"));
-        let malformed = "https://github.com/Ariestar/sivtr";
-        assert_eq!(malformed.rsplit('/').next(), Some("sivtr"));
+        assert_eq!(
+            release_tag_from_path("/Ariestar/sivtr/releases/tag/v0.6.0"),
+            Some("v0.6.0")
+        );
+        assert_eq!(release_tag_from_path("/Ariestar/sivtr/releases/tag/"), None);
+        assert_eq!(release_tag_from_path("/Ariestar/sivtr"), None);
     }
 }


### PR DESCRIPTION
## Purpose

`sivtr update` failed with `error: cannot reach GitHub API: http status: 403` because the version check called `api.github.com` unauthenticated, which GitHub rate-limits per IP for anonymous requests.

## Changes

- `latest_version()` now follows the `https://github.com/Ariestar/sivtr/releases/latest` redirect to `/releases/tag/<tag>` and reads the tag from the final URL.
- Removed the now-unneeded `Release` serde struct and JSON body parsing.

No GitHub CLI or token required; the redirect endpoint is served by the github.com web frontend and is not subject to the API rate limit. `/releases/latest` semantics match the API: latest stable release, prereleases excluded.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (450 + 212 passed)
- End-to-end `sivtr update` → `success: sivtr 0.6.0 is up to date` (previously exited 1 with the 403)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of the latest available version by accepting only valid official release redirect paths.
  * Added safeguards against empty, nested, or unrelated release paths, making update checks more reliable.
  * Improved error details for malformed release redirects, helping identify invalid version information more clearly.
  * Removed reliance on an obsolete release lookup path to provide more consistent version-checking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->