### PR TITLE
refactor(browse): unify content block coordinates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ Keep this file limited to durable, cross-session guidance. Current progress, tem
 
 ## Verification
 
+- Build after every code change (`cargo build`, or the project's equivalent). Never leave a change unbuilt, even a one-line edit.
 - Run the relevant project checks after making changes.
 - Fix failures caused by the current change, then rerun the checks.
 - If a relevant check cannot be run, state the reason explicitly.

--- a/src/commands/browse/content.rs
+++ b/src/commands/browse/content.rs
@@ -4,8 +4,7 @@ use anyhow::Result;
 use crossterm::event::KeyCode;
 
 use crate::commands::select::CommandSelection;
-use crate::tui::content::block::{half_blocks, Block};
-use crate::tui::content::io::ContentIoFocus;
+use crate::tui::content::block::{dialogue_blocks, Block};
 use crate::tui::content::view::{line_count, ContentViewMode};
 use crate::tui::search::{WorkspaceSearchMatch, WorkspaceSearchOutput};
 use crate::tui::workspace::{
@@ -144,13 +143,9 @@ pub(super) fn workspace_picked_content_for_marked_blocks(
         else {
             continue;
         };
-        for (input, half) in [
-            (true, ContentIoFocus::Input),
-            (false, ContentIoFocus::Output),
-        ] {
-            for block in half_blocks(record, input) {
-                collect_marked_blocks(&block, half, dialogue_idx, content_pane, record, &mut texts);
-            }
+        let (input_blocks, output_blocks) = dialogue_blocks(record);
+        for block in input_blocks.iter().chain(&output_blocks) {
+            collect_marked_blocks(block, dialogue_idx, content_pane, record, &mut texts);
         }
     }
     picked_for_texts(dialogues, selected_dialogues, dialogue_idx, texts)
@@ -160,14 +155,13 @@ pub(super) fn workspace_picked_content_for_marked_blocks(
 /// member of a folded run carries its own id, separate from the run's).
 fn collect_marked_blocks(
     block: &Block,
-    half: ContentIoFocus,
     dialogue_idx: usize,
     content_pane: &ContentPane,
     record: &WorkRecord,
     texts: &mut Vec<String>,
 ) {
     if content_pane
-        .marked(half, dialogue_idx)
+        .marked(dialogue_idx)
         .get(block.id)
         .copied()
         .unwrap_or(false)
@@ -175,7 +169,7 @@ fn collect_marked_blocks(
         texts.push(block.body(record));
     }
     for child in &block.children {
-        collect_marked_blocks(child, half, dialogue_idx, content_pane, record, texts);
+        collect_marked_blocks(child, dialogue_idx, content_pane, record, texts);
     }
 }
 
@@ -185,15 +179,14 @@ pub(super) fn workspace_picked_content_for_cursor_block(
     dialogues: &[WorkspaceDialogue],
     selected_dialogues: &[bool],
     dialogue_idx: usize,
-    half: ContentIoFocus,
     block_id: usize,
 ) -> Option<WorkspacePickedContent> {
     let dialogue = dialogues.get(dialogue_idx)?;
     let record = dialogue.record.as_ref()?;
-    let input = matches!(half, ContentIoFocus::Input);
-    let blocks = half_blocks(record, input);
-    let block = blocks
+    let (input_blocks, output_blocks) = dialogue_blocks(record);
+    let block = input_blocks
         .iter()
+        .chain(&output_blocks)
         .find_map(|block| find_block(block, block_id))?;
     picked_for_texts(
         dialogues,
@@ -450,7 +443,9 @@ mod tests {
                 io_focus: ContentIoFocus::Output,
                 expanded: &ExpandedBlocks::default(),
             });
-            pane.toggle_mark(ContentIoFocus::Output, idx, 0);
+            // Dialogue-global ids: the input user block is 0, so the output
+            // tool block is 1.
+            pane.toggle_mark(idx, 1);
         }
 
         let picked = workspace_picked_content_for_marked_blocks(&dialogues, &selected, 0, &pane)

--- a/src/commands/browse/help.rs
+++ b/src/commands/browse/help.rs
@@ -50,8 +50,8 @@ pub(super) fn apply_workspace_help_action(
     dialogue_state: &mut ListState,
     selected_dialogues: &mut Vec<bool>,
     range_anchor: &mut Option<usize>,
-    // Content block-range anchor for `v` (half + block id of the first press).
-    content_range_anchor: &mut Option<(ContentIoFocus, usize)>,
+    // Content block-range anchor for `v` (block id of the first press).
+    content_range_anchor: &mut Option<usize>,
     content_scrolls: &mut ContentScrolls,
     content_io_focus: &mut ContentIoFocus,
     content_mode: &mut ContentViewMode,
@@ -116,7 +116,6 @@ pub(super) fn apply_workspace_help_action(
             dialogue_state,
             selected_dialogues,
             content_scrolls,
-            *content_io_focus,
             content_cursor,
             content_blocks,
         ),
@@ -131,7 +130,6 @@ pub(super) fn apply_workspace_help_action(
             dialogue_state,
             selected_dialogues,
             content_scrolls,
-            *content_io_focus,
             content_cursor,
             content_blocks,
         ),
@@ -205,8 +203,8 @@ pub(super) fn apply_workspace_help_action(
                 // pages one dialogue at a time, so the shown dialogue owns
                 // the mark regardless of the selection count.
                 let shown = shown_dialogue_idx(selected_dialogues, *content_page, dialogue_idx);
-                if let Some((half, block)) = content_cursor.focused(*content_io_focus) {
-                    content_pane.toggle_mark(half, shown, block);
+                if let Some(block) = content_cursor.get() {
+                    content_pane.toggle_mark(shown, block);
                 }
             }
         },
@@ -298,29 +296,26 @@ pub(super) fn apply_workspace_help_action(
                 apply_range_selection(range_anchor, selected_dialogues, dialogue_idx);
             }
             WorkspaceFocus::Content => {
-                // Block range: `v` anchors the cursor block in the current
-                // half, moves extend, and a second `v` toggles marks across
-                // the anchor..cursor span. Switching half re-anchors.
-                if let Some((half, cursor_block)) = content_cursor.focused(*content_io_focus) {
+                // Block range: `v` anchors the cursor block, moves extend,
+                // and a second `v` toggles marks across the anchor..cursor
+                // span of the continuous input+output block sequence.
+                if let Some(cursor_block) = content_cursor.get() {
                     match *content_range_anchor {
-                        Some((anchor_half, anchor_block)) if anchor_half == half => {
+                        Some(anchor_block) => {
                             let shown =
                                 shown_dialogue_idx(selected_dialogues, *content_page, dialogue_idx);
-                            let blocks = match half {
-                                ContentIoFocus::Input => content_blocks.0,
-                                ContentIoFocus::Output => content_blocks.1,
-                            };
-                            let anchor = blocks.iter().position(|b| b.id == anchor_block);
-                            let cursor = blocks.iter().position(|b| b.id == cursor_block);
-                            if let (Some(anchor), Some(cursor)) = (anchor, cursor) {
-                                let (lo, hi) = (anchor.min(cursor), anchor.max(cursor));
-                                for block in &blocks[lo..=hi] {
-                                    content_pane.toggle_mark(half, shown, block.id);
+                            let (lo, hi) = (
+                                anchor_block.min(cursor_block),
+                                anchor_block.max(cursor_block),
+                            );
+                            for block in content_blocks.0.iter().chain(content_blocks.1) {
+                                if (lo..=hi).contains(&block.id) {
+                                    content_pane.toggle_mark(shown, block.id);
                                 }
                             }
                             *content_range_anchor = None;
                         }
-                        _ => *content_range_anchor = Some((half, cursor_block)),
+                        _ => *content_range_anchor = Some(cursor_block),
                     }
                 }
             }
@@ -379,8 +374,8 @@ pub(super) fn apply_workspace_help_action(
         }
         WorkspaceHelpAction::ToggleBlockFold if *focus == WorkspaceFocus::Content => {
             if *content_mode == ContentViewMode::Reading {
-                if let Some((half, block)) = content_cursor.focused(*content_io_focus) {
-                    expanded.toggle(half, block);
+                if let Some(block) = content_cursor.get() {
+                    expanded.toggle(block);
                     content_cursor.follow = true;
                 }
             }
@@ -442,12 +437,11 @@ pub(super) fn apply_workspace_help_action(
             // The block id belongs to the *displayed* dialogue, so resolve
             // the shown index like the marked paths do, not the focused row.
             let shown = shown_dialogue_idx(selected_dialogues, *content_page, dialogue_idx);
-            let block_id = content_cursor.get(*content_io_focus).unwrap_or(0);
+            let block_id = content_cursor.get().unwrap_or(0);
             if let Some(picked) = workspace_picked_content_for_cursor_block(
                 dialogues,
                 selected_dialogues,
                 shown,
-                *content_io_focus,
                 block_id,
             ) {
                 return Ok(HelpDispatch::Picked(picked));
@@ -599,7 +593,7 @@ pub(super) fn set_focus(
     focus: &mut WorkspaceFocus,
     fullscreen: &mut Option<WorkspaceFocus>,
     range_anchor: &mut Option<usize>,
-    content_range_anchor: &mut Option<(ContentIoFocus, usize)>,
+    content_range_anchor: &mut Option<usize>,
     next: WorkspaceFocus,
 ) {
     *focus = next;

--- a/src/commands/browse/nav.rs
+++ b/src/commands/browse/nav.rs
@@ -31,41 +31,46 @@ pub(super) fn open_link_target(target: &str) -> Result<()> {
     Ok(())
 }
 
-/// Keyboard/mouse cursor over content blocks, one position per half (each
-/// half keeps its own, like the session/dialogue lists). `follow` asks the
+/// Keyboard/mouse cursor over content blocks, one position per dialogue
+/// across both IO halves (block ids are dialogue-global). `follow` asks the
 /// picker to keep the cursor block visible on the next redraw; keyboard
 /// moves set it, clicks do not (a clicked line is already visible).
 #[derive(Default)]
 pub(super) struct ContentBlockCursor {
-    pub(super) input: Option<usize>,
-    pub(super) output: Option<usize>,
+    pub(super) block: Option<usize>,
     pub(super) follow: bool,
 }
 
 impl ContentBlockCursor {
-    pub(super) fn get(&self, half: ContentIoFocus) -> Option<usize> {
-        match half {
-            ContentIoFocus::Input => self.input,
-            ContentIoFocus::Output => self.output,
-        }
+    pub(super) fn get(&self) -> Option<usize> {
+        self.block
     }
 
-    pub(super) fn set(&mut self, half: ContentIoFocus, block: usize) {
-        match half {
-            ContentIoFocus::Input => self.input = Some(block),
-            ContentIoFocus::Output => self.output = Some(block),
-        }
+    pub(super) fn set(&mut self, block: usize) {
+        self.block = Some(block);
     }
 
     pub(super) fn clear(&mut self) {
-        self.input = None;
-        self.output = None;
+        self.block = None;
         self.follow = false;
     }
 
-    /// `(half, block)` of the focused half, for the view highlight.
-    pub(super) fn focused(&self, focus: ContentIoFocus) -> Option<(ContentIoFocus, usize)> {
-        self.get(focus).map(|block| (focus, block))
+    /// `(half, block)` of the cursor, for the view highlight and block
+    /// operations. The half is the one whose displayed segments own the
+    /// cursor id; a block hidden by a fold has no half and no highlight.
+    pub(super) fn focused(
+        &self,
+        blocks: (&[BlockText], &[BlockText]),
+    ) -> Option<(ContentIoFocus, usize)> {
+        let block = self.block?;
+        let half = if blocks.0.iter().any(|segment| segment.id == block) {
+            ContentIoFocus::Input
+        } else if blocks.1.iter().any(|segment| segment.id == block) {
+            ContentIoFocus::Output
+        } else {
+            return None;
+        };
+        Some((half, block))
     }
 }
 
@@ -131,7 +136,6 @@ pub(super) fn move_workspace_cursor_up(
     dialogue_state: &mut ListState,
     selected_dialogues: &mut Vec<bool>,
     content_scrolls: &mut ContentScrolls,
-    content_io_focus: ContentIoFocus,
     content_cursor: &mut ContentBlockCursor,
     content_blocks: (&[BlockText], &[BlockText]),
 ) {
@@ -156,7 +160,7 @@ pub(super) fn move_workspace_cursor_up(
             content_scrolls.clear();
         }
         WorkspaceFocus::Content => {
-            move_content_cursor(true, content_cursor, content_blocks, content_io_focus);
+            move_content_cursor(true, content_cursor, content_blocks);
         }
     }
 }
@@ -173,7 +177,6 @@ pub(super) fn move_workspace_cursor_down(
     dialogue_state: &mut ListState,
     selected_dialogues: &mut Vec<bool>,
     content_scrolls: &mut ContentScrolls,
-    content_io_focus: ContentIoFocus,
     content_cursor: &mut ContentBlockCursor,
     content_blocks: (&[BlockText], &[BlockText]),
 ) {
@@ -201,38 +204,46 @@ pub(super) fn move_workspace_cursor_down(
             content_scrolls.clear();
         }
         WorkspaceFocus::Content => {
-            move_content_cursor(false, content_cursor, content_blocks, content_io_focus);
+            move_content_cursor(false, content_cursor, content_blocks);
         }
     }
 }
 
-/// Move the content block cursor within the focused half, clamped like a
-/// list selection; the next redraw keeps the cursor block visible. The walk
-/// follows the *visible* block sequence (the rendered segments), so folds —
-/// which change which blocks are shown — resolve the cursor id against the
-/// current segments and clamp to the nearest visible block.
+/// Move the content cursor across the whole dialogue: input blocks then
+/// output blocks form one continuous sequence, so j/k flows over the half
+/// boundary. The walk follows the *visible* block sequence (the rendered
+/// segments), so folds — which change which blocks are shown — resolve the
+/// cursor id against the current segments and clamp to the nearest visible
+/// block.
 fn move_content_cursor(
     up: bool,
     cursor: &mut ContentBlockCursor,
     blocks: (&[BlockText], &[BlockText]),
-    focus: ContentIoFocus,
 ) {
-    let blocks = match focus {
-        ContentIoFocus::Input => blocks.0,
-        ContentIoFocus::Output => blocks.1,
-    };
-    if blocks.is_empty() {
+    let (input_blocks, output_blocks) = blocks;
+    let input_len = input_blocks.len();
+    let total = input_len + output_blocks.len();
+    if total == 0 {
         return;
     }
-    let position = cursor
-        .get(focus)
-        .and_then(|id| blocks.iter().position(|block| block.id == id));
+    // Cursor's position in the continuous input + output sequence.
+    let position = cursor.get().and_then(|id| {
+        input_blocks
+            .iter()
+            .chain(output_blocks)
+            .position(|block| block.id == id)
+    });
     let next = match position {
         Some(pos) if up => pos.saturating_sub(1),
-        Some(pos) => (pos + 1).min(blocks.len() - 1),
+        Some(pos) => (pos + 1).min(total - 1),
         None => 0,
     };
-    cursor.set(focus, blocks[next].id);
+    let id = if next < input_len {
+        input_blocks[next].id
+    } else {
+        output_blocks[next - input_len].id
+    };
+    cursor.set(id);
     cursor.follow = true;
 }
 

--- a/src/commands/browse/nav.rs
+++ b/src/commands/browse/nav.rs
@@ -226,24 +226,24 @@ fn move_content_cursor(
     if total == 0 {
         return;
     }
-    // Cursor's position in the continuous input + output sequence.
-    let position = cursor.get().and_then(|id| {
-        input_blocks
+    let ids: Vec<_> = input_blocks
+        .iter()
+        .chain(output_blocks)
+        .map(|block| block.id)
+        .collect();
+    let current_id = cursor.get();
+    let position = current_id.and_then(|id| ids.iter().position(|visible| *visible == id));
+    let next = match (current_id, position) {
+        (None, _) => 0,
+        (Some(_), Some(pos)) if up => pos.saturating_sub(1),
+        (Some(_), Some(pos)) => (pos + 1).min(total - 1),
+        (Some(id), None) if up => ids.iter().rposition(|visible| *visible < id).unwrap_or(0),
+        (Some(id), None) => ids
             .iter()
-            .chain(output_blocks)
-            .position(|block| block.id == id)
-    });
-    let next = match position {
-        Some(pos) if up => pos.saturating_sub(1),
-        Some(pos) => (pos + 1).min(total - 1),
-        None => 0,
+            .position(|visible| *visible > id)
+            .unwrap_or(total - 1),
     };
-    let id = if next < input_len {
-        input_blocks[next].id
-    } else {
-        output_blocks[next - input_len].id
-    };
-    cursor.set(id);
+    cursor.set(ids[next]);
     cursor.follow = true;
 }
 
@@ -309,8 +309,19 @@ pub(super) fn reset_workspace_dialogue_state(
 
 #[cfg(test)]
 mod tests {
-    use super::{row_list_index, shown_dialogue_idx};
+    use super::{move_content_cursor, row_list_index, shown_dialogue_idx, ContentBlockCursor};
+    use crate::tui::content::block::BlockText;
     use ratatui::layout::Rect;
+    use sivtr_core::record::WorkPartKind;
+
+    fn block(id: usize) -> BlockText {
+        BlockText {
+            id,
+            text: String::new(),
+            tight: false,
+            kind: WorkPartKind::Output,
+        }
+    }
 
     #[test]
     fn row_list_index_includes_scroll_offset() {
@@ -340,5 +351,19 @@ mod tests {
         assert_eq!(shown_dialogue_idx(&selected, 2, 0), 4);
         // A page past the end clamps to the last selected dialogue.
         assert_eq!(shown_dialogue_idx(&selected, 9, 0), 4);
+    }
+
+    #[test]
+    fn hidden_cursor_moves_to_the_nearest_visible_block() {
+        let blocks = [block(0), block(1), block(4)];
+        let mut cursor = ContentBlockCursor::default();
+        cursor.set(3);
+
+        move_content_cursor(true, &mut cursor, (&[], &blocks));
+        assert_eq!(cursor.get(), Some(1));
+
+        cursor.set(3);
+        move_content_cursor(false, &mut cursor, (&[], &blocks));
+        assert_eq!(cursor.get(), Some(4));
     }
 }

--- a/src/commands/browse/panes.rs
+++ b/src/commands/browse/panes.rs
@@ -8,7 +8,6 @@
 //! Do **not** reimplement viewport growth, keep/evict, or blanking rules.
 
 use crate::pane::{Pane, PaneInput, Selection, SlidingPane, WindowRow};
-use crate::tui::content::block::{marked_mask_len, BlockText};
 use crate::tui::content::view::ContentViewMode;
 use crate::tui::workspace::{
     workspace_content_io_texts, ContentIoFocus, ContentIoFrame, ExpandedBlocks, WorkspaceDialogue,
@@ -421,51 +420,26 @@ pub struct ContentCtx<'a> {
 /// Tracks layout line counts for Input / Output halves separately and owns
 /// the per-dialogue block multi-select (native pane selection): clicking a
 /// block's dot toggles its id, and content (copy, fold) consumes the mask.
-/// Marks are keyed by dialogue so multi-select paging (J/K) keeps every
-/// page's marks; the picker clears the whole set when the selection changes.
+/// Block ids are dialogue-global (input blocks first, output blocks after),
+/// so one mask per dialogue spans both halves. Marks are keyed by dialogue
+/// so multi-select paging (J/K) keeps every page's marks; the picker clears
+/// the whole set when the selection changes.
 #[derive(Default)]
 pub struct ContentPane {
     input_lines: usize,
     output_lines: usize,
-    /// Marked block ids per dialogue per half, indexed by block id (dense
-    /// DFS ids): `dialogue_idx -> (input, output)`.
-    marked: std::collections::HashMap<usize, [Selection; 2]>,
+    /// Marked block ids per dialogue (dense dialogue-global ids).
+    marked: std::collections::HashMap<usize, Selection>,
 }
 
-/// Block-selection mask length of one half: the shown dialogue's *complete*
-/// block-id collection when its record is loaded (so marks for folded
-/// blocks survive resizing and are restored on expand), else the displayed
-/// segments of the current frame.
-fn block_mask_len(
-    dialogues: &[WorkspaceDialogue],
-    idx: usize,
-    input: bool,
-    displayed: &[BlockText],
-) -> usize {
-    let full = dialogues
+/// Block-selection mask length of the shown dialogue: its *complete* block
+/// count, so marks on blocks currently hidden by a fold survive a rebuild.
+/// A dialogue whose record is not loaded has no blocks to mark.
+fn block_mask_len(dialogues: &[WorkspaceDialogue], idx: usize) -> usize {
+    dialogues
         .get(idx)
         .and_then(|dialogue| dialogue.record.as_ref())
-        .map(|record| {
-            marked_mask_len(
-                crate::tui::content::block::half_blocks(record, input)
-                    .iter()
-                    .map(|block| block.id),
-            )
-        })
-        .unwrap_or(0);
-    full.max(marked_mask_len(displayed.iter().map(|block| block.id)))
-}
-
-fn half_selection_mut(
-    marked: &mut std::collections::HashMap<usize, [Selection; 2]>,
-    idx: usize,
-    half: ContentIoFocus,
-) -> &mut Selection {
-    let entry = marked.entry(idx).or_default();
-    match half {
-        ContentIoFocus::Input => &mut entry[0],
-        ContentIoFocus::Output => &mut entry[1],
-    }
+        .map_or(0, crate::tui::content::block::dialogue_block_count)
 }
 
 impl ContentPane {
@@ -476,7 +450,7 @@ impl ContentPane {
         }
     }
 
-    /// Build the frame for this context, resizing the block selection masks
+    /// Build the frame for this context, resizing the block selection mask
     /// of the shown dialogue's block ids. Rebuilds the cached layouts; call
     /// it only when the content actually changed.
     pub fn ensure(&mut self, ctx: ContentCtx<'_>) -> ContentIoFrame {
@@ -490,43 +464,24 @@ impl ContentPane {
         let frame = ContentIoFrame::build(ctx.area, texts, ctx.mode, ctx.io_focus);
         self.input_lines = frame.line_count(ContentIoFocus::Input);
         self.output_lines = frame.line_count(ContentIoFocus::Output);
-        half_selection_mut(&mut self.marked, ctx.highlighted_idx, ContentIoFocus::Input).resize(
-            block_mask_len(
-                ctx.dialogues,
-                ctx.highlighted_idx,
-                true,
-                &frame.texts.input_blocks,
-            ),
-        );
-        half_selection_mut(
-            &mut self.marked,
-            ctx.highlighted_idx,
-            ContentIoFocus::Output,
-        )
-        .resize(block_mask_len(
-            ctx.dialogues,
-            ctx.highlighted_idx,
-            false,
-            &frame.texts.output_blocks,
-        ));
+        self.marked
+            .entry(ctx.highlighted_idx)
+            .or_default()
+            .resize(block_mask_len(ctx.dialogues, ctx.highlighted_idx));
         frame
     }
 
-    /// Marked block mask of one dialogue's half (`mask[block_id]` = marked);
+    /// Marked block mask of one dialogue (`mask[block_id]` = marked);
     /// an unknown dialogue has no marks.
-    pub fn marked(&self, half: ContentIoFocus, dialogue_idx: usize) -> &[bool] {
-        let [input, output] = match self.marked.get(&dialogue_idx) {
-            Some(entry) => entry,
-            None => return &[],
-        };
-        match half {
-            ContentIoFocus::Input => input.mask(),
-            ContentIoFocus::Output => output.mask(),
+    pub fn marked(&self, dialogue_idx: usize) -> &[bool] {
+        match self.marked.get(&dialogue_idx) {
+            Some(selection) => selection.mask(),
+            None => &[],
         }
     }
 
-    pub fn toggle_mark(&mut self, half: ContentIoFocus, dialogue_idx: usize, block: usize) {
-        half_selection_mut(&mut self.marked, dialogue_idx, half).toggle(block);
+    pub fn toggle_mark(&mut self, dialogue_idx: usize, block: usize) {
+        self.marked.entry(dialogue_idx).or_default().toggle(block);
     }
 
     /// Drop every dialogue's marks (selection set changed).
@@ -537,7 +492,7 @@ impl ContentPane {
     pub fn marked_count(&self) -> usize {
         self.marked
             .values()
-            .map(|[input, output]| input.count() + output.count())
+            .map(|selection| selection.count())
             .sum()
     }
 }

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -97,13 +97,13 @@ pub(crate) fn run(
     let mut pending_block_toggle: Option<(ContentIoFocus, usize)> = None;
     // Last single click on a block (time + target); a second click on the
     // same block within the window folds it.
-    let mut last_block_click: Option<(std::time::Instant, ContentIoFocus, usize)> = None;
+    let mut last_block_click: Option<(std::time::Instant, usize)> = None;
     // Block cursor (keyboard j/k + click), highlighted like a list row; one
-    // position per half.
+    // position per dialogue, spanning both IO halves.
     let mut content_cursor = ContentBlockCursor::default();
-    // Content block-range anchor for `v` (half + block id); cleared when the
-    // focus, half, or shown dialogue changes.
-    let mut content_range_anchor: Option<(ContentIoFocus, usize)> = None;
+    // Content block-range anchor for `v` (dialogue-global block id); cleared
+    // when the focus or shown dialogue changes.
+    let mut content_range_anchor: Option<usize> = None;
     // Mouse-down anchor inside content; promoted to a real selection only by
     // the first drag, so a pure click never shows a selection flash.
     let mut mouse_down_select: Option<MouseSelectionStart> = None;
@@ -374,8 +374,7 @@ pub(crate) fn run(
                 selected_dialogues.clone(),
             );
             if expanded_key.as_ref() != Some(&expand_key) {
-                expanded_blocks.input.clear();
-                expanded_blocks.output.clear();
+                expanded_blocks.clear();
                 pending_block_toggle = None;
                 last_block_click = None;
                 mouse_down_select = None;
@@ -418,11 +417,14 @@ pub(crate) fn run(
                 );
                 last_content_key = Some(content_key);
             }
+            // Cursor block resolved against the frame's displayed segments
+            // once: the follow-scroll and the view highlight share it.
+            let cursor_focus = content_cursor.focused(content_frame.texts.block_slices());
             // Keyboard moves ask the next redraw to keep the cursor block in
             // view; clicks never set `follow`, so they keep the scroll as-is.
             if content_cursor.follow {
                 content_cursor.follow = false;
-                if let Some((half, block)) = content_cursor.focused(content_io_focus) {
+                if let Some((half, block)) = cursor_focus {
                     let area = content_frame.areas.area(half);
                     if let Some(range) = content_block_range(content_frame.layout(half), block) {
                         let visible = area.height.saturating_sub(2) as usize;
@@ -500,15 +502,9 @@ pub(crate) fn run(
                         fullscreen,
                         content_selection: visual_select_mode
                             .map(|mode: VisualSelectMode| mode.selection),
-                        content_block_cursor: content_cursor.focused(content_io_focus),
-                        content_range: content_range_anchor.and_then(|(half, anchor)| {
-                            content_cursor
-                                .focused(half)
-                                .map(|(_, cursor)| (half, anchor, cursor))
-                        }),
-                        content_marked_input: content_pane.marked(ContentIoFocus::Input, shown_idx),
-                        content_marked_output: content_pane
-                            .marked(ContentIoFocus::Output, shown_idx),
+                        content_block_cursor: cursor_focus,
+                        content_range: content_range_anchor.zip(content_cursor.get()),
+                        content_marked: content_pane.marked(shown_idx),
                         content_page: (selected > 1).then_some((content_page, selected)),
                         content_frame: &content_frame,
                     },
@@ -658,7 +654,6 @@ pub(crate) fn run(
                                 &mut dialogue_state,
                                 &mut selected_dialogues,
                                 &mut content_scrolls,
-                                content_io_focus,
                                 &mut content_cursor,
                                 content_frame.texts.block_slices(),
                             );
@@ -675,7 +670,6 @@ pub(crate) fn run(
                                 &mut dialogue_state,
                                 &mut selected_dialogues,
                                 &mut content_scrolls,
-                                content_io_focus,
                                 &mut content_cursor,
                                 content_frame.texts.block_slices(),
                             );
@@ -1009,7 +1003,7 @@ pub(crate) fn run(
                                     &mut content_range_anchor,
                                     WorkspaceFocus::Content,
                                 );
-                                content_cursor.set(half, block);
+                                content_cursor.set(block);
                                 // Dot marks belong to the shown dialogue
                                 // (multi-select pages one dialogue at a
                                 // time, so ids never repeat on screen).
@@ -1018,7 +1012,7 @@ pub(crate) fn run(
                                     content_page,
                                     dialogue_idx,
                                 );
-                                content_pane.toggle_mark(half, shown, block);
+                                content_pane.toggle_mark(shown, block);
                                 continue;
                             }
                         }
@@ -1104,20 +1098,18 @@ pub(crate) fn run(
                             // block; a second click on the same block within
                             // the window folds it (read mode only).
                             if matches!(mouse.kind, MouseEventKind::Up(MouseButton::Left)) {
-                                if let Some((half, block)) = pending_block_toggle.take() {
-                                    content_cursor.set(half, block);
+                                if let Some((_, block)) = pending_block_toggle.take() {
+                                    content_cursor.set(block);
                                     let now = std::time::Instant::now();
-                                    let double_click = last_block_click.is_some_and(
-                                        |(at, last_half, last_block)| {
-                                            last_half == half
-                                                && last_block == block
+                                    let double_click =
+                                        last_block_click.is_some_and(|(at, last_block)| {
+                                            last_block == block
                                                 && now.duration_since(at)
                                                     < std::time::Duration::from_millis(400)
-                                        },
-                                    );
-                                    last_block_click = Some((now, half, block));
+                                        });
+                                    last_block_click = Some((now, block));
                                     if double_click && content_mode == ContentViewMode::Reading {
-                                        expanded_blocks.toggle(half, block);
+                                        expanded_blocks.toggle(block);
                                     }
                                     redraw = true;
                                 }
@@ -1626,8 +1618,10 @@ mod tests {
             workspace_picked_content_for_marked_blocks(&dialogues, &selected, 0, &pane).is_none()
         );
 
-        // Mark the tool block (output half): copy joins the call + result bodies.
-        pane.toggle_mark(ContentIoFocus::Output, 0, 0);
+        // Mark the tool block (output half): copy joins the call + result
+        // bodies. Ids are dialogue-global — the input user block is 0, so the
+        // output pair is 1.
+        pane.toggle_mark(0, 1);
         let picked = workspace_picked_content_for_marked_blocks(&dialogues, &selected, 0, &pane)
             .expect("marked copy");
         assert_eq!(picked.units.len(), 1);
@@ -1643,7 +1637,7 @@ mod tests {
         );
 
         // Mark the user block (input half): both marked blocks are joined.
-        pane.toggle_mark(ContentIoFocus::Input, 0, 0);
+        pane.toggle_mark(0, 0);
         let picked = workspace_picked_content_for_marked_blocks(&dialogues, &selected, 0, &pane)
             .expect("marked copy");
         let text = &picked.units[0].plain;
@@ -1708,10 +1702,10 @@ mod tests {
             expanded: &crate::tui::content::io::ExpandedBlocks::default(),
         });
 
-        // Mark the output run block: the tool run is id 1 (assistant's
-        // reply is id 0 in the output half). Copy joins the run's tool
-        // bodies, never the user or assistant blocks.
-        pane.toggle_mark(ContentIoFocus::Output, 0, 1);
+        // Mark the output run block. Ids are dialogue-global: the input user
+        // block is 0, the assistant reply 1, so the tool run is 2. Copy joins
+        // the run's tool bodies, never the user or assistant blocks.
+        pane.toggle_mark(0, 2);
         let picked = workspace_picked_content_for_marked_blocks(&dialogues, &selected, 0, &pane)
             .expect("marked copy");
         let text = &picked.units[0].plain;
@@ -1727,7 +1721,7 @@ mod tests {
     }
 
     #[test]
-    fn dot_marked_block_survives_ensure_and_matches_half_blocks_ids() {
+    fn dot_marked_block_survives_ensure_and_matches_dialogue_block_ids() {
         // Simulate the real click flow: build the frame, hit a block through
         // the layout (as the dot gutter does), toggle it, then run the copy
         // collection — it must find the block, never return None.
@@ -1796,7 +1790,7 @@ mod tests {
             }
         }
         let hit_id = hit_id.expect("a block is hit in the output half");
-        pane.toggle_mark(ContentIoFocus::Output, 0, hit_id);
+        pane.toggle_mark(0, hit_id);
 
         let picked = workspace_picked_content_for_marked_blocks(&dialogues, &selected, 0, &pane)
             .expect("marked copy must not be None after a real dot hit");
@@ -1858,16 +1852,10 @@ mod tests {
         let dialogues = [dialogue.clone()];
         let selected = [true];
 
-        // Output half: assistant = id 0, grep tool pair = id 1. The cursor
-        // on the tool block copies only it.
-        let picked = workspace_picked_content_for_cursor_block(
-            &dialogues,
-            &selected,
-            0,
-            ContentIoFocus::Output,
-            1,
-        )
-        .expect("tool block copy must not be None");
+        // Dialogue-global ids: user = 0, assistant = 1, grep tool pair = 2.
+        // The cursor on the tool block copies only it.
+        let picked = workspace_picked_content_for_cursor_block(&dialogues, &selected, 0, 2)
+            .expect("tool block copy must not be None");
         let text = &picked.units[0].plain;
         assert!(text.contains("fn main"), "tool call missing: {text}");
         assert!(text.contains("\"matches\""), "tool result missing: {text}");
@@ -1879,10 +1867,10 @@ mod tests {
 
     #[test]
     fn run_member_block_copies_even_though_nested_under_the_run() {
-        // Two consecutive tool pairs merge into a run (id 0) with members
-        // (id 1, 2). The cursor may sit on a member after expanding the run;
-        // y must copy just that member, not fail because the member is not a
-        // top-level block.
+        // Two consecutive tool pairs merge into a run (id 1, after the input
+        // user block) with members (id 2, 3). The cursor may sit on a member
+        // after expanding the run; y must copy just that member, not fail
+        // because the member is not a top-level block.
         let mut record = workspace_test_record(
             WorkspaceSource::agent(AgentProvider::Codex),
             "cmd",
@@ -1919,15 +1907,9 @@ mod tests {
         let dialogues = [dialogue.clone()];
         let selected = [true];
 
-        // Member id 1 = the first tool of the run.
-        let picked = workspace_picked_content_for_cursor_block(
-            &dialogues,
-            &selected,
-            0,
-            ContentIoFocus::Output,
-            1,
-        )
-        .expect("run member copy must not be None");
+        // Member id 2 = the first tool of the run.
+        let picked = workspace_picked_content_for_cursor_block(&dialogues, &selected, 0, 2)
+            .expect("run member copy must not be None");
         let text = &picked.units[0].plain;
         assert!(text.contains("pat 0"), "first member missing: {text}");
         assert!(!text.contains("pat 1"), "second member leaked: {text}");
@@ -1936,7 +1918,7 @@ mod tests {
         // so the mask covers the member ids.
         let mut pane = ContentPane::default();
         let mut expanded = crate::tui::content::io::ExpandedBlocks::default();
-        expanded.toggle(ContentIoFocus::Output, 0);
+        expanded.toggle(1);
         pane.ensure(ContentCtx {
             dialogues: &dialogues,
             highlighted_idx: 0,
@@ -1946,7 +1928,7 @@ mod tests {
             io_focus: ContentIoFocus::Output,
             expanded: &expanded,
         });
-        pane.toggle_mark(ContentIoFocus::Output, 0, 1);
+        pane.toggle_mark(0, 2);
         let picked = workspace_picked_content_for_marked_blocks(&dialogues, &selected, 0, &pane)
             .expect("marked member copy");
         let text = &picked.units[0].plain;
@@ -1990,15 +1972,10 @@ mod tests {
         let dialogues = [dialogue.clone()];
         let selected = [true];
 
-        // Cursor on the tool block (output half): call + result bodies only.
-        let picked = workspace_picked_content_for_cursor_block(
-            &dialogues,
-            &selected,
-            0,
-            ContentIoFocus::Output,
-            0,
-        )
-        .expect("cursor block copy");
+        // Cursor on the tool block (output half, id 1 after the input user
+        // block): call + result bodies only.
+        let picked = workspace_picked_content_for_cursor_block(&dialogues, &selected, 0, 1)
+            .expect("cursor block copy");
         assert_eq!(picked.units.len(), 1);
         let text = &picked.units[0].plain;
         assert!(text.contains("$ ls"), "tool call body missing: {text}");
@@ -2011,15 +1988,9 @@ mod tests {
             "other input block leaked: {text}"
         );
 
-        // Cursor on the user block (input half): just the user text.
-        let picked = workspace_picked_content_for_cursor_block(
-            &dialogues,
-            &selected,
-            0,
-            ContentIoFocus::Input,
-            0,
-        )
-        .expect("cursor block copy");
+        // Cursor on the user block (input half, id 0): just the user text.
+        let picked = workspace_picked_content_for_cursor_block(&dialogues, &selected, 0, 0)
+            .expect("cursor block copy");
         assert_eq!(picked.units[0].plain, "user text");
     }
 
@@ -2417,7 +2388,6 @@ mod tests {
             &mut dialogue_state,
             &mut selected_dialogues,
             &mut content_scrolls,
-            ContentIoFocus::Input,
             &mut super::super::nav::ContentBlockCursor::default(),
             (&[], &[]),
         );

--- a/src/commands/browse/visual.rs
+++ b/src/commands/browse/visual.rs
@@ -380,7 +380,7 @@ pub(super) fn apply_workspace_mouse_scroll(
         let next = next.min(layout.lines.len().saturating_sub(1));
         content_scrolls.set(content_io_focus, next);
         if let Some(block) = content_block_at(layout, next) {
-            content_cursor.set(content_io_focus, block);
+            content_cursor.set(block);
         }
         return;
     }
@@ -397,7 +397,6 @@ pub(super) fn apply_workspace_mouse_scroll(
                 dialogue_state,
                 selected_dialogues,
                 content_scrolls,
-                content_io_focus,
                 content_cursor,
                 content_frame.texts.block_slices(),
             );
@@ -413,7 +412,6 @@ pub(super) fn apply_workspace_mouse_scroll(
                 dialogue_state,
                 selected_dialogues,
                 content_scrolls,
-                content_io_focus,
                 content_cursor,
                 content_frame.texts.block_slices(),
             );

--- a/src/tui/content/block.rs
+++ b/src/tui/content/block.rs
@@ -164,6 +164,23 @@ pub(crate) fn dialogue_block_count(record: &WorkRecord) -> usize {
     input.iter().chain(&output).map(Block::node_count).sum()
 }
 
+pub(crate) fn dialogue_block_id(record: &WorkRecord, seq: usize) -> Option<usize> {
+    let (input, output) = dialogue_blocks(record);
+    let part = record.parts.iter().position(|part| part.seq == seq)?;
+    input
+        .iter()
+        .chain(&output)
+        .find_map(|block| block_id_for_part(block, part))
+}
+
+fn block_id_for_part(block: &Block, part: usize) -> Option<usize> {
+    block
+        .children
+        .iter()
+        .find_map(|child| block_id_for_part(child, part))
+        .or_else(|| block.parts.contains(&part).then_some(block.id))
+}
+
 fn build_half_units(record: &WorkRecord, input: bool) -> Vec<Block> {
     let parts: Vec<usize> = record
         .parts
@@ -706,6 +723,7 @@ mod tests {
         assert_eq!(input.len(), 1);
         assert_eq!(output[0].children.len(), 2);
         assert_eq!(output[0].children[1].id, 3);
+        assert_eq!(dialogue_block_id(&rec, 3), Some(3));
     }
 
     /// Render one half through the dialogue-global block ids.

--- a/src/tui/content/block.rs
+++ b/src/tui/content/block.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 
 use sivtr_core::record::{WorkPart, WorkPartData, WorkPartKind, WorkRecord};
 
-use crate::tui::content::io::{ContentIoFocus, ExpandedBlocks};
+use crate::tui::content::io::ExpandedBlocks;
 use crate::tui::content::tool::{part_body_text, tool_display_name, tool_tag_for_part};
 
 /// A foldable content block: the parts it owns, the kind that drives its
@@ -21,8 +21,9 @@ use crate::tui::content::tool::{part_body_text, tool_display_name, tool_tag_for_
 /// the member blocks revealed when the run is expanded.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct Block {
-    /// Stable identity within one IO half (DFS pre-order), used by the fold
-    /// state and the content cursor; id 0 is the first block of the half.
+    /// Stable identity within the dialogue (DFS pre-order over the input
+    /// half then the output half), used by the fold state, the marks, and
+    /// the content cursor; id 0 is the dialogue's first block.
     pub(crate) id: usize,
     /// Indices into the record's parts, in display order.
     pub(crate) parts: Vec<usize>,
@@ -43,12 +44,6 @@ pub(crate) struct BlockText {
     pub(crate) kind: WorkPartKind,
 }
 
-/// Largest block id plus one for the given ids, for mask sizing. Shared by
-/// the content layout and the block-selection masks.
-pub(crate) fn marked_mask_len(ids: impl IntoIterator<Item = usize>) -> usize {
-    ids.into_iter().max().map_or(0, |max| max + 1)
-}
-
 impl Block {
     /// A leaf (non-run) block; ids are assigned by `assign_ids` afterwards.
     fn leaf(parts: Vec<usize>, kind: WorkPartKind) -> Self {
@@ -58,6 +53,11 @@ impl Block {
             kind,
             children: Vec::new(),
         }
+    }
+
+    /// This block plus every nested member — the ids `assign_ids` consumes.
+    fn node_count(&self) -> usize {
+        1 + self.children.iter().map(Block::node_count).sum::<usize>()
     }
 
     /// Full body of a leaf: every part formatted as in the current content
@@ -126,9 +126,45 @@ fn kind_name(kind: WorkPartKind) -> &'static str {
 /// carrying the same call id fold into one unit — wherever the result lands,
 /// so interleaved parallel calls pair correctly — and consecutive structure
 /// units (tool / thinking / skill, mixed kinds allowed) fold into one run;
-/// anything else is one part per block. Blocks get stable DFS pre-order ids
-/// so the fold state and cursor survive folds.
+/// anything else is one part per block. Runs get stable DFS pre-order ids
+/// later, over the whole dialogue, so the fold state and cursor survive
+/// folds and can move continuously across the input/output boundary.
+pub(crate) fn dialogue_blocks(record: &WorkRecord) -> (Vec<Block>, Vec<Block>) {
+    let mut input = build_half_units(record, true);
+    let mut output = build_half_units(record, false);
+    // One global id space per dialogue: input blocks first, output blocks
+    // continue after them. The cursor, fold state, and marks key on this
+    // single sequence instead of two per-half id spaces.
+    let mut next = 0usize;
+    for block in &mut input {
+        assign_ids(block, &mut next);
+    }
+    for block in &mut output {
+        assign_ids(block, &mut next);
+    }
+    (input, output)
+}
+
+/// One half's blocks in the dialogue-global id space.
+#[cfg(test)]
 pub(crate) fn half_blocks(record: &WorkRecord, input: bool) -> Vec<Block> {
+    let (input_blocks, output_blocks) = dialogue_blocks(record);
+    if input {
+        input_blocks
+    } else {
+        output_blocks
+    }
+}
+
+/// Size of a dialogue's id space: every block of both halves, nested run
+/// members included, so a mask of this length holds a mark on any block —
+/// even one currently hidden by a fold.
+pub(crate) fn dialogue_block_count(record: &WorkRecord) -> usize {
+    let (input, output) = dialogue_blocks(record);
+    input.iter().chain(&output).map(Block::node_count).sum()
+}
+
+fn build_half_units(record: &WorkRecord, input: bool) -> Vec<Block> {
     let parts: Vec<usize> = record
         .parts
         .iter()
@@ -202,11 +238,6 @@ pub(crate) fn half_blocks(record: &WorkRecord, input: bool) -> Vec<Block> {
         }
     }
 
-    // Stable DFS pre-order ids for the fold state and the content cursor.
-    let mut next = 0usize;
-    for block in &mut blocks {
-        assign_ids(block, &mut next);
-    }
     blocks
 }
 
@@ -289,21 +320,17 @@ fn same_idless_tool(call_tool: Option<&str>, result_tool: Option<&str>) -> bool 
 /// Render one IO half's blocks to their display segments, in display order:
 /// a block's full body when shown, its collapsed tag otherwise. Runs always
 /// show the aggregate tag; expanding a run reveals its members below it,
-/// each still folded, joined on adjacent lines.
+/// each still folded, joined on adjacent lines. `blocks` comes from
+/// [`dialogue_blocks`], so ids are dialogue-global.
 pub(crate) fn render_half(
     record: &WorkRecord,
-    input: bool,
+    blocks: &[Block],
     reading: bool,
     expanded: &ExpandedBlocks,
 ) -> Vec<BlockText> {
-    let focus = if input {
-        ContentIoFocus::Input
-    } else {
-        ContentIoFocus::Output
-    };
     let mut out = Vec::new();
-    for block in half_blocks(record, input) {
-        out.extend(render_block(record, &block, reading, focus, expanded));
+    for block in blocks {
+        out.extend(render_block(record, block, reading, expanded));
     }
     out
 }
@@ -312,7 +339,6 @@ fn render_block(
     record: &WorkRecord,
     block: &Block,
     reading: bool,
-    focus: ContentIoFocus,
     expanded: &ExpandedBlocks,
 ) -> Vec<BlockText> {
     let mut segs = Vec::new();
@@ -327,12 +353,12 @@ fn render_block(
             });
         } else {
             for child in &block.children {
-                segs.extend(render_block(record, child, reading, focus, expanded));
+                segs.extend(render_block(record, child, reading, expanded));
             }
         }
     } else if block.children.is_empty() {
         // Leaf: body or collapsed tag by the block's fold default.
-        let shown = expanded.expanded(focus, block.id, block.kind.is_structure());
+        let shown = expanded.expanded(block.id, block.kind.is_structure());
         segs.push(BlockText {
             id: block.id,
             text: if shown {
@@ -346,7 +372,7 @@ fn render_block(
     } else {
         // Run: the aggregate tag stays as the group header; expanding the
         // run reveals its members below it, each still folded.
-        let shown = expanded.expanded(focus, block.id, true);
+        let shown = expanded.expanded(block.id, true);
         segs.push(BlockText {
             id: block.id,
             text: block.fold_label(record),
@@ -355,7 +381,7 @@ fn render_block(
         });
         if shown {
             for child in &block.children {
-                segs.extend(render_block(record, child, reading, focus, expanded));
+                segs.extend(render_block(record, child, reading, expanded));
             }
         }
     }
@@ -595,8 +621,8 @@ mod tests {
     fn body_parts_default_to_full_text_and_structure_to_tag() {
         let rec = record(vec![user_part(1, "question"), tool_part(2, "Bash", "ls")]);
         let expanded = ExpandedBlocks::default();
-        let input = render_half(&rec, true, true, &expanded);
-        let output = render_half(&rec, false, true, &expanded);
+        let input = render(&rec, true, true, &expanded);
+        let output = render(&rec, false, true, &expanded);
         // Body block shows its text; the tool block folds to its tag.
         assert_eq!(texts(input), vec!["question"]);
         assert_eq!(texts(output), vec!["<:bash: ls:>"]);
@@ -606,19 +632,16 @@ mod tests {
     fn body_block_folds_to_kind_tag_when_flipped() {
         let rec = record(vec![user_part(1, "question")]);
         let mut expanded = ExpandedBlocks::default();
-        expanded.toggle(ContentIoFocus::Input, 0);
-        assert_eq!(
-            texts(render_half(&rec, true, true, &expanded)),
-            vec!["<:user:>"]
-        );
+        expanded.toggle(0);
+        assert_eq!(texts(render(&rec, true, true, &expanded)), vec!["<:user:>"]);
     }
 
     #[test]
     fn raw_mode_shows_every_block_full() {
         let rec = record(vec![user_part(1, "question"), tool_part(2, "Bash", "ls")]);
         let expanded = ExpandedBlocks::default();
-        let input = render_half(&rec, true, false, &expanded);
-        let output = render_half(&rec, false, false, &expanded);
+        let input = render(&rec, true, false, &expanded);
+        let output = render(&rec, false, false, &expanded);
         assert_eq!(texts(input), vec!["question"]);
         assert_eq!(output[0].text, "$ ls");
     }
@@ -637,12 +660,12 @@ mod tests {
         ]);
         let mut expanded = ExpandedBlocks::default();
         // Folded: the run collapses to its tag.
-        let folded = render_half(&rec, false, true, &expanded);
+        let folded = render(&rec, false, true, &expanded);
         assert_eq!(texts(folded), vec!["<:bash, read:>"]);
         // Expanded: the tag stays as the group header, members below it as
         // folded lines, joined without blank lines (tight).
-        expanded.toggle(ContentIoFocus::Output, 0);
-        let shown = render_half(&rec, false, true, &expanded);
+        expanded.toggle(0);
+        let shown = render(&rec, false, true, &expanded);
         assert_eq!(
             texts(shown.clone()),
             vec!["<:bash, read:>", "<:bash: ls:>", "<:tool:Read call:>"]
@@ -659,13 +682,40 @@ mod tests {
             tool_part(2, "Read", "file"),
         ]);
         let mut expanded = ExpandedBlocks::default();
-        expanded.toggle(ContentIoFocus::Output, 0); // run open
-        expanded.toggle(ContentIoFocus::Output, 1); // first member open
-        let shown = render_half(&rec, false, true, &expanded);
+        expanded.toggle(0); // run open
+        expanded.toggle(1); // first member open
+        let shown = render(&rec, false, true, &expanded);
         assert_eq!(shown.len(), 3);
         assert_eq!(shown[0].text, "<:bash, read:>");
         assert_eq!(shown[1].text, "$ ls");
         assert_eq!(shown[2].text, "<:tool:Read call:>");
+    }
+
+    #[test]
+    fn block_count_covers_run_members_so_folded_marks_fit_the_mask() {
+        // Input user block + an output run of two tool members: the id space
+        // is 4 wide, not 2 — a mask sized by top-level blocks alone would
+        // drop a mark on a member the moment the run folds.
+        let rec = record(vec![
+            user_part(1, "question"),
+            tool_part(2, "Bash", "ls"),
+            tool_part(3, "Read", "file"),
+        ]);
+        assert_eq!(dialogue_block_count(&rec), 4);
+        let (input, output) = dialogue_blocks(&rec);
+        assert_eq!(input.len(), 1);
+        assert_eq!(output[0].children.len(), 2);
+        assert_eq!(output[0].children[1].id, 3);
+    }
+
+    /// Render one half through the dialogue-global block ids.
+    fn render(
+        rec: &WorkRecord,
+        input: bool,
+        reading: bool,
+        expanded: &ExpandedBlocks,
+    ) -> Vec<BlockText> {
+        render_half(rec, &half_blocks(rec, input), reading, expanded)
     }
 
     /// Segment texts for compact assertions.

--- a/src/tui/content/io.rs
+++ b/src/tui/content/io.rs
@@ -163,40 +163,35 @@ impl ContentScrolls {
 }
 
 /// Which blocks show their full body instead of their `<:…:>` tag, per
-/// content half. Structure blocks (tool/skill/thinking, including runs)
-/// default to collapsed, body blocks default to expanded; a block in the
-/// set flips the kind default (structure expanded, body collapsed). Raw
-/// mode always shows full blocks and ignores this state. A block id is the
-/// block's stable DFS id within its half — stable because ids come from the
-/// block tree, not the rendered segment count.
+/// dialogue. Structure blocks (tool/skill/thinking, including runs) default
+/// to collapsed, body blocks default to expanded; a block in the set flips
+/// the kind default (structure expanded, body collapsed). Raw mode always
+/// shows full blocks and ignores this state. A block id is the block's
+/// stable DFS id within the dialogue — stable because ids come from the
+/// block tree, not the rendered segment count, and unique across both IO
+/// halves so the fold state spans the input/output boundary.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub(crate) struct ExpandedBlocks {
-    pub(crate) input: HashSet<usize>,
-    pub(crate) output: HashSet<usize>,
-}
+pub(crate) struct ExpandedBlocks(HashSet<usize>);
 
 impl ExpandedBlocks {
-    /// Whether `block` in `focus` shows its full body.
-    pub(crate) fn expanded(&self, focus: ContentIoFocus, block: usize, structure: bool) -> bool {
-        let set = match focus {
-            ContentIoFocus::Input => &self.input,
-            ContentIoFocus::Output => &self.output,
-        };
+    /// Whether `block` shows its full body.
+    pub(crate) fn expanded(&self, block: usize, structure: bool) -> bool {
         if structure {
-            set.contains(&block)
+            self.0.contains(&block)
         } else {
-            !set.contains(&block)
+            !self.0.contains(&block)
         }
     }
 
-    pub(crate) fn toggle(&mut self, focus: ContentIoFocus, block: usize) {
-        let set = match focus {
-            ContentIoFocus::Input => &mut self.input,
-            ContentIoFocus::Output => &mut self.output,
-        };
-        if !set.insert(block) {
-            set.remove(&block);
+    pub(crate) fn toggle(&mut self, block: usize) {
+        if !self.0.insert(block) {
+            self.0.remove(&block);
         }
+    }
+
+    /// Drop every flip (the shown dialogue changed).
+    pub(crate) fn clear(&mut self) {
+        self.0.clear();
     }
 }
 

--- a/src/tui/content/text.rs
+++ b/src/tui/content/text.rs
@@ -2,7 +2,7 @@
 
 use sivtr_core::record::{WorkAt, WorkRecord};
 
-use crate::tui::content::block::render_half;
+use crate::tui::content::block::{dialogue_blocks, render_half};
 use crate::tui::content::io::{ContentIoTexts, ExpandedBlocks};
 use crate::tui::content::view::ContentViewMode;
 use crate::tui::workspace::model::WorkspaceDialogue;
@@ -10,15 +10,17 @@ use crate::tui::workspace::model::WorkspaceDialogue;
 /// Read mode folds every block to its `<:…:>` tag (structure blocks by
 /// default, body blocks only when flipped); blocks listed in `expanded`
 /// show their full body instead. Raw mode always shows full blocks (the
-/// expand state only affects reading).
+/// expand state only affects reading). Block ids are dialogue-global, so
+/// the fold state spans the input/output boundary.
 pub(crate) fn content_io_from_record(
     record: &WorkRecord,
     reading: bool,
     expanded: &ExpandedBlocks,
 ) -> ContentIoTexts {
+    let (input_blocks, output_blocks) = dialogue_blocks(record);
     ContentIoTexts::new(
-        render_half(record, true, reading, expanded),
-        render_half(record, false, reading, expanded),
+        render_half(record, &input_blocks, reading, expanded),
+        render_half(record, &output_blocks, reading, expanded),
     )
 }
 
@@ -79,7 +81,7 @@ pub(crate) fn is_structure_marker(line: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::content_io_from_record;
-    use crate::tui::content::io::{ContentIoFocus, ExpandedBlocks};
+    use crate::tui::content::io::ExpandedBlocks;
     use sivtr_core::ai::AgentProvider;
     use sivtr_core::record::{WorkPart, WorkPartData, WorkRecord, WorkRef};
 
@@ -144,7 +146,7 @@ mod tests {
         assert!(!output.contains("file"));
 
         let mut expanded = ExpandedBlocks::default();
-        expanded.toggle(ContentIoFocus::Output, 0);
+        expanded.toggle(0);
         let io = content_io_from_record(&rec, true, &expanded);
         let output = &io.output;
         // The run opens to its member tags; bodies stay folded.
@@ -154,7 +156,7 @@ mod tests {
         assert!(!output.contains("file"));
 
         // Opening a member shows its body.
-        expanded.toggle(ContentIoFocus::Output, 1);
+        expanded.toggle(1);
         let io = content_io_from_record(&rec, true, &expanded);
         assert!(io.output.contains("$ ls"));
     }
@@ -163,7 +165,7 @@ mod tests {
     fn raw_mode_ignores_expand_state() {
         let rec = record(vec![tool_part(1, "Bash", "ls")]);
         let mut expanded = ExpandedBlocks::default();
-        expanded.toggle(ContentIoFocus::Output, 0);
+        expanded.toggle(0);
         let io = content_io_from_record(&rec, false, &expanded);
         assert_eq!(io.output, "$ ls");
     }
@@ -187,7 +189,7 @@ mod tests {
         // Expanding the run reveals member tags on adjacent lines (no blank
         // line between); the result payload stays folded.
         let mut expanded = ExpandedBlocks::default();
-        expanded.toggle(ContentIoFocus::Output, 0);
+        expanded.toggle(0);
         let io = content_io_from_record(&rec, true, &expanded);
         let output = &io.output;
         // The call+result pair is one member; its collapsed tag is the call
@@ -199,7 +201,7 @@ mod tests {
         assert!(!output.contains("file"));
 
         // Opening the result member shows its payload.
-        expanded.toggle(ContentIoFocus::Output, 1);
+        expanded.toggle(1);
         let io = content_io_from_record(&rec, true, &expanded);
         assert!(io.output.contains("ok"));
     }

--- a/src/tui/content/view.rs
+++ b/src/tui/content/view.rs
@@ -6,7 +6,7 @@ use regex::Regex;
 use std::rc::Rc;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-use crate::tui::content::block::{marked_mask_len, BlockText};
+use crate::tui::content::block::BlockText;
 use crate::tui::content::markdown::{render_markdown_lines, MarkdownLineKind};
 use crate::tui::pane::{panel_block, render_panel_scrollbar, Panel, PanelScroll};
 use sivtr_core::record::WorkPartKind;
@@ -93,8 +93,10 @@ pub(crate) struct ContentLink {
 pub(crate) struct ContentLayout {
     pub(crate) lines: Vec<ContentLine>,
     pub(crate) ownership: Vec<Option<usize>>,
-    /// Dot color per block id (dense DFS ids; hidden ids keep a placeholder).
-    pub(crate) kinds: Vec<WorkPartKind>,
+    /// Dot color per line, parallel to [`Self::ownership`]: block ids are
+    /// dialogue-global, so an id-keyed table would have to be padded across
+    /// the other half's range and would report a foreign id as a real kind.
+    pub(crate) kinds: Vec<Option<WorkPartKind>>,
 }
 
 /// Lay one half out once from its blocks. Empty halves use `text` (`<empty>`).
@@ -112,19 +114,20 @@ pub(crate) fn layout_content(
         return ContentLayout {
             lines,
             ownership: vec![None; n],
-            kinds: Vec::new(),
+            kinds: vec![None; n],
         };
     }
-    let mut kinds = vec![WorkPartKind::User; marked_mask_len(blocks.iter().map(|b| b.id))];
     let mut lines = Vec::new();
     let mut ownership = Vec::new();
+    let mut kinds = Vec::new();
     for (idx, segment) in blocks.iter().enumerate() {
-        kinds[segment.id] = segment.kind;
         let block_lines = all_content_lines(&segment.text, width, mode);
         ownership.extend(std::iter::repeat_n(Some(segment.id), block_lines.len()));
+        kinds.extend(std::iter::repeat_n(Some(segment.kind), block_lines.len()));
         lines.extend(block_lines);
         if idx + 1 < blocks.len() && !segment.tight {
             ownership.push(None);
+            kinds.push(None);
             lines.push(raw_content_line(""));
         }
     }
@@ -1164,7 +1167,8 @@ fn block_dot_lines(
                     let glyph = crate::tui::pane::selection_dot(marked);
                     Line::from(Span::styled(
                         glyph,
-                        Style::default().fg(block_dot_color(layout.kinds.get(block))),
+                        Style::default()
+                            .fg(block_dot_color(layout.kinds.get(idx).copied().flatten())),
                     ))
                 }
                 _ => Line::from("  "),
@@ -1176,7 +1180,7 @@ fn block_dot_lines(
 
 /// Dot color by block kind: the same palette the pane uses for roles, so a
 /// conversation's dots read like chat bubbles (user, tool, thinking, ...).
-fn block_dot_color(kind: Option<&WorkPartKind>) -> Color {
+fn block_dot_color(kind: Option<WorkPartKind>) -> Color {
     use WorkPartKind::{
         Assistant, Command, Error, Output, Prompt, Skill, Thinking, ToolCall, ToolResult, User,
     };

--- a/src/tui/workspace/model.rs
+++ b/src/tui/workspace/model.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 use std::time::SystemTime;
 
 use crate::commands::select::CommandSelection;
-use crate::tui::content::block::{fold_label_for_part, BlockText};
+use crate::tui::content::block::{dialogue_block_id, fold_label_for_part, BlockText};
 use crate::tui::content::io::{
     ContentIoFocus, ContentIoFrame, ContentIoTexts, ContentScrolls, ExpandedBlocks,
 };
@@ -259,12 +259,13 @@ impl WorkspaceDialogue {
                 return ContentIoTexts::new(Vec::new(), Vec::new());
             };
             let input = part.kind().is_input();
+            let block_id = dialogue_block_id(record, part.seq).expect("target part has a block");
             let shown = match mode {
                 ContentViewMode::Raw => true,
-                ContentViewMode::Reading => expanded.expanded(0, part.kind().is_structure()),
+                ContentViewMode::Reading => expanded.expanded(block_id, part.kind().is_structure()),
             };
             let segment = BlockText {
-                id: 0,
+                id: block_id,
                 text: if shown {
                     crate::tui::content::tool::part_body_text(part)
                 } else {

--- a/src/tui/workspace/model.rs
+++ b/src/tui/workspace/model.rs
@@ -261,14 +261,7 @@ impl WorkspaceDialogue {
             let input = part.kind().is_input();
             let shown = match mode {
                 ContentViewMode::Raw => true,
-                ContentViewMode::Reading => {
-                    let focus = if input {
-                        ContentIoFocus::Input
-                    } else {
-                        ContentIoFocus::Output
-                    };
-                    expanded.expanded(focus, 0, part.kind().is_structure())
-                }
+                ContentViewMode::Reading => expanded.expanded(0, part.kind().is_structure()),
             };
             let segment = BlockText {
                 id: 0,
@@ -397,16 +390,16 @@ pub(crate) struct WorkspaceView<'a> {
     pub(crate) line_filter_error: Option<&'a str>,
     pub(crate) fullscreen: Option<WorkspaceFocus>,
     pub(crate) content_selection: Option<ContentSelection>,
-    /// Block under the keyboard/mouse cursor per half; highlighted like a
-    /// list row when its half is focused.
+    /// Block under the keyboard/mouse cursor plus its half (derived from
+    /// the dialogue-global id); highlighted like a list row in that half.
     pub(crate) content_block_cursor: Option<(ContentIoFocus, usize)>,
-    /// Pending `v` block-range span `(half, anchor block, cursor block)`;
+    /// Pending `v` block-range span `(anchor block, cursor block)`;
     /// its lines render with the same amber range style as the list panes.
-    pub(crate) content_range: Option<(ContentIoFocus, usize, usize)>,
-    /// Marked block masks per half (`mask[block_id]` = marked), owned by the
-    /// content pane's native selection; consumed by the dot gutter and copy.
-    pub(crate) content_marked_input: &'a [bool],
-    pub(crate) content_marked_output: &'a [bool],
+    pub(crate) content_range: Option<(usize, usize)>,
+    /// Marked block mask (`mask[block_id]` = marked, dialogue-global ids),
+    /// owned by the content pane's native selection; consumed by the dot
+    /// gutter and copy.
+    pub(crate) content_marked: &'a [bool],
     /// Multi-select paging `(current_page, page_count)` when several
     /// dialogues are selected; the content pane shows one at a time.
     pub(crate) content_page: Option<(usize, usize)>,

--- a/src/tui/workspace/render.rs
+++ b/src/tui/workspace/render.rs
@@ -125,17 +125,13 @@ pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
             ContentIoFocus::Input => "Input",
             ContentIoFocus::Output => "Output",
         };
-        // The block cursor highlights the focused half like the cursor row in
-        // the session/dialogue lists; it never depends on the panel being
+        // The block cursor highlights its half like the cursor row in the
+        // session/dialogue lists; it never depends on the panel being
         // focused, so scrolling content always shows where the cursor is.
         let cursor_block = view
             .content_block_cursor
             .filter(|(focus, _)| *focus == half)
             .map(|(_, block)| block);
-        let range_blocks = view
-            .content_range
-            .filter(|(focus, _, _)| *focus == half)
-            .map(|(_, anchor, cursor)| (anchor, cursor));
         render_content_panel(
             frame,
             area,
@@ -153,11 +149,8 @@ pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
                 .filter(|_| view.content_io_focus == half),
             content_search,
             cursor_block,
-            range_blocks,
-            match half {
-                ContentIoFocus::Input => view.content_marked_input,
-                ContentIoFocus::Output => view.content_marked_output,
-            },
+            view.content_range,
+            view.content_marked,
         );
     }
 

--- a/src/tui/workspace/tests.rs
+++ b/src/tui/workspace/tests.rs
@@ -146,6 +146,45 @@ fn content_preview_text_uses_structured_targeted_part_text_in_reading_mode() {
 }
 
 #[test]
+fn targeted_part_uses_its_dialogue_global_block_id() {
+    let record = chat_record(vec![
+        part(
+            1,
+            sivtr_core::record::WorkPartData::User {
+                content: "question".to_string(),
+            },
+        ),
+        part(
+            2,
+            sivtr_core::record::WorkPartData::Assistant {
+                content: "answer".to_string(),
+            },
+        ),
+        part(
+            3,
+            sivtr_core::record::WorkPartData::ToolCall {
+                call_id: None,
+                tool: Some("tool".to_string()),
+                input: tool_test_value("target body".to_string()),
+            },
+        ),
+    ]);
+    let dialogue = codex_dialogue(record);
+    let mut expanded = ExpandedBlocks::default();
+    let folded =
+        dialogue.content_io_texts(ContentViewMode::Reading, Some(WorkAt::Part(3)), &expanded);
+    assert_eq!(
+        crate::tui::content::block::dialogue_block_id(dialogue.record.as_ref().unwrap(), 3),
+        Some(2)
+    );
+    assert_eq!(folded.output.trim(), "<:tool:tool call:>");
+    expanded.toggle(2);
+    let open =
+        dialogue.content_io_texts(ContentViewMode::Reading, Some(WorkAt::Part(3)), &expanded);
+    assert!(open.output.contains("target body"));
+}
+
+#[test]
 fn reading_mode_folds_structure_and_raw_expands() {
     let record = chat_record(vec![
         part(


### PR DESCRIPTION
## Purpose
Unify content-block coordinates so navigation, marking, folding, and copying address the same dialogue content.

## Changes
- Use one block coordinate model across input and output sections.
- Keep cursor movement, range selection, and rendering aligned with dialogue-global block IDs.
- Cover folded and nested blocks with regression tests.

## Validation
Validated on the stack tip with `cargo build --target-dir target/build-check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p sivtr --lib`.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Content blocks now use a unified view across input and output sections.
  * Cursor movement, range selection, marking, folding, and copying work continuously across both sections.
  * Nested content blocks receive consistent selection and expansion behavior.

* **Bug Fixes**
  * Improved block targeting and folding in reading mode.
  * Preserved accurate highlighting and gutter indicators for displayed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->