### PR TITLE
refactor(browse): unify selection semantics

### DIFF
--- a/src/commands/browse/help.rs
+++ b/src/commands/browse/help.rs
@@ -297,22 +297,26 @@ pub(super) fn apply_workspace_help_action(
             }
             WorkspaceFocus::Content => {
                 // Block range: `v` anchors the cursor block, moves extend,
-                // and a second `v` toggles marks across the anchor..cursor
-                // span of the continuous input+output block sequence.
+                // and a second `v` marks the anchor..cursor span of the
+                // continuous input+output block sequence. Only visible blocks
+                // are in the span — a folded run is one unit, so marking its
+                // hidden members too would copy their bodies twice.
                 if let Some(cursor_block) = content_cursor.get() {
                     match *content_range_anchor {
                         Some(anchor_block) => {
                             let shown =
                                 shown_dialogue_idx(selected_dialogues, *content_page, dialogue_idx);
-                            let (lo, hi) = (
-                                anchor_block.min(cursor_block),
-                                anchor_block.max(cursor_block),
+                            let span =
+                                anchor_block.min(cursor_block)..=anchor_block.max(cursor_block);
+                            content_pane.toggle_mark_range(
+                                shown,
+                                content_blocks
+                                    .0
+                                    .iter()
+                                    .chain(content_blocks.1)
+                                    .map(|block| block.id)
+                                    .filter(|id| span.contains(id)),
                             );
-                            for block in content_blocks.0.iter().chain(content_blocks.1) {
-                                if (lo..=hi).contains(&block.id) {
-                                    content_pane.toggle_mark(shown, block.id);
-                                }
-                            }
                             *content_range_anchor = None;
                         }
                         _ => *content_range_anchor = Some(cursor_block),

--- a/src/commands/browse/panes.rs
+++ b/src/commands/browse/panes.rs
@@ -484,6 +484,19 @@ impl ContentPane {
         self.marked.entry(dialogue_idx).or_default().toggle(block);
     }
 
+    /// Mark a block range: the same one-state rule the list panes use for
+    /// `v`, over the visible block ids the range spans.
+    pub fn toggle_mark_range(
+        &mut self,
+        dialogue_idx: usize,
+        blocks: impl Iterator<Item = usize> + Clone,
+    ) {
+        self.marked
+            .entry(dialogue_idx)
+            .or_default()
+            .toggle_ids(blocks);
+    }
+
     /// Drop every dialogue's marks (selection set changed).
     pub fn clear_marks(&mut self) {
         self.marked.clear();

--- a/src/commands/browse/panes.rs
+++ b/src/commands/browse/panes.rs
@@ -497,7 +497,7 @@ impl ContentPane {
             .toggle_ids(blocks);
     }
 
-    /// Drop every dialogue's marks (selection set changed).
+    /// Drop every dialogue's marks (the set of markable dialogues changed).
     pub fn clear_marks(&mut self) {
         self.marked.clear();
     }

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -135,9 +135,10 @@ pub(crate) fn run(
     // Multi-select paging: which selected dialogue the content pane shows
     // (J/K flip the page); single selection always shows the focused row.
     let mut content_page = 0usize;
-    // Last selection mask; marks drop when the selection set itself changes
-    // (they belong to their dialogue and survive page flips).
-    let mut previous_selection_key = None;
+    // Which dialogues may currently own a mark: the selection mask, plus the
+    // shown row when nothing is selected. Marks drop when that set changes;
+    // they belong to their dialogue and survive page flips.
+    let mut markable_key: Option<(Vec<bool>, Option<usize>)> = None;
 
     loop {
         // ── Unified pane poll/ensure ───────────────────────────────────────
@@ -382,11 +383,18 @@ pub(crate) fn run(
                 content_range_anchor = None;
                 expanded_key = Some(expand_key);
             }
-            // Marks belong to their dialogue (they survive page flips for
-            // cross-page copy); drop them when the selection set changes.
-            if previous_selection_key.as_ref() != Some(&selected_dialogues) {
+            // Marks are keyed by dialogue index, so they only stay meaningful
+            // while the set of dialogues that can own one is unchanged: the
+            // selection mask, or — with nothing selected — the focused row
+            // alone. Page flips inside a selection keep the marks so a later
+            // copy can join pages.
+            let marks_key = (
+                selected_dialogues.clone(),
+                (selected == 0).then_some(shown_idx),
+            );
+            if markable_key.as_ref() != Some(&marks_key) {
                 content_pane.clear_marks();
-                previous_selection_key = Some(selected_dialogues.clone());
+                markable_key = Some(marks_key);
             }
             // Rebuild the content frame (texts + cached layouts) only when
             // the shown dialogue, mode, focus, target, expansion, or pane

--- a/src/commands/browse/selection.rs
+++ b/src/commands/browse/selection.rs
@@ -8,7 +8,7 @@ use ratatui::widgets::ListState;
 use crate::tui::workspace::{selected_index, WorkspaceFocus, WorkspaceSession, WorkspaceSource};
 
 use super::load::SessionColumn;
-use crate::pane::Viewport;
+use crate::pane::{toggle_row_ids, Viewport};
 
 /// Active rows: multi-select if any, otherwise the focused row.
 pub(super) fn active_mask(selected: &[bool], focus_idx: usize, len: usize) -> Vec<bool> {
@@ -131,25 +131,23 @@ pub(super) fn has_selected_sessions(selected_sessions: &[bool]) -> bool {
 }
 
 /// Range-select rows: first `v` anchors at `idx`, the next completes the
-/// span between anchor and `idx` (inverting the span if any row is unselected).
+/// span between anchor and `idx`. The span rule itself is
+/// [`toggle_row_ids`], shared with the content pane's block range.
 /// Shared by every list pane (Source/Sessions/Dialogues).
 pub(super) fn apply_range_selection(
     range_anchor: &mut Option<usize>,
     selected: &mut [bool],
     idx: usize,
 ) {
-    if let Some(anchor) = range_anchor.take() {
-        // Reject out-of-bounds endpoints before iterating: a stray large
-        // index must not walk a near-empty mask for the whole span.
-        let Some(span) = selected.get_mut(anchor.min(idx)..=anchor.max(idx)) else {
-            return;
-        };
-        let select = span.iter().any(|flag| !*flag);
-        for flag in span {
-            *flag = select;
-        }
-    } else {
+    let Some(anchor) = range_anchor.take() else {
         *range_anchor = Some(idx);
+        return;
+    };
+    // Reject out-of-bounds endpoints before iterating: a stray large
+    // index must not walk a near-empty mask for the whole span.
+    let (lo, hi) = (anchor.min(idx), anchor.max(idx));
+    if hi < selected.len() {
+        toggle_row_ids(selected, lo..=hi);
     }
 }
 

--- a/src/pane/mod.rs
+++ b/src/pane/mod.rs
@@ -12,6 +12,6 @@ mod model;
 mod sliding;
 mod store;
 
-pub use model::{Pane, PaneInput, Selection};
+pub use model::{toggle_row_ids, Pane, PaneInput, Selection};
 pub use sliding::{MetaNeed, SlidingPane};
 pub use store::{keep_keys, StorePhase, Viewport, WindowRow, FETCH_CEILING, FETCH_FLOOR};

--- a/src/pane/model.rs
+++ b/src/pane/model.rs
@@ -19,6 +19,22 @@ pub struct PaneInput<'a> {
     pub force: bool,
 }
 
+/// Set the listed rows to one state: select them all when any of them is
+/// unselected, clear them all otherwise. This is the range-selection rule
+/// every pane uses for `v` and range clicks, and the only place it lives.
+/// The ids need not be contiguous — the content pane's visible blocks skip
+/// the ids a fold is hiding — and out-of-range ids are ignored.
+pub fn toggle_row_ids(mask: &mut [bool], ids: impl Iterator<Item = usize> + Clone) {
+    let select = ids
+        .clone()
+        .any(|id| mask.get(id).is_some_and(|flag| !*flag));
+    for id in ids {
+        if let Some(flag) = mask.get_mut(id) {
+            *flag = select;
+        }
+    }
+}
+
 /// Native multi-select: a boolean mask plus a range anchor, with one
 /// toggle / range-toggle / clear API shared by every pane (source, session,
 /// dialogue, and content blocks). Panes own a `Selection` when their rows
@@ -75,19 +91,11 @@ impl Selection {
         }
     }
 
-    /// Toggle every row between the anchor and `idx` to the same state:
-    /// select the range when any of its rows is unselected, clear it
-    /// otherwise — the range-click semantics the list panes use.
-    pub fn toggle_range(&mut self, idx: usize) {
-        let anchor = self.anchor.unwrap_or(idx);
-        let (start, end) = (anchor.min(idx), anchor.max(idx));
-        if let Some(range) = self.mask.get_mut(start..=end) {
-            let select = range.iter().any(|flag| !*flag);
-            for flag in range {
-                *flag = select;
-            }
-        }
-        self.anchor = Some(idx);
+    /// Range-select the given rows through [`toggle_row_ids`], leaving the
+    /// anchor on the last of them.
+    pub fn toggle_ids(&mut self, ids: impl Iterator<Item = usize> + Clone) {
+        self.anchor = ids.clone().last();
+        toggle_row_ids(&mut self.mask, ids);
     }
 }
 
@@ -152,14 +160,18 @@ mod tests {
     }
 
     #[test]
-    fn selection_range_toggles_between_anchor_and_index() {
+    fn selection_range_toggles_every_listed_row_to_one_state() {
         let mut selection = Selection::new(5);
         selection.toggle(1);
-        selection.toggle_range(3);
+        selection.toggle_ids(1..=3);
         assert_eq!(selection.mask(), &[false, true, true, true, false]);
         // Second range over the same rows clears them.
-        selection.toggle_range(1);
+        selection.toggle_ids(1..=3);
         assert_eq!(selection.mask(), &[false, false, false, false, false]);
+        // Gaps are allowed (folded blocks are skipped) and out-of-range ids
+        // are ignored.
+        selection.toggle_ids([0, 3, 9].into_iter());
+        assert_eq!(selection.mask(), &[true, false, false, true, false]);
     }
 
     #[test]


### PR DESCRIPTION
## Purpose
Make content marking and range selection follow one consistent selection model.

## Changes
- Centralize range and mark semantics for visible content rows.
- Handle non-contiguous and folded rows without duplicate selection paths.
- Clear or ignore stale and out-of-range marks deterministically.

## Validation
Validated on the stack tip with `cargo build --target-dir target/build-check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p sivtr --lib`.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>