### PR TITLE
refactor(copy): resolve copied dialogues once

### DIFF
--- a/src/commands/browse/content.rs
+++ b/src/commands/browse/content.rs
@@ -8,7 +8,7 @@ use crate::tui::content::block::{dialogue_blocks, Block};
 use crate::tui::content::view::{line_count, ContentViewMode};
 use crate::tui::search::{WorkspaceSearchMatch, WorkspaceSearchOutput};
 use crate::tui::workspace::{
-    active_rows, WorkspaceDialogue, WorkspacePickedContent, WorkspaceSession, WorkspaceSource,
+    WorkspaceDialogue, WorkspacePickedContent, WorkspaceSession, WorkspaceSource,
 };
 use sivtr_core::record::{WorkAt, WorkRecord, WorkRef};
 
@@ -25,7 +25,10 @@ pub(super) enum WorkspaceCopyShortcut {
 }
 
 /// Source a copy is attributed to: the first picked dialogue's.
-fn picked_source(dialogues: &[WorkspaceDialogue], picked: &[usize]) -> Option<WorkspaceSource> {
+pub(super) fn picked_source(
+    dialogues: &[WorkspaceDialogue],
+    picked: &[usize],
+) -> Option<WorkspaceSource> {
     dialogues
         .get(*picked.first()?)
         .map(|dialogue| dialogue.source.clone())
@@ -33,23 +36,20 @@ fn picked_source(dialogues: &[WorkspaceDialogue], picked: &[usize]) -> Option<Wo
 
 pub(super) fn workspace_picked_content_for_copy_with_line_filter(
     dialogues: &[WorkspaceDialogue],
-    selected_dialogues: &[bool],
-    dialogue_idx: usize,
+    picked: &[usize],
     shortcut: WorkspaceCopyShortcut,
     line_filter: Option<&str>,
     target: Option<WorkAt>,
     content_mode: ContentViewMode,
 ) -> Result<WorkspacePickedContent> {
-    let picked_indices = active_rows(selected_dialogues, dialogue_idx, dialogues.len());
-    let source =
-        picked_source(dialogues, &picked_indices).context("copy needs at least one dialogue")?;
-    let display_target = (picked_indices.len() == 1
+    let source = picked_source(dialogues, picked).context("copy needs at least one dialogue")?;
+    let display_target = (picked.len() == 1
         && matches!(shortcut, WorkspaceCopyShortcut::Displayed))
     .then_some(target)
     .flatten();
-    let units = picked_indices
-        .into_iter()
-        .filter_map(|idx| dialogues.get(idx))
+    let units = picked
+        .iter()
+        .filter_map(|&idx| dialogues.get(idx))
         .map(|dialogue| match shortcut {
             WorkspaceCopyShortcut::Displayed => dialogue.display_unit(content_mode, display_target),
             WorkspaceCopyShortcut::Input => dialogue.copy.input.clone(),
@@ -69,14 +69,12 @@ pub(super) fn workspace_picked_content_for_copy_with_line_filter(
 #[cfg(test)]
 pub(super) fn workspace_picked_content_for_copy(
     dialogues: &[WorkspaceDialogue],
-    selected_dialogues: &[bool],
-    dialogue_idx: usize,
+    picked: &[usize],
     shortcut: WorkspaceCopyShortcut,
 ) -> WorkspacePickedContent {
     workspace_picked_content_for_copy_with_line_filter(
         dialogues,
-        selected_dialogues,
-        dialogue_idx,
+        picked,
         shortcut,
         None,
         None,
@@ -87,15 +85,13 @@ pub(super) fn workspace_picked_content_for_copy(
 
 pub(super) fn workspace_picked_content_with_line_filter(
     dialogues: &[WorkspaceDialogue],
-    selected_dialogues: &[bool],
-    dialogue_idx: usize,
+    picked: &[usize],
     line_filter: Option<&str>,
     target: Option<WorkAt>,
 ) -> Result<WorkspacePickedContent> {
     workspace_picked_content_for_copy_with_line_filter(
         dialogues,
-        selected_dialogues,
-        dialogue_idx,
+        picked,
         WorkspaceCopyShortcut::Displayed,
         line_filter,
         target,
@@ -105,17 +101,10 @@ pub(super) fn workspace_picked_content_with_line_filter(
 
 pub(super) fn workspace_picked_content(
     dialogues: &[WorkspaceDialogue],
-    selected_dialogues: &[bool],
-    dialogue_idx: usize,
+    picked: &[usize],
     target: Option<WorkAt>,
 ) -> Result<WorkspacePickedContent> {
-    workspace_picked_content_with_line_filter(
-        dialogues,
-        selected_dialogues,
-        dialogue_idx,
-        None,
-        target,
-    )
+    workspace_picked_content_with_line_filter(dialogues, picked, None, target)
 }
 
 /// Picked content from the content pane's marked blocks: every selected
@@ -126,13 +115,11 @@ pub(super) fn workspace_picked_content(
 /// nothing is marked.
 pub(super) fn workspace_picked_content_for_marked_blocks(
     dialogues: &[WorkspaceDialogue],
-    selected_dialogues: &[bool],
-    dialogue_idx: usize,
+    picked: &[usize],
     content_pane: &ContentPane,
 ) -> Option<WorkspacePickedContent> {
-    let picked_indices = active_rows(selected_dialogues, dialogue_idx, dialogues.len());
     let mut texts = Vec::new();
-    for dialogue_idx in picked_indices {
+    for &dialogue_idx in picked {
         let Some(record) = dialogues
             .get(dialogue_idx)
             .and_then(|dialogue| dialogue.record.as_ref())
@@ -144,7 +131,7 @@ pub(super) fn workspace_picked_content_for_marked_blocks(
             collect_marked_blocks(block, dialogue_idx, content_pane, record, &mut texts);
         }
     }
-    picked_for_texts(dialogues, selected_dialogues, dialogue_idx, texts)
+    picked_for_texts(dialogues, picked, texts)
 }
 
 /// Push every marked block's body. A run's body already spans its members,
@@ -174,10 +161,10 @@ fn collect_marked_blocks(
 }
 
 /// Copy the block under the content cursor: y without marked blocks joins
-/// just that block's call + result bodies, not the whole dialogue.
+/// just that block's call + result bodies, not the whole dialogue. The copy
+/// is attributed to the dialogue the block belongs to.
 pub(super) fn workspace_picked_content_for_cursor_block(
     dialogues: &[WorkspaceDialogue],
-    selected_dialogues: &[bool],
     dialogue_idx: usize,
     block_id: usize,
 ) -> Option<WorkspacePickedContent> {
@@ -188,12 +175,7 @@ pub(super) fn workspace_picked_content_for_cursor_block(
         .iter()
         .chain(&output_blocks)
         .find_map(|block| find_block(block, block_id))?;
-    picked_for_texts(
-        dialogues,
-        selected_dialogues,
-        dialogue_idx,
-        vec![block.body(record)],
-    )
+    picked_for_texts(dialogues, &[dialogue_idx], vec![block.body(record)])
 }
 
 /// Depth-first block lookup: run members live nested in `children`, and the
@@ -211,16 +193,14 @@ fn find_block(block: &Block, id: usize) -> Option<&Block> {
 /// One copy unit from already-collected block bodies.
 fn picked_for_texts(
     dialogues: &[WorkspaceDialogue],
-    selected_dialogues: &[bool],
-    dialogue_idx: usize,
+    picked: &[usize],
     texts: Vec<String>,
 ) -> Option<WorkspacePickedContent> {
     if texts.is_empty() {
         return None;
     }
     let plain = texts.join("\n\n");
-    let picked = active_rows(selected_dialogues, dialogue_idx, dialogues.len());
-    let source = picked_source(dialogues, &picked)?;
+    let source = picked_source(dialogues, picked)?;
     Some(WorkspacePickedContent {
         source,
         units: vec![crate::tui::workspace::TextPair {
@@ -430,7 +410,6 @@ mod tests {
         let a = dialogue(record("A", "Bash", "ls", 0));
         let b = dialogue(record("B", "Bash", "git status", 1));
         let dialogues = [a, b];
-        let selected = [true, true];
         let mut pane = ContentPane::default();
         // Multi-select paging ensures each dialogue in turn, keeping its
         // marks; both end up owned by their dialogue.
@@ -449,7 +428,7 @@ mod tests {
             pane.toggle_mark(idx, 1);
         }
 
-        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &selected, 0, &pane)
+        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &[0, 1], &pane)
             .expect("marked blocks across two dialogues");
         let joined: Vec<String> = picked.units.iter().map(|unit| unit.plain.clone()).collect();
         let all = joined.join("\n");
@@ -493,7 +472,7 @@ mod tests {
         pane.toggle_mark(0, 1);
         pane.toggle_mark(0, 2);
 
-        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &[true], 0, &pane)
+        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &[0], &pane)
             .expect("marked run");
         let all = picked
             .units

--- a/src/commands/browse/content.rs
+++ b/src/commands/browse/content.rs
@@ -147,8 +147,11 @@ pub(super) fn workspace_picked_content_for_marked_blocks(
     picked_for_texts(dialogues, selected_dialogues, dialogue_idx, texts)
 }
 
-/// Push every marked block's body, descending into run members (a marked
-/// member of a folded run carries its own id, separate from the run's).
+/// Push every marked block's body. A run's body already spans its members,
+/// so a marked run closes the branch: marking the run and a member of it —
+/// which an expanded run lets a click or a `v` span do — must not copy that
+/// member twice. Members are only collected on their own when the run itself
+/// is unmarked.
 fn collect_marked_blocks(
     block: &Block,
     dialogue_idx: usize,
@@ -163,6 +166,7 @@ fn collect_marked_blocks(
         .unwrap_or(false)
     {
         texts.push(block.body(record));
+        return;
     }
     for child in &block.children {
         collect_marked_blocks(child, dialogue_idx, content_pane, record, texts);
@@ -457,5 +461,46 @@ mod tests {
             all.contains("$ git status"),
             "dialogue B marked block missing: {all}"
         );
+    }
+
+    #[test]
+    fn a_marked_run_copies_its_members_once() {
+        let mut base = record("A", "Bash", "ls", 0);
+        // A second consecutive tool call folds both into one run: block 1 is
+        // the run, blocks 2 and 3 its members.
+        base.parts.push(WorkPart {
+            seq: 3,
+            occurred_at: None,
+            data: WorkPartData::ToolCall {
+                call_id: Some("c2".to_string()),
+                tool: Some("Bash".to_string()),
+                input: serde_json::json!({ "command": "git status" }),
+            },
+        });
+        let dialogues = [dialogue(base)];
+        let mut pane = ContentPane::default();
+        pane.ensure(ContentCtx {
+            dialogues: &dialogues,
+            highlighted_idx: 0,
+            mode: ContentViewMode::Reading,
+            target: None,
+            area: ratatui::layout::Rect::new(0, 0, 60, 20),
+            io_focus: ContentIoFocus::Output,
+            expanded: &ExpandedBlocks::default(),
+        });
+        // An expanded run shows its header and its members, so a `v` span or
+        // two clicks can mark both; the run's body already spans the member.
+        pane.toggle_mark(0, 1);
+        pane.toggle_mark(0, 2);
+
+        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &[true], 0, &pane)
+            .expect("marked run");
+        let all = picked
+            .units
+            .iter()
+            .map(|unit| unit.plain.clone())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(all.matches("$ ls").count(), 1, "member copied twice: {all}");
     }
 }

--- a/src/commands/browse/help.rs
+++ b/src/commands/browse/help.rs
@@ -236,8 +236,7 @@ pub(super) fn apply_workspace_help_action(
             WorkspaceFocus::Dialogues | WorkspaceFocus::Content => {
                 return Ok(HelpDispatch::Picked(workspace_picked_content(
                     dialogues,
-                    rows.dialogues.mask(),
-                    rows.dialogues.cursor(),
+                    &rows.dialogues.active(),
                     content_at,
                 )?));
             }
@@ -247,8 +246,7 @@ pub(super) fn apply_workspace_help_action(
             return Ok(HelpDispatch::Picked(
                 workspace_picked_content_for_copy_with_line_filter(
                     dialogues,
-                    rows.dialogues.mask(),
-                    rows.dialogues.cursor(),
+                    &rows.dialogues.active(),
                     WorkspaceCopyShortcut::Input,
                     line_filter,
                     None,
@@ -260,8 +258,7 @@ pub(super) fn apply_workspace_help_action(
             return Ok(HelpDispatch::Picked(
                 workspace_picked_content_for_copy_with_line_filter(
                     dialogues,
-                    rows.dialogues.mask(),
-                    rows.dialogues.cursor(),
+                    &rows.dialogues.active(),
                     WorkspaceCopyShortcut::Output,
                     line_filter,
                     None,
@@ -276,12 +273,9 @@ pub(super) fn apply_workspace_help_action(
             // the shown index like the marked paths do, not the focused row.
             let shown = shown_dialogue_idx(&rows.dialogues, *content_page);
             let block_id = content_cursor.get().unwrap_or(0);
-            if let Some(picked) = workspace_picked_content_for_cursor_block(
-                dialogues,
-                rows.dialogues.mask(),
-                shown,
-                block_id,
-            ) {
+            if let Some(picked) =
+                workspace_picked_content_for_cursor_block(dialogues, shown, block_id)
+            {
                 return Ok(HelpDispatch::Picked(picked));
             }
         }
@@ -289,8 +283,7 @@ pub(super) fn apply_workspace_help_action(
             return Ok(HelpDispatch::Picked(
                 workspace_picked_content_for_copy_with_line_filter(
                     dialogues,
-                    rows.dialogues.mask(),
-                    rows.dialogues.cursor(),
+                    &rows.dialogues.active(),
                     WorkspaceCopyShortcut::Command,
                     line_filter,
                     None,

--- a/src/commands/browse/help.rs
+++ b/src/commands/browse/help.rs
@@ -145,8 +145,8 @@ pub(super) fn apply_workspace_help_action(
         WorkspaceHelpAction::RangeSelect => match *focus {
             WorkspaceFocus::Content => {
                 // The span covers block ids instead of list rows, and only
-                // visible blocks are in it — a folded run is one unit, so
-                // marking its hidden members too would copy them twice.
+                // visible blocks are in it: a folded run is one unit, and its
+                // header already carries every member's body.
                 if let Some(cursor_block) = content_cursor.get() {
                     if let Some(span) = rows.range(*focus, cursor_block) {
                         let shown = shown_dialogue_idx(&rows.dialogues, *content_page);

--- a/src/commands/browse/panes.rs
+++ b/src/commands/browse/panes.rs
@@ -460,10 +460,6 @@ impl ContentPane {
     }
 }
 
-// ── Compatibility helpers used by tests / selection ─────────────────────
-
-// (none — new panes implement `Pane` only)
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -571,8 +571,7 @@ pub(crate) fn run(
                         content_mode,
                         active.scroll,
                         &dialogues,
-                        rows.dialogues.mask(),
-                        dialogue_idx,
+                        shown_dialogue_idx(&rows.dialogues, content_page),
                     )? {
                         return Ok(picked);
                     }
@@ -769,8 +768,7 @@ pub(crate) fn run(
                     if action == WorkspaceHelpAction::CopyBlock && content_pane.marked_count() > 0 {
                         if let Some(picked) = workspace_picked_content_for_marked_blocks(
                             &dialogues,
-                            rows.dialogues.mask(),
-                            dialogue_idx,
+                            &rows.dialogues.active(),
                             &content_pane,
                         ) {
                             return Ok(picked);
@@ -1438,7 +1436,6 @@ mod tests {
             copy: WorkspaceCopyParts::default(),
         };
         let dialogues = [dialogue.clone()];
-        let selected = [true];
         let mut pane = ContentPane::default();
         pane.ensure(ContentCtx {
             dialogues: &dialogues,
@@ -1451,15 +1448,13 @@ mod tests {
         });
 
         // Nothing marked: the copy path yields None.
-        assert!(
-            workspace_picked_content_for_marked_blocks(&dialogues, &selected, 0, &pane).is_none()
-        );
+        assert!(workspace_picked_content_for_marked_blocks(&dialogues, &[0], &pane).is_none());
 
         // Mark the tool block (output half): copy joins the call + result
         // bodies. Ids are dialogue-global — the input user block is 0, so the
         // output pair is 1.
         pane.toggle_mark(0, 1);
-        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &selected, 0, &pane)
+        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &[0], &pane)
             .expect("marked copy");
         assert_eq!(picked.units.len(), 1);
         let text = &picked.units[0].plain;
@@ -1475,7 +1470,7 @@ mod tests {
 
         // Mark the user block (input half): both marked blocks are joined.
         pane.toggle_mark(0, 0);
-        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &selected, 0, &pane)
+        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &[0], &pane)
             .expect("marked copy");
         let text = &picked.units[0].plain;
         assert!(text.contains("user text"));
@@ -1527,7 +1522,6 @@ mod tests {
             copy: WorkspaceCopyParts::default(),
         };
         let dialogues = [dialogue.clone()];
-        let selected = [true];
         let mut pane = ContentPane::default();
         pane.ensure(ContentCtx {
             dialogues: &dialogues,
@@ -1543,7 +1537,7 @@ mod tests {
         // block is 0, the assistant reply 1, so the tool run is 2. Copy joins
         // the run's tool bodies, never the user or assistant blocks.
         pane.toggle_mark(0, 2);
-        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &selected, 0, &pane)
+        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &[0], &pane)
             .expect("marked copy");
         let text = &picked.units[0].plain;
         assert!(text.contains("cmd 0") && text.contains("cmd 2"), "{text}");
@@ -1603,7 +1597,6 @@ mod tests {
             copy: WorkspaceCopyParts::default(),
         };
         let dialogues = [dialogue.clone()];
-        let selected = [true];
         let mut pane = ContentPane::default();
         let area = ratatui::layout::Rect::new(0, 0, 60, 20);
         let frame = pane.ensure(ContentCtx {
@@ -1629,7 +1622,7 @@ mod tests {
         let hit_id = hit_id.expect("a block is hit in the output half");
         pane.toggle_mark(0, hit_id);
 
-        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &selected, 0, &pane)
+        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &[0], &pane)
             .expect("marked copy must not be None after a real dot hit");
         let text = &picked.units[0].plain;
         assert!(text.contains("cmd 0") && text.contains("cmd 2"), "{text}");
@@ -1687,11 +1680,10 @@ mod tests {
             copy: WorkspaceCopyParts::default(),
         };
         let dialogues = [dialogue.clone()];
-        let selected = [true];
 
         // Dialogue-global ids: user = 0, assistant = 1, grep tool pair = 2.
         // The cursor on the tool block copies only it.
-        let picked = workspace_picked_content_for_cursor_block(&dialogues, &selected, 0, 2)
+        let picked = workspace_picked_content_for_cursor_block(&dialogues, 0, 2)
             .expect("tool block copy must not be None");
         let text = &picked.units[0].plain;
         assert!(text.contains("fn main"), "tool call missing: {text}");
@@ -1742,10 +1734,9 @@ mod tests {
             copy: WorkspaceCopyParts::default(),
         };
         let dialogues = [dialogue.clone()];
-        let selected = [true];
 
         // Member id 2 = the first tool of the run.
-        let picked = workspace_picked_content_for_cursor_block(&dialogues, &selected, 0, 2)
+        let picked = workspace_picked_content_for_cursor_block(&dialogues, 0, 2)
             .expect("run member copy must not be None");
         let text = &picked.units[0].plain;
         assert!(text.contains("pat 0"), "first member missing: {text}");
@@ -1766,7 +1757,7 @@ mod tests {
             expanded: &expanded,
         });
         pane.toggle_mark(0, 2);
-        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &selected, 0, &pane)
+        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &[0], &pane)
             .expect("marked member copy");
         let text = &picked.units[0].plain;
         assert!(text.contains("pat 0"), "first member missing: {text}");
@@ -1807,12 +1798,11 @@ mod tests {
             copy: WorkspaceCopyParts::default(),
         };
         let dialogues = [dialogue.clone()];
-        let selected = [true];
 
         // Cursor on the tool block (output half, id 1 after the input user
         // block): call + result bodies only.
-        let picked = workspace_picked_content_for_cursor_block(&dialogues, &selected, 0, 1)
-            .expect("cursor block copy");
+        let picked =
+            workspace_picked_content_for_cursor_block(&dialogues, 0, 1).expect("cursor block copy");
         assert_eq!(picked.units.len(), 1);
         let text = &picked.units[0].plain;
         assert!(text.contains("$ ls"), "tool call body missing: {text}");
@@ -1826,8 +1816,8 @@ mod tests {
         );
 
         // Cursor on the user block (input half, id 0): just the user text.
-        let picked = workspace_picked_content_for_cursor_block(&dialogues, &selected, 0, 0)
-            .expect("cursor block copy");
+        let picked =
+            workspace_picked_content_for_cursor_block(&dialogues, 0, 0).expect("cursor block copy");
         assert_eq!(picked.units[0].plain, "user text");
     }
 
@@ -2222,14 +2212,15 @@ mod tests {
     }
 
     #[test]
-    fn workspace_picked_content_uses_selected_dialogues_only() {
+    fn workspace_picked_content_copies_the_picked_rows_in_order() {
         let dialogues = vec![
             workspace_test_dialogue("d1", "text 1"),
             workspace_test_dialogue("d2", "text 2"),
             workspace_test_dialogue("d3", "text 3"),
         ];
 
-        let picked = workspace_picked_content(&dialogues, &[false, true, true], 0, None).unwrap();
+        // Which rows those are is [`ListPane::active`]'s answer, tested there.
+        let picked = workspace_picked_content(&dialogues, &[1, 2], None);
 
         assert_eq!(picked.units.len(), 2);
         assert!(picked.units[0].plain.contains("text 2"));
@@ -2239,21 +2230,6 @@ mod tests {
             picked.selection,
             CommandSelection::RecentExplicit(vec![1, 2])
         );
-    }
-
-    #[test]
-    fn workspace_picked_content_falls_back_to_highlighted_dialogue() {
-        let dialogues = vec![
-            workspace_test_dialogue("d1", "text 1"),
-            workspace_test_dialogue("d2", "text 2"),
-        ];
-
-        let picked = workspace_picked_content(&dialogues, &[false, false], 1, None).unwrap();
-
-        assert_eq!(picked.units.len(), 1);
-        assert!(picked.units[0].plain.contains("text 2"));
-        assert!(!picked.units[0].plain.contains("text 1"));
-        assert_eq!(picked.selection, CommandSelection::RecentExplicit(vec![1]));
     }
 
     #[test]
@@ -2275,18 +2251,10 @@ mod tests {
             },
         }];
 
-        let input = workspace_picked_content_for_copy(
-            &dialogues,
-            &[false],
-            0,
-            WorkspaceCopyShortcut::Input,
-        );
-        let output = workspace_picked_content_for_copy(
-            &dialogues,
-            &[false],
-            0,
-            WorkspaceCopyShortcut::Output,
-        );
+        let input =
+            workspace_picked_content_for_copy(&dialogues, &[0], WorkspaceCopyShortcut::Input);
+        let output =
+            workspace_picked_content_for_copy(&dialogues, &[0], WorkspaceCopyShortcut::Output);
 
         assert_eq!(input.units[0].plain, "question");
         assert_eq!(output.units[0].plain, "answer");
@@ -2313,12 +2281,10 @@ mod tests {
         };
 
         let displayed =
-            workspace_picked_content_with_line_filter(&dialogues, &[false], 0, Some("2:3"), None)
-                .unwrap();
+            workspace_picked_content_with_line_filter(&dialogues, &[0], Some("2:3"), None).unwrap();
         let input = workspace_picked_content_for_copy_with_line_filter(
             &dialogues,
-            &[false],
-            0,
+            &[0],
             WorkspaceCopyShortcut::Input,
             Some("1,3"),
             None,
@@ -2335,9 +2301,8 @@ mod tests {
     fn workspace_line_filter_rejects_invalid_specs() {
         let dialogues = vec![workspace_test_dialogue("d1", "alpha\nbeta\ngamma")];
 
-        let err =
-            workspace_picked_content_with_line_filter(&dialogues, &[false], 0, Some("x"), None)
-                .unwrap_err();
+        let err = workspace_picked_content_with_line_filter(&dialogues, &[0], Some("x"), None)
+            .unwrap_err();
 
         assert!(
             err.to_string().contains("Invalid line number"),
@@ -2431,12 +2396,8 @@ mod tests {
             },
         }];
 
-        let picked = workspace_picked_content_for_copy(
-            &dialogues,
-            &[false],
-            0,
-            WorkspaceCopyShortcut::Command,
-        );
+        let picked =
+            workspace_picked_content_for_copy(&dialogues, &[0], WorkspaceCopyShortcut::Command);
 
         assert_eq!(picked.units[0].plain, "cargo test");
     }
@@ -2484,8 +2445,7 @@ mod tests {
             }),
         }];
 
-        let picked =
-            workspace_picked_content(&dialogues, &[false], 0, Some(WorkAt::Part(1))).unwrap();
+        let picked = workspace_picked_content(&dialogues, &[0], Some(WorkAt::Part(1)));
 
         assert_eq!(picked.units[0].plain.trim(), "<:tool:tool call:>");
         // Displayed copy uses Reading mode: fold marker only, no payload.

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -2220,7 +2220,7 @@ mod tests {
         ];
 
         // Which rows those are is [`ListPane::active`]'s answer, tested there.
-        let picked = workspace_picked_content(&dialogues, &[1, 2], None);
+        let picked = workspace_picked_content(&dialogues, &[1, 2], None).expect("pick succeeds");
 
         assert_eq!(picked.units.len(), 2);
         assert!(picked.units[0].plain.contains("text 2"));
@@ -2445,7 +2445,8 @@ mod tests {
             }),
         }];
 
-        let picked = workspace_picked_content(&dialogues, &[0], Some(WorkAt::Part(1)));
+        let picked = workspace_picked_content(&dialogues, &[0], Some(WorkAt::Part(1)))
+            .expect("pick succeeds");
 
         assert_eq!(picked.units[0].plain.trim(), "<:tool:tool call:>");
         // Displayed copy uses Reading mode: fold marker only, no payload.

--- a/src/commands/browse/visual.rs
+++ b/src/commands/browse/visual.rs
@@ -14,7 +14,7 @@ use crate::tui::workspace::{
     ContentIoFocus, ContentScrolls, Rows, WorkspaceDialogue, WorkspaceFocus, WorkspacePickedContent,
 };
 
-use super::content::workspace_picked_content;
+use super::content::picked_source;
 use super::nav::move_workspace_cursor;
 
 /// Lines per wheel notch: web-like scroll steps (lists move selection by the
@@ -51,32 +51,29 @@ pub(super) fn handle_visual_select_key(
     content_mode: ContentViewMode,
     content_scroll: &mut usize,
     dialogues: &[WorkspaceDialogue],
-    selected_dialogues: &[bool],
     dialogue_idx: usize,
 ) -> Result<Option<WorkspacePickedContent>> {
     match key {
         KeyCode::Esc => return Ok(None),
         KeyCode::Enter | KeyCode::Char('y') => {
-            return Ok(Some(workspace_picked_content_for_visual_selection(
+            return Ok(workspace_picked_content_for_visual_selection(
                 dialogues,
-                selected_dialogues,
                 dialogue_idx,
                 content_area,
                 text,
                 content_mode,
                 mode.selection,
-            )?));
+            ));
         }
         KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
-            return Ok(Some(workspace_picked_content_for_visual_selection(
+            return Ok(workspace_picked_content_for_visual_selection(
                 dialogues,
-                selected_dialogues,
                 dialogue_idx,
                 content_area,
                 text,
                 content_mode,
                 mode.selection,
-            )?));
+            ));
         }
         KeyCode::Left | KeyCode::Char('h') => move_visual_cursor(
             mode,
@@ -326,19 +323,20 @@ pub(super) fn mouse_selection_kind(modifiers: KeyModifiers) -> ContentSelectionK
     }
 }
 
+/// Copy the visually selected text of the dialogue on screen, attributed to
+/// that dialogue — the selection covers its rendered content, so the shown
+/// index is the only one that can own it. `None` when that dialogue is gone.
 pub(super) fn workspace_picked_content_for_visual_selection(
     dialogues: &[WorkspaceDialogue],
-    selected_dialogues: &[bool],
     dialogue_idx: usize,
     content_area: ratatui::layout::Rect,
     text: &str,
     content_mode: ContentViewMode,
     selection: ContentSelection,
-) -> Result<WorkspacePickedContent> {
-    let source =
-        workspace_picked_content(dialogues, selected_dialogues, dialogue_idx, None)?.source;
+) -> Option<WorkspacePickedContent> {
+    let source = picked_source(dialogues, &[dialogue_idx])?;
     let plain = selected_content_text(content_area, text, content_mode, selection);
-    Ok(WorkspacePickedContent {
+    Some(WorkspacePickedContent {
         source,
         units: vec![crate::tui::workspace::TextPair {
             ansi: plain.clone(),


### PR DESCRIPTION
## Purpose
Resolve copied dialogues once and make copy output respect the canonical selected content.

## Changes
- Deduplicate selected dialogue resolution before copying.
- Preserve block order, filtering, structured parts, commands, and targeted content.
- Keep visual marks separate from domain selection while retaining their exact ranges.

## Validation
Validated on the stack tip with `cargo build --target-dir target/build-check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p sivtr --lib`.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved copying for selections spanning multiple dialogues.
  * Prevented duplicated content when copying marked or folded blocks.
  * Fixed cursor-block copying to include both input and output content.
  * Improved ordering, filtering, and targeting for copied workspace content.
  * Visual selections now handle unavailable dialogue content safely.

* **Tests**
  * Expanded coverage for multi-dialogue selections, marked runs, block isolation, filtering, and structured content copying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->