### PR TITLE
refactor(workset): preserve anchor granularity

### DIFF
--- a/src/commands/browse/content.rs
+++ b/src/commands/browse/content.rs
@@ -3,7 +3,6 @@
 use anyhow::{Context, Result};
 use crossterm::event::KeyCode;
 
-use crate::commands::select::CommandSelection;
 use crate::tui::content::block::{dialogue_blocks, Block};
 use crate::tui::content::view::{line_count, ContentViewMode};
 use crate::tui::search::{WorkspaceSearchMatch, WorkspaceSearchOutput};
@@ -58,12 +57,7 @@ pub(super) fn workspace_picked_content_for_copy_with_line_filter(
         })
         .collect::<Vec<_>>();
     let units = apply_workspace_line_filter(units, line_filter)?;
-    let selection = CommandSelection::RecentExplicit((1..=units.len()).collect());
-    Ok(WorkspacePickedContent {
-        source,
-        units,
-        selection,
-    })
+    Ok(WorkspacePickedContent { source, units })
 }
 
 #[cfg(test)]
@@ -207,7 +201,6 @@ fn picked_for_texts(
             ansi: plain.clone(),
             plain,
         }],
-        selection: CommandSelection::RecentExplicit(vec![1]),
     })
 }
 

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -2219,7 +2219,7 @@ mod tests {
         ];
 
         // Which rows those are is [`ListPane::active`]'s answer, tested there.
-        let picked = workspace_picked_content(&dialogues, &[1, 2], None).expect("pick succeeds");
+let picked = workspace_picked_content(&dialogues, &[1, 2], None).expect("pick succeeds");
 
         assert_eq!(picked.units.len(), 2);
         assert!(picked.units[0].plain.contains("text 2"));

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -2219,7 +2219,7 @@ mod tests {
         ];
 
         // Which rows those are is [`ListPane::active`]'s answer, tested there.
-let picked = workspace_picked_content(&dialogues, &[1, 2], None).expect("pick succeeds");
+        let picked = workspace_picked_content(&dialogues, &[1, 2], None).expect("pick succeeds");
 
         assert_eq!(picked.units.len(), 2);
         assert!(picked.units[0].plain.contains("text 2"));

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -1206,7 +1206,6 @@ mod tests {
     };
     use super::super::nav::move_workspace_cursor;
     use super::super::panes::{ContentCtx, ContentPane, DialogueCtx, DialoguePane};
-    use crate::commands::select::CommandSelection;
     use crate::pane::{Pane, PaneInput, Viewport};
     use crate::tui::content::view::ContentViewMode;
     use crate::tui::search::{
@@ -2226,10 +2225,6 @@ mod tests {
         assert!(picked.units[0].plain.contains("text 2"));
         assert!(picked.units[1].plain.contains("text 3"));
         assert!(!picked.units[0].plain.contains("text 1"));
-        assert_eq!(
-            picked.selection,
-            CommandSelection::RecentExplicit(vec![1, 2])
-        );
     }
 
     #[test]

--- a/src/commands/browse/visual.rs
+++ b/src/commands/browse/visual.rs
@@ -3,7 +3,6 @@
 use anyhow::Result;
 use crossterm::event::{KeyCode, KeyModifiers, MouseButton, MouseEventKind};
 
-use crate::commands::select::CommandSelection;
 use crate::tui::content::io::ContentIoFrame;
 use crate::tui::content::view::{
     clamp_content_position, content_block_at, content_position_in_text_row, content_text_area,
@@ -342,7 +341,6 @@ pub(super) fn workspace_picked_content_for_visual_selection(
             ansi: plain.clone(),
             plain,
         }],
-        selection: CommandSelection::RecentExplicit(vec![1]),
     })
 }
 

--- a/src/commands/memory/copy/export.rs
+++ b/src/commands/memory/copy/export.rs
@@ -7,8 +7,7 @@ use crate::commands::browse::{filter_lines_by_spec, select_lines};
 use crate::output;
 use crate::tui::workspace::{TextPair, WorkspacePickedContent};
 
-use super::plan::{CopyFilters, DialogueSelect};
-use crate::commands::select::resolve_selector;
+use super::plan::CopyFilters;
 
 /// Export TUI-picked content to the clipboard.
 ///
@@ -20,11 +19,8 @@ pub fn export_picked(
     lines: Option<&str>,
     ansi: bool,
 ) -> Result<()> {
-    let empty = format!("selected {} content is empty", picked.source.label());
-    let success = format!("copied {} content to clipboard", picked.source.label());
     finish_units(
         &picked.units,
-        &picked.selection,
         &CopyFilters {
             print: print_full,
             ansi,
@@ -33,49 +29,32 @@ pub fn export_picked(
             prompt: None,
             cwd: None,
         },
-        &empty,
-        &success,
+        &picked.source.label(),
     )
 }
 
-pub(super) fn finish_units(
-    units: &[TextPair],
-    selection: &DialogueSelect,
-    filters: &CopyFilters,
-    empty_message: &str,
-    success_message: &str,
-) -> Result<()> {
-    let indices = resolve_selector(selection, units.len())?;
-    let selected: Vec<TextPair> = indices
+/// Join every unit that carries text and sink it, naming `label` in both the
+/// empty warning and the success line. The single path both copy surfaces —
+/// the CLI plan and the TUI pick — end on.
+pub(super) fn finish_units(units: &[TextPair], filters: &CopyFilters, label: &str) -> Result<()> {
+    let kept: Vec<TextPair> = units
         .iter()
-        .filter_map(|idx| units.get(*idx).cloned())
         .filter(|unit| !unit.plain.trim().is_empty())
+        .cloned()
         .collect();
-    if selected.is_empty() {
-        output::warning(empty_message);
+    if kept.is_empty() {
+        output::warning(format!("selected {label} content is empty"));
         return Ok(());
     }
-    let text = join_text_pairs(&selected, "\n\n");
-    finish_text(text, filters, success_message)
+    let count = kept.len();
+    finish_text(
+        join_text_pairs(&kept),
+        filters,
+        &format!("copied {count} item(s) from {label} to clipboard"),
+    )
 }
 
-pub(super) fn finish_text_pairs(
-    pairs: &[TextPair],
-    filters: &CopyFilters,
-    success_message: &str,
-) -> Result<()> {
-    if pairs.is_empty() {
-        output::warning("selected content is empty");
-        return Ok(());
-    }
-    finish_text(join_text_pairs(pairs, "\n\n"), filters, success_message)
-}
-
-pub(super) fn finish_text(
-    mut text: TextPair,
-    filters: &CopyFilters,
-    success_message: &str,
-) -> Result<()> {
+fn finish_text(mut text: TextPair, filters: &CopyFilters, success_message: &str) -> Result<()> {
     if let Some(pattern) = filters.regex.as_deref() {
         text = filter_lines_by_regex(&text, pattern)?;
     }
@@ -99,22 +78,30 @@ pub(super) fn finish_text(
     Ok(())
 }
 
-pub(super) fn join_text_pairs(pairs: &[TextPair], separator: &str) -> TextPair {
+fn join_text_pairs(pairs: &[TextPair]) -> TextPair {
     TextPair {
         plain: pairs
             .iter()
             .map(|pair| pair.plain.as_str())
             .collect::<Vec<_>>()
-            .join(separator),
+            .join(
+                "
+
+",
+            ),
         ansi: pairs
             .iter()
             .map(|pair| pair.ansi.as_str())
             .collect::<Vec<_>>()
-            .join(separator),
+            .join(
+                "
+
+",
+            ),
     }
 }
 
-pub(super) fn filter_lines_by_regex(text: &TextPair, pattern: &str) -> Result<TextPair> {
+fn filter_lines_by_regex(text: &TextPair, pattern: &str) -> Result<TextPair> {
     let regex = Regex::new(pattern)
         .with_context(|| format!("Invalid regex `{pattern}`. Check the pattern syntax."))?;
     let indices = text

--- a/src/commands/memory/copy/export.rs
+++ b/src/commands/memory/copy/export.rs
@@ -31,6 +31,7 @@ pub fn export_picked(
         },
         &picked.source.label(),
     )
+    .context("export picked content")
 }
 
 /// Join every unit that carries text and sink it, naming `label` in both the

--- a/src/commands/memory/copy/mod.rs
+++ b/src/commands/memory/copy/mod.rs
@@ -23,7 +23,7 @@ use crate::tui::workspace::{
     WorkspaceFocus, WorkspaceSession, WorkspaceSource, WorkspaceSourceKind,
 };
 
-use export::finish_text_pairs;
+use export::finish_units;
 use load::load_for_plan;
 use project::project_record;
 
@@ -40,23 +40,10 @@ pub fn execute(plan: CopyPlan) -> Result<()> {
     let prompt = plan.filters.prompt.as_deref();
     let mut units = Vec::new();
     for record in &loaded.records {
-        let unit = project_record(record, loaded.projection, prompt)?;
-        if !unit.plain.trim().is_empty() {
-            units.push(unit);
-        }
+        units.push(project_record(record, loaded.projection, prompt)?);
     }
 
-    if units.is_empty() {
-        output::warning(format!("selected {} content is empty", loaded.label));
-        return Ok(());
-    }
-
-    let count = units.len();
-    finish_text_pairs(
-        &units,
-        &plan.filters,
-        &format!("copied {count} item(s) from {} to clipboard", loaded.label),
-    )
+    finish_units(&units, &plan.filters, &loaded.label)
 }
 
 fn execute_pick(plan: &CopyPlan) -> Result<()> {

--- a/src/commands/memory/copy/mod.rs
+++ b/src/commands/memory/copy/mod.rs
@@ -40,10 +40,13 @@ pub fn execute(plan: CopyPlan) -> Result<()> {
     let prompt = plan.filters.prompt.as_deref();
     let mut units = Vec::new();
     for record in &loaded.records {
-        units.push(project_record(record, loaded.projection, prompt)?);
+        units.push(
+            project_record(record, loaded.projection, prompt)
+                .context("project record for copy")?,
+        );
     }
 
-    finish_units(&units, &plan.filters, &loaded.label)
+    finish_units(&units, &plan.filters, &loaded.label).context("finish copy")
 }
 
 fn execute_pick(plan: &CopyPlan) -> Result<()> {

--- a/src/commands/memory/copy/mod.rs
+++ b/src/commands/memory/copy/mod.rs
@@ -41,8 +41,7 @@ pub fn execute(plan: CopyPlan) -> Result<()> {
     let mut units = Vec::new();
     for record in &loaded.records {
         units.push(
-            project_record(record, loaded.projection, prompt)
-                .context("project record for copy")?,
+            project_record(record, loaded.projection, prompt).context("project record for copy")?,
         );
     }
 

--- a/src/commands/memory/workset/mod.rs
+++ b/src/commands/memory/workset/mod.rs
@@ -123,14 +123,9 @@ impl WorkSet {
         Ok(())
     }
 
+    /// Persist the anchors a reader would see, so a saved WorkSet keeps them.
     pub fn ensure_anchors(&mut self) {
-        if self.anchors.is_empty() {
-            self.anchors = self
-                .records
-                .iter()
-                .map(|record| record.work_ref.whole())
-                .collect();
-        }
+        self.anchors = self.anchors();
     }
 
     pub fn anchors(&self) -> Vec<WorkRef> {

--- a/src/commands/memory/workset/source.rs
+++ b/src/commands/memory/workset/source.rs
@@ -206,8 +206,11 @@ fn resolve_source(source: &str, cwd: &Path) -> Result<Vec<QuerySource>> {
 /// Merge per-source outcomes into one corpus, then apply the filter once
 /// across the merged records. A failed source drops without aborting the
 /// batch; when every source failed, the first error is what the caller sees.
+/// Anchors merge with the records: a source that resolved part anchors keeps
+/// them, and one that carried none contributes its records' whole refs.
 fn merge_and_apply(results: Vec<QuerySourceResult>, cwd: &Path, filter: Filter) -> Result<WorkSet> {
     let mut records: Vec<WorkRecord> = Vec::new();
+    let mut anchors: Vec<WorkRef> = Vec::new();
     let mut seen: HashSet<WorkRef> = HashSet::new();
     let mut errors: Vec<String> = Vec::new();
     let mut any_ok = false;
@@ -215,6 +218,7 @@ fn merge_and_apply(results: Vec<QuerySourceResult>, cwd: &Path, filter: Filter) 
         match result {
             QuerySourceResult::Ok(set) => {
                 any_ok = true;
+                anchors.extend(set.anchors());
                 for record in set.records {
                     if seen.insert(record.work_ref.whole()) {
                         records.push(record);
@@ -233,7 +237,14 @@ fn merge_and_apply(results: Vec<QuerySourceResult>, cwd: &Path, filter: Filter) 
     for error in &errors {
         output::warning(format!("skipped an origin: {error}"));
     }
-    apply_loaded(WorkSet::new(cwd.display().to_string(), records), filter)
+    apply_loaded(
+        WorkSet::with_anchors(
+            cwd.display().to_string(),
+            records,
+            crate::commands::memory::var::unique_anchors(anchors),
+        ),
+        filter,
+    )
 }
 
 /// Load many sources in parallel — local, remote, and group share one
@@ -599,7 +610,75 @@ pub fn load_context_records(
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_source, split_group_scope, QueryTransport};
+    use super::{merge_and_apply, resolve_source, split_group_scope, QueryTransport};
+    use crate::commands::memory::workset::{QuerySourceResult, WorkSet};
+    use sivtr_core::record::{
+        WorkChannel, WorkPart, WorkPartData, WorkRecord, WorkRecordKind, WorkSessionRef,
+        WorkSource, WorkTime,
+    };
+    use sivtr_core::search::Filter;
+
+    fn record(index: usize) -> WorkRecord {
+        WorkRecord {
+            schema_version: sivtr_core::record::RECORD_SCHEMA_VERSION,
+            work_ref: format!("terminal/session_1/{index}")
+                .parse()
+                .expect("valid work ref"),
+            kind: WorkRecordKind::TerminalCommand,
+            source: WorkSource {
+                channel: WorkChannel::Terminal,
+                provider: None,
+            },
+            session: WorkSessionRef {
+                id: "session_1".to_string(),
+                canonical_id: Some("session_1".to_string()),
+                path: None,
+            },
+            cwd: None,
+            time: WorkTime::default(),
+            status: None,
+            title: format!("record {index}"),
+            parts: (1..=2)
+                .map(|seq| WorkPart {
+                    seq,
+                    occurred_at: None,
+                    data: WorkPartData::Output {
+                        content: format!("record {index} part {seq}"),
+                        ansi: None,
+                    },
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn merging_sources_keeps_each_ones_anchor_granularity() {
+        let first = record(1);
+        let second = record(2);
+        let part = first.work_ref.with_part(2);
+        let results = vec![
+            QuerySourceResult::Ok(WorkSet::with_anchors(
+                "/repo",
+                vec![first],
+                vec![part.clone()],
+            )),
+            QuerySourceResult::Ok(WorkSet::new("/repo", vec![second.clone()])),
+        ];
+
+        let merged = merge_and_apply(results, std::path::Path::new("/repo"), Filter::none())
+            .expect("merge succeeds");
+        let mut refs = merged
+            .anchors()
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        refs.sort();
+        assert_eq!(
+            refs,
+            vec![part.to_string(), second.work_ref.whole().to_string()],
+            "a part anchor must survive the merge alongside a record anchor"
+        );
+    }
 
     #[test]
     fn group_scope_splits_team_and_member_forms() {

--- a/src/commands/select.rs
+++ b/src/commands/select.rs
@@ -5,7 +5,6 @@ use anyhow::{Context, Result};
 pub enum CommandSelection {
     RecentSingle(usize),
     RecentRange { newer: usize, older: usize },
-    RecentExplicit(Vec<usize>),
 }
 
 pub fn parse_selector(value: &str) -> Result<CommandSelection> {
@@ -50,29 +49,6 @@ pub fn resolve_selector(selection: &CommandSelection, total: usize) -> Result<Ve
             let start = total - older;
             let end = total - newer;
             Ok((start..=end).collect())
-        }
-        CommandSelection::RecentExplicit(selected) => {
-            if selected.is_empty() {
-                anyhow::bail!("No command blocks selected.");
-            }
-
-            let mut indices = Vec::with_capacity(selected.len());
-            for recent in selected {
-                let recent = *recent;
-                if recent == 0 {
-                    anyhow::bail!("Selector values are 1-based. Use `1` for the last command.");
-                }
-                if recent > total {
-                    anyhow::bail!(
-                        "Only {total} command(s) recorded. Try a smaller selector or `--pick`."
-                    );
-                }
-                indices.push(total - recent);
-            }
-
-            indices.sort_unstable();
-            indices.dedup();
-            Ok(indices)
         }
     }
 }
@@ -120,14 +96,6 @@ mod tests {
         assert_eq!(
             resolve_selector(&CommandSelection::RecentRange { newer: 2, older: 5 }, 10).unwrap(),
             vec![5, 6, 7, 8]
-        );
-    }
-
-    #[test]
-    fn resolves_explicit_selection_as_disjoint_commands() {
-        assert_eq!(
-            resolve_selector(&CommandSelection::RecentExplicit(vec![1, 4, 7]), 10).unwrap(),
-            vec![3, 6, 9]
         );
     }
 }

--- a/src/tui/workspace/model.rs
+++ b/src/tui/workspace/model.rs
@@ -7,7 +7,6 @@ use sivtr_core::record::{WorkAt, WorkRecord, WorkRef};
 use std::collections::HashSet;
 use std::time::SystemTime;
 
-use crate::commands::select::CommandSelection;
 use crate::tui::content::block::{dialogue_block_id, fold_label_for_part, BlockText};
 use crate::tui::content::io::{
     ContentIoFocus, ContentIoFrame, ContentIoTexts, ContentScrolls, ExpandedBlocks,
@@ -196,7 +195,6 @@ impl WorkspaceCopyParts {
 pub(crate) struct WorkspacePickedContent {
     pub(crate) source: WorkspaceSource,
     pub(crate) units: Vec<TextPair>,
-    pub(crate) selection: CommandSelection,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## Purpose
Preserve the smallest meaningful WorkSet anchor when selections change granularity.

## Changes
- Keep Whole and Part anchors canonical through selection updates.
- Prevent anchor shadowing and accidental loss of targeted parts.
- Route persistence through the shared WorkSet representation.

## Validation
Validated on the stack tip with `cargo build --target-dir target/build-check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p sivtr --lib`.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preserved detailed part-level anchors when combining content from multiple sources.
  * Copy operations now include all selected content, including blank units where applicable.
  * Copy results use the selected source label in status and warning messages.

* **Bug Fixes**
  * Removed obsolete selection metadata from picked workspace content.
  * Simplified selection handling and eliminated unsupported explicit multi-selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->