### PR TITLE
feat(browse): walk cursor across dialogues

### DIFF
--- a/docs-site/src/content/docs/reference/keybindings.md
+++ b/docs-site/src/content/docs/reference/keybindings.md
@@ -15,7 +15,7 @@ This page documents the workspace picker TUI (the default `sivtr` interface). Th
 | `1` | Focus Sessions pane |
 | `2` | Focus Dialogues pane |
 | `3` | Focus Content pane |
-| `j` / `k` | Move down / up (Content: block cursor) |
+| `j` / `k` | Move down / up (Content: block cursor, crossing into the next dialogue) |
 | `h` / `l` | Focus previous / next pane |
 | `Space` | Toggle source/session/dialogue, or mark a content block |
 | `a` | Select all sources (Source) or toggle all dialogues (Dialogues) |
@@ -28,7 +28,6 @@ This page documents the workspace picker TUI (the default `sivtr` interface). Th
 | `r` | Toggle read/raw content mode in Content |
 | `Enter` | Focus next / copy (lists); fold/unfold the cursor block (Content) |
 | `i` / `o` / `y` / `c` | Copy input / output / input+output block / bare command |
-| `J` / `K` | Page next/previous selected dialogue (Content, multi-select) |
 | `z` | Toggle the focused pane fullscreen |
 | `?` | Toggle help overlay |
 | `/` | Open search |

--- a/docs-site/src/content/docs/reference/keybindings.md
+++ b/docs-site/src/content/docs/reference/keybindings.md
@@ -15,7 +15,7 @@ This page documents the workspace picker TUI (the default `sivtr` interface). Th
 | `1` | Focus Sessions pane |
 | `2` | Focus Dialogues pane |
 | `3` | Focus Content pane |
-| `j` / `k` | Move down / up (Content: block cursor, crossing into the next dialogue) |
+| `j` / `k` | Move down / up (Content: block cursor, crossing into an adjacent dialogue) |
 | `h` / `l` | Focus previous / next pane |
 | `Space` | Toggle source/session/dialogue, or mark a content block |
 | `a` | Select all sources (Source) or toggle all dialogues (Dialogues) |

--- a/docs-site/src/content/docs/usage/browse-and-select.md
+++ b/docs-site/src/content/docs/usage/browse-and-select.md
@@ -32,7 +32,6 @@ Layout: Source · Sessions · Dialogues · Content. Content splits into **Input*
 | `r` | Toggle read/raw content (structure markers + fold tags vs expanded payloads) |
 | `Ctrl-d` / `Ctrl-u` · `PgDn` / `PgUp` | Scroll content |
 | `g` / `G` | Content top / bottom |
-| `J` / `K` | Page next/previous selected dialogue (Content, multi-select) |
 | `i` / `o` / `y` / `c` | Copy input / output / block / command |
 | `Enter` | Confirm / open next / copy; fold/unfold the cursor block (Content) |
 | `/` | Search |

--- a/src/commands/browse/content.rs
+++ b/src/commands/browse/content.rs
@@ -103,29 +103,32 @@ pub(super) fn workspace_picked_content(
 
 /// Picked content from the content pane's marked blocks: every selected
 /// block's full body (regardless of fold state), joined in display order.
-/// Marks follow their dialogue (multi-select paging keeps them), so all
-/// marked dialogues contribute, in selection order. Dialogues without a
-/// record are skipped, keeping the blocks already collected. `None` when
-/// nothing is marked.
+/// Marks are keyed by dialogue, so every dialogue holding one contributes —
+/// including dialogues the content pane has since scrolled away from.
+/// Dialogues without a record are skipped, keeping the blocks already
+/// collected. `None` when nothing is marked.
 pub(super) fn workspace_picked_content_for_marked_blocks(
     dialogues: &[WorkspaceDialogue],
-    picked: &[usize],
     content_pane: &ContentPane,
 ) -> Option<WorkspacePickedContent> {
     let mut texts = Vec::new();
-    for &dialogue_idx in picked {
-        let Some(record) = dialogues
-            .get(dialogue_idx)
-            .and_then(|dialogue| dialogue.record.as_ref())
-        else {
+    // Attribution follows the first dialogue that actually contributed; no
+    // contributor means nothing was marked, and there is nothing to copy.
+    let mut source = None;
+    for (dialogue_idx, dialogue) in dialogues.iter().enumerate() {
+        let Some(record) = dialogue.record.as_ref() else {
             continue;
         };
+        let collected = texts.len();
         let (input_blocks, output_blocks) = dialogue_blocks(record);
         for block in input_blocks.iter().chain(&output_blocks) {
             collect_marked_blocks(block, dialogue_idx, content_pane, record, &mut texts);
         }
+        if texts.len() > collected {
+            source.get_or_insert_with(|| dialogue.source.clone());
+        }
     }
-    picked_for_texts(dialogues, picked, texts)
+    Some(picked_for_texts(source?, texts))
 }
 
 /// Push every marked block's body. A run's body already spans its members,
@@ -169,7 +172,10 @@ pub(super) fn workspace_picked_content_for_cursor_block(
         .iter()
         .chain(&output_blocks)
         .find_map(|block| find_block(block, block_id))?;
-    picked_for_texts(dialogues, &[dialogue_idx], vec![block.body(record)])
+    Some(picked_for_texts(
+        dialogue.source.clone(),
+        vec![block.body(record)],
+    ))
 }
 
 /// Depth-first block lookup: run members live nested in `children`, and the
@@ -185,23 +191,15 @@ fn find_block(block: &Block, id: usize) -> Option<&Block> {
 }
 
 /// One copy unit from already-collected block bodies.
-fn picked_for_texts(
-    dialogues: &[WorkspaceDialogue],
-    picked: &[usize],
-    texts: Vec<String>,
-) -> Option<WorkspacePickedContent> {
-    if texts.is_empty() {
-        return None;
-    }
+fn picked_for_texts(source: WorkspaceSource, texts: Vec<String>) -> WorkspacePickedContent {
     let plain = texts.join("\n\n");
-    let source = picked_source(dialogues, picked)?;
-    Some(WorkspacePickedContent {
+    WorkspacePickedContent {
         source,
         units: vec![crate::tui::workspace::TextPair {
             ansi: plain.clone(),
             plain,
         }],
-    })
+    }
 }
 
 pub(super) fn line_filter_spec(line_filter: &str) -> Option<&str> {
@@ -404,8 +402,8 @@ mod tests {
         let b = dialogue(record("B", "Bash", "git status", 1));
         let dialogues = [a, b];
         let mut pane = ContentPane::default();
-        // Multi-select paging ensures each dialogue in turn, keeping its
-        // marks; both end up owned by their dialogue.
+        // The content pane shows one dialogue at a time; walking the cursor
+        // onto each in turn keeps the marks left behind on the first.
         for idx in 0..2 {
             pane.ensure(ContentCtx {
                 dialogues: &dialogues,
@@ -421,7 +419,7 @@ mod tests {
             pane.toggle_mark(idx, 1);
         }
 
-        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &[0, 1], &pane)
+        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &pane)
             .expect("marked blocks across two dialogues");
         let joined: Vec<String> = picked.units.iter().map(|unit| unit.plain.clone()).collect();
         let all = joined.join("\n");
@@ -465,8 +463,8 @@ mod tests {
         pane.toggle_mark(0, 1);
         pane.toggle_mark(0, 2);
 
-        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &[0], &pane)
-            .expect("marked run");
+        let picked =
+            workspace_picked_content_for_marked_blocks(&dialogues, &pane).expect("marked run");
         let all = picked
             .units
             .iter()

--- a/src/commands/browse/help.rs
+++ b/src/commands/browse/help.rs
@@ -19,9 +19,7 @@ use super::content::{
     workspace_picked_content_for_copy_with_line_filter, workspace_picked_content_for_cursor_block,
     WorkspaceCopyShortcut,
 };
-use super::nav::{
-    invalidate_panes_below, move_workspace_cursor, shown_dialogue_idx, ContentBlockCursor,
-};
+use super::nav::{invalidate_panes_below, move_workspace_cursor, ContentBlockCursor};
 use super::panes::ContentPane;
 use super::selection::{select_sources, WorkspaceSourceSelection};
 use super::vim::open_vim_view;
@@ -47,8 +45,6 @@ pub(super) fn apply_workspace_help_action(
     content_io_focus: &mut ContentIoFocus,
     content_mode: &mut ContentViewMode,
     expanded: &mut ExpandedBlocks,
-    // Which marked dialogue the content pane shows (multi-select paging).
-    content_page: &mut usize,
     content_cursor: &mut ContentBlockCursor,
     content_pane: &mut ContentPane,
     content_blocks: (&[BlockText], &[BlockText]),
@@ -96,12 +92,11 @@ pub(super) fn apply_workspace_help_action(
         WorkspaceHelpAction::ToggleSelection => match *focus {
             WorkspaceFocus::Content => {
                 // Pane-native selection: Space marks the focused block for
-                // batch copy, like Space toggles a list row. Multi-select
-                // pages one dialogue at a time, so the shown dialogue owns
-                // the mark regardless of the selection count.
-                let shown = shown_dialogue_idx(&rows.dialogues, *content_page);
+                // batch copy, like Space toggles a list row. The content pane
+                // shows the dialogue under the dialogue cursor, so that row
+                // owns the mark.
                 if let Some(block) = content_cursor.get() {
-                    content_pane.toggle_mark(shown, block);
+                    content_pane.toggle_mark(rows.dialogues.cursor(), block);
                 }
             }
             pane => {
@@ -110,23 +105,6 @@ pub(super) fn apply_workspace_help_action(
                 }
             }
         },
-        // Multi-select paging: J/K flip the content pane to the next /
-        // previous marked dialogue. The redraw resets the fold state and
-        // cursor when the shown dialogue changes; marks follow their
-        // dialogue and stay, so a later copy can join pages.
-        WorkspaceHelpAction::NextDialoguePage if *focus == WorkspaceFocus::Content => {
-            let count = rows.dialogues.marked();
-            if count > 1 {
-                *content_page = (*content_page + 1).min(count.saturating_sub(1));
-                content_scrolls.clear();
-            }
-        }
-        WorkspaceHelpAction::PreviousDialoguePage if *focus == WorkspaceFocus::Content => {
-            if rows.dialogues.marked() > 1 {
-                *content_page = content_page.saturating_sub(1);
-                content_scrolls.clear();
-            }
-        }
         WorkspaceHelpAction::SelectAllSources
         | WorkspaceHelpAction::SelectAgentSources
         | WorkspaceHelpAction::SelectTerminalSource => {
@@ -149,9 +127,8 @@ pub(super) fn apply_workspace_help_action(
                 // header already carries every member's body.
                 if let Some(cursor_block) = content_cursor.get() {
                     if let Some(span) = rows.range(*focus, cursor_block) {
-                        let shown = shown_dialogue_idx(&rows.dialogues, *content_page);
                         content_pane.toggle_mark_range(
-                            shown,
+                            rows.dialogues.cursor(),
                             content_blocks
                                 .0
                                 .iter()
@@ -178,7 +155,7 @@ pub(super) fn apply_workspace_help_action(
         WorkspaceHelpAction::OpenVim if can_open_dialogue_vim(*focus, dialogue_count) => {
             let view = dialogue_text_vim_view(workspace_content_text(
                 dialogues,
-                shown_dialogue_idx(&rows.dialogues, *content_page),
+                rows.dialogues.cursor(),
                 *content_mode,
                 content_at,
             ));
@@ -269,13 +246,14 @@ pub(super) fn apply_workspace_help_action(
         WorkspaceHelpAction::CopyBlock if dialogue_count > 0 => {
             // y copies the block under the content cursor (call + result
             // bodies); marked blocks take over in the picker beforehand.
-            // The block id belongs to the *displayed* dialogue, so resolve
-            // the shown index like the marked paths do, not the focused row.
-            let shown = shown_dialogue_idx(&rows.dialogues, *content_page);
+            // The block id belongs to the *displayed* dialogue — the one under
+            // the dialogue cursor.
             let block_id = content_cursor.get().unwrap_or(0);
-            if let Some(picked) =
-                workspace_picked_content_for_cursor_block(dialogues, shown, block_id)
-            {
+            if let Some(picked) = workspace_picked_content_for_cursor_block(
+                dialogues,
+                rows.dialogues.cursor(),
+                block_id,
+            ) {
                 return Ok(HelpDispatch::Picked(picked));
             }
         }
@@ -331,8 +309,6 @@ pub(super) fn apply_workspace_help_action(
         | WorkspaceHelpAction::ToggleContentMode
         | WorkspaceHelpAction::ToggleContentIo
         | WorkspaceHelpAction::ToggleBlockFold
-        | WorkspaceHelpAction::NextDialoguePage
-        | WorkspaceHelpAction::PreviousDialoguePage
         | WorkspaceHelpAction::CopyInput
         | WorkspaceHelpAction::CopyOutput
         | WorkspaceHelpAction::CopyBlock

--- a/src/commands/browse/nav.rs
+++ b/src/commands/browse/nav.rs
@@ -270,7 +270,7 @@ pub(super) fn source_list_index(
 
 #[cfg(test)]
 mod tests {
-    use super::{move_content_cursor, row_list_index, shown_dialogue_idx, ContentBlockCursor};
+    use super::{move_content_cursor, row_list_index, ContentBlockCursor};
     use crate::tui::content::block::BlockText;
     use crate::tui::workspace::{ContentScrolls, ListPane, Rows};
     use ratatui::layout::Rect;
@@ -286,10 +286,7 @@ mod tests {
     }
 
     fn blocks(ids: &[usize]) -> Vec<BlockText> {
-        ids.iter()
-            .copied()
-            .map(block)
-            .collect()
+        ids.iter().copied().map(block).collect()
     }
 
     /// Two dialogues, one block each: j off the end of the first steps the
@@ -347,34 +344,18 @@ mod tests {
     }
 
     #[test]
-    fn shown_dialogue_idx_falls_back_to_the_cursor_row_without_marks() {
-        let mut pane = ListPane::with_marks(vec![false, false]);
-        pane.select(1);
-        assert_eq!(shown_dialogue_idx(&pane, 0), 1);
-    }
-
-    #[test]
-    fn shown_dialogue_idx_pages_through_the_marked_dialogues() {
-        let pane = ListPane::with_marks(vec![false, true, false, true, true]);
-        // Page 0..3 maps onto the 2nd, 4th, and 5th dialogues.
-        assert_eq!(shown_dialogue_idx(&pane, 0), 1);
-        assert_eq!(shown_dialogue_idx(&pane, 1), 3);
-        assert_eq!(shown_dialogue_idx(&pane, 2), 4);
-        // A page past the end clamps to the last marked dialogue.
-        assert_eq!(shown_dialogue_idx(&pane, 9), 4);
-    }
-
-    #[test]
     fn hidden_cursor_moves_to_the_nearest_visible_block() {
         let blocks = [block(0), block(1), block(4)];
+        let mut rows = Rows::default();
+        let mut scrolls = ContentScrolls::default();
         let mut cursor = ContentBlockCursor::default();
         cursor.set(3);
 
-        move_content_cursor(true, &mut cursor, (&[], &blocks));
+        move_content_cursor(true, &mut rows, &mut scrolls, &mut cursor, (&[], &blocks));
         assert_eq!(cursor.get(), Some(1));
 
         cursor.set(3);
-        move_content_cursor(false, &mut cursor, (&[], &blocks));
+        move_content_cursor(false, &mut rows, &mut scrolls, &mut cursor, (&[], &blocks));
         assert_eq!(cursor.get(), Some(4));
     }
 }

--- a/src/commands/browse/nav.rs
+++ b/src/commands/browse/nav.rs
@@ -5,7 +5,7 @@ use std::process::Command;
 
 use crate::tui::content::block::BlockText;
 use crate::tui::workspace::{
-    ContentIoFocus, ContentScrolls, ListPane, Rows, WorkspaceFocus, WorkspaceSource,
+    ContentIoFocus, ContentScrolls, Rows, WorkspaceFocus, WorkspaceSource,
 };
 
 pub(super) fn open_link_target(target: &str) -> Result<()> {
@@ -35,6 +35,10 @@ pub(super) fn open_link_target(target: &str) -> Result<()> {
 pub(super) struct ContentBlockCursor {
     pub(super) block: Option<usize>,
     pub(super) follow: bool,
+    /// Direction of a step that walked off the shown dialogue's blocks and
+    /// moved the dialogue cursor instead. The next dialogue's blocks only
+    /// exist once its frame is built, so the redraw lands the cursor.
+    crossed: Option<bool>,
 }
 
 impl ContentBlockCursor {
@@ -46,9 +50,25 @@ impl ContentBlockCursor {
         self.block = Some(block);
     }
 
+    /// Forget the block: its id named the dialogue that just left the screen.
+    /// A pending crossing survives — it is *why* that dialogue left.
     pub(super) fn clear(&mut self) {
         self.block = None;
         self.follow = false;
+    }
+
+    /// Land on the end of the shown dialogue's visible blocks a crossing
+    /// arrived at: the last block when it stepped up, the first when down.
+    /// No visible block (an unhydrated dialogue) leaves the cursor unset.
+    pub(super) fn land_crossing(&mut self, blocks: (&[BlockText], &[BlockText])) {
+        let Some(up) = self.crossed.take() else {
+            return;
+        };
+        let mut ids = blocks.0.iter().chain(blocks.1).map(|block| block.id);
+        if let Some(id) = if up { ids.next_back() } else { ids.next() } {
+            self.set(id);
+            self.follow = true;
+        }
     }
 
     /// `(half, block)` of the cursor, for the view highlight and block
@@ -68,17 +88,6 @@ impl ContentBlockCursor {
         };
         Some((half, block))
     }
-}
-
-/// Index of the dialogue the content pane shows: the `page`-th marked
-/// dialogue when several are marked, otherwise the cursor row — the pane's
-/// own "which rows does this act on" answer, paged. `page` is clamped to
-/// that row count.
-pub(super) fn shown_dialogue_idx(dialogues: &ListPane, page: usize) -> usize {
-    let rows = dialogues.active();
-    rows.get(page.min(rows.len().saturating_sub(1)))
-        .copied()
-        .unwrap_or(0)
 }
 
 /// Discard whatever the panes right of `focus` derived from its selection,
@@ -150,7 +159,7 @@ pub(super) fn move_workspace_cursor(
     content_blocks: (&[BlockText], &[BlockText]),
 ) {
     if focus == WorkspaceFocus::Content {
-        move_content_cursor(up, content_cursor, content_blocks);
+        move_content_cursor(up, rows, content_scrolls, content_cursor, content_blocks);
         return;
     }
     if rows.pane_mut(focus).is_some_and(|pane| pane.step(up)) {
@@ -164,8 +173,16 @@ pub(super) fn move_workspace_cursor(
 /// segments), so folds — which change which blocks are shown — resolve the
 /// cursor id against the current segments and clamp to the nearest visible
 /// block.
+///
+/// Walking off either end steps the dialogue list instead, and the redraw
+/// lands the cursor on the end of the new dialogue it arrived at — so one
+/// j/k walk covers every dialogue the list holds, across every marked
+/// session. An empty dialogue stops the walk: its blocks may still be
+/// hydrating, and a step past it would skip content the user never saw.
 fn move_content_cursor(
     up: bool,
+    rows: &mut Rows,
+    content_scrolls: &mut ContentScrolls,
     cursor: &mut ContentBlockCursor,
     blocks: (&[BlockText], &[BlockText]),
 ) {
@@ -183,14 +200,19 @@ fn move_content_cursor(
     let current_id = cursor.get();
     let position = current_id.and_then(|id| ids.iter().position(|visible| *visible == id));
     let next = match (current_id, position) {
-        (None, _) => 0,
-        (Some(_), Some(pos)) if up => pos.saturating_sub(1),
-        (Some(_), Some(pos)) => (pos + 1).min(total - 1),
-        (Some(id), None) if up => ids.iter().rposition(|visible| *visible < id).unwrap_or(0),
-        (Some(id), None) => ids
-            .iter()
-            .position(|visible| *visible > id)
-            .unwrap_or(total - 1),
+        (None, _) => Some(0),
+        (Some(_), Some(pos)) if up => pos.checked_sub(1),
+        (Some(_), Some(pos)) => (pos + 1 < total).then_some(pos + 1),
+        (Some(id), None) if up => ids.iter().rposition(|visible| *visible < id),
+        (Some(id), None) => ids.iter().position(|visible| *visible > id),
+    };
+    let Some(next) = next else {
+        // Off the end of this dialogue: continue into the next one.
+        if rows.dialogues.step(up) {
+            cursor.crossed = Some(up);
+            invalidate_after_cursor_move(WorkspaceFocus::Dialogues, rows, content_scrolls);
+        }
+        return;
     };
     cursor.set(ids[next]);
     cursor.follow = true;
@@ -250,7 +272,7 @@ pub(super) fn source_list_index(
 mod tests {
     use super::{move_content_cursor, row_list_index, shown_dialogue_idx, ContentBlockCursor};
     use crate::tui::content::block::BlockText;
-    use crate::tui::workspace::ListPane;
+    use crate::tui::workspace::{ContentScrolls, ListPane, Rows};
     use ratatui::layout::Rect;
     use sivtr_core::record::WorkPartKind;
 
@@ -261,6 +283,53 @@ mod tests {
             tight: false,
             kind: WorkPartKind::Output,
         }
+    }
+
+    fn blocks(ids: &[usize]) -> Vec<BlockText> {
+        ids.iter()
+            .copied()
+            .map(block)
+            .collect()
+    }
+
+    /// Two dialogues, one block each: j off the end of the first steps the
+    /// dialogue list, and the next redraw's blocks land the cursor.
+    #[test]
+    fn a_step_off_the_last_block_crosses_into_the_next_dialogue() {
+        let mut rows = Rows::default();
+        rows.dialogues = ListPane::with_marks(vec![false, false]);
+        let mut scrolls = ContentScrolls::default();
+        let mut cursor = ContentBlockCursor::default();
+        let first = blocks(&[0]);
+        let second = blocks(&[7, 8]);
+
+        move_content_cursor(false, &mut rows, &mut scrolls, &mut cursor, (&[], &first));
+        assert_eq!(cursor.get(), Some(0), "first step lands on the only block");
+
+        move_content_cursor(false, &mut rows, &mut scrolls, &mut cursor, (&[], &first));
+        assert_eq!(rows.dialogues.cursor(), 1, "off the end steps the list");
+        cursor.clear();
+        cursor.land_crossing((&[], &second));
+        assert_eq!(cursor.get(), Some(7), "down lands on the first block");
+
+        // Back up: the cursor walks this dialogue's blocks first, then returns
+        // to the end of the previous dialogue.
+        move_content_cursor(false, &mut rows, &mut scrolls, &mut cursor, (&[], &second));
+        assert_eq!(cursor.get(), Some(8), "down inside the second dialogue");
+        move_content_cursor(true, &mut rows, &mut scrolls, &mut cursor, (&[], &second));
+        assert_eq!(cursor.get(), Some(7));
+        assert_eq!(rows.dialogues.cursor(), 1, "still inside the second");
+        move_content_cursor(true, &mut rows, &mut scrolls, &mut cursor, (&[], &second));
+        assert_eq!(rows.dialogues.cursor(), 0, "off the top steps back");
+        cursor.clear();
+        cursor.land_crossing((&[], &first));
+        assert_eq!(cursor.get(), Some(0), "up lands on the last block");
+
+        // The list ends here: the step is refused and the cursor stays put.
+        move_content_cursor(true, &mut rows, &mut scrolls, &mut cursor, (&[], &first));
+        assert_eq!(rows.dialogues.cursor(), 0);
+        cursor.land_crossing((&[], &first));
+        assert_eq!(cursor.get(), Some(0));
     }
 
     #[test]

--- a/src/commands/browse/panes.rs
+++ b/src/commands/browse/panes.rs
@@ -367,9 +367,9 @@ pub struct ContentCtx<'a> {
 /// the per-dialogue block multi-select (native pane selection): clicking a
 /// block's dot toggles its id, and content (copy, fold) consumes the mask.
 /// Block ids are dialogue-global (input blocks first, output blocks after),
-/// so one mask per dialogue spans both halves. Marks are keyed by dialogue
-/// so multi-select paging (J/K) keeps every page's marks; the picker clears
-/// the whole set when the selection changes.
+/// so one mask per dialogue spans both halves. Marks are keyed by dialogue,
+/// so walking the content cursor into another dialogue keeps the marks left
+/// behind for as long as that dialogue still has a materialized body.
 ///
 /// Not a [`crate::pane::Pane`]: its rows are the shown dialogue's rendered
 /// lines, not a window over a growing list, so there is nothing to grow,
@@ -447,9 +447,15 @@ impl ContentPane {
             .toggle_ids(blocks);
     }
 
-    /// Drop every dialogue's marks (the set of markable dialogues changed).
-    pub fn clear_marks(&mut self) {
-        self.marked.clear();
+    /// Drop the marks of every dialogue `dialogues` no longer carries a body
+    /// for — the only ones a copy could read. A mark on any other index names
+    /// a dialogue that is gone.
+    pub fn retain_marks(&mut self, dialogues: &[WorkspaceDialogue]) {
+        self.marked.retain(|idx, _| {
+            dialogues
+                .get(*idx)
+                .is_some_and(|dialogue| dialogue.record.is_some())
+        });
     }
 
     pub fn marked_count(&self) -> usize {

--- a/src/commands/browse/panes.rs
+++ b/src/commands/browse/panes.rs
@@ -81,14 +81,11 @@ impl DialoguePane {
         if rows.is_empty() {
             return;
         }
-        let any = selected.iter().any(|s| *s);
         let focus = focus.min(rows.len() - 1);
         for (i, row) in rows.iter().enumerate() {
-            let need_body = if any {
-                selected.get(i).copied().unwrap_or(false)
-            } else {
-                i == focus
-            };
+            // The cursor dialogue's body is always needed: the content pane
+            // shows it even when the selection marks other dialogues.
+            let need_body = i == focus || selected.get(i).copied().unwrap_or(false);
             let item = if need_body {
                 if let Some(body) = row.body.clone() {
                     body

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -31,7 +31,7 @@ use super::help::{apply_workspace_help_action, set_focus, toggle_list_row, HelpD
 use super::load::{SessionColumn, SessionCtx, SourceLoadState};
 use super::nav::{
     dot_gutter_hit, invalidate_after_cursor_move, invalidate_panes_below, move_workspace_cursor,
-    open_link_target, row_list_index, shown_dialogue_idx, source_list_index, ContentBlockCursor,
+    open_link_target, row_list_index, source_list_index, ContentBlockCursor,
 };
 use super::panes::{ContentCtx, ContentPane, DialogueCtx, DialoguePane};
 use super::selection::refresh_next_level;
@@ -123,13 +123,6 @@ pub(crate) fn run(
     // (engine generation, selected mask, focused index) for the projection in
     // `dialogues`; unchanged redraws reuse it instead of re-cloning bodies.
     let mut dialogues_key: Option<(u64, Vec<bool>, usize)> = None;
-    // Multi-select paging: which selected dialogue the content pane shows
-    // (J/K flip the page); single selection always shows the focused row.
-    let mut content_page = 0usize;
-    // Which dialogues may currently own a mark: the selection mask, plus the
-    // shown row when nothing is selected. Marks drop when that set changes;
-    // they belong to their dialogue and survive page flips.
-    let mut markable_key: Option<(Vec<bool>, Option<usize>)> = None;
 
     loop {
         // ── Unified pane poll/ensure ───────────────────────────────────────
@@ -294,16 +287,14 @@ pub(crate) fn run(
         );
         if dialogues_key.as_ref() != Some(&materialize_key) {
             dialogue_pane.materialize_into(rows.dialogues.mask(), dialogue_idx, &mut dialogues);
+            // Marks are keyed by dialogue index, and only the dialogues the
+            // projection carries a body for can be copied from.
+            content_pane.retain_marks(&dialogues);
             dialogues_key = Some(materialize_key.clone());
         }
 
         if redraw {
             redraw = false;
-            // Multi-select pages through one selected dialogue at a time
-            // (J/K flips the page); single selection shows the focused row.
-            let selected = rows.dialogues.marked();
-            content_page = content_page.min(selected.saturating_sub(1));
-            let shown_idx = shown_dialogue_idx(&rows.dialogues, content_page);
             // List: title borrows. Content/copy: materialize (body only for focus∪select).
             let dialogue_titles: Vec<&str> = dialogue_pane.titles().collect();
 
@@ -322,16 +313,13 @@ pub(crate) fn run(
             if let Some((half, _)) = pending_half {
                 content_io_focus = half;
             }
-            // Expansion indices are per-dialogue; reset when the shown
-            // dialogue's identity, page flip, target, or selection changes.
-            let dialogue_identity = dialogues
-                .get(shown_idx)
-                .map(|dialogue| (dialogue.source.clone(), dialogue.work_ref.clone()));
+            // Fold state is per-dialogue: reset it when another dialogue — or
+            // another targeted part of it — comes on screen.
             let expand_key = (
-                dialogue_identity,
-                shown_idx,
+                dialogues
+                    .get(dialogue_idx)
+                    .map(|dialogue| (dialogue.source.clone(), dialogue.work_ref.clone())),
                 active_content_at,
-                rows.dialogues.mask().to_vec(),
             );
             if expanded_key.as_ref() != Some(&expand_key) {
                 expanded_blocks.clear();
@@ -344,26 +332,12 @@ pub(crate) fn run(
                 rows.close_range(WorkspaceFocus::Content);
                 expanded_key = Some(expand_key);
             }
-            // Marks are keyed by dialogue index, so they only stay meaningful
-            // while the set of dialogues that can own one is unchanged: the
-            // selection mask, or — with nothing selected — the focused row
-            // alone. Page flips inside a selection keep the marks so a later
-            // copy can join pages.
-            let marks_key = (
-                rows.dialogues.mask().to_vec(),
-                (selected == 0).then_some(shown_idx),
-            );
-            if markable_key.as_ref() != Some(&marks_key) {
-                content_pane.clear_marks();
-                markable_key = Some(marks_key);
-            }
             // Rebuild the content frame (texts + cached layouts) only when
             // the shown dialogue, mode, focus, target, expansion, or pane
             // size changed. Scroll events reuse the cached layouts — wheel
             // input never re-lays-out the text, so it stays responsive.
             let content_key = (
                 materialize_key.clone(),
-                shown_idx,
                 active_content_at,
                 content_mode,
                 content_io_focus,
@@ -373,7 +347,7 @@ pub(crate) fn run(
             if last_content_key.as_ref() != Some(&content_key) {
                 content_frame = content_pane.ensure(ContentCtx {
                     dialogues: &dialogues,
-                    highlighted_idx: shown_idx,
+                    highlighted_idx: dialogue_idx,
                     mode: content_mode,
                     target: active_content_at,
                     area: layout.content,
@@ -386,6 +360,9 @@ pub(crate) fn run(
                 );
                 last_content_key = Some(content_key);
             }
+            // A j/k step that walked off this dialogue's blocks moved the
+            // dialogue cursor instead; the blocks it arrived at exist now.
+            content_cursor.land_crossing(content_frame.texts.block_slices());
             // Cursor block resolved against the frame's displayed segments
             // once: the follow-scroll and the view highlight share it.
             let cursor_focus = content_cursor.focused(content_frame.texts.block_slices());
@@ -469,8 +446,7 @@ pub(crate) fn run(
                         content_range: rows
                             .range_start(WorkspaceFocus::Content)
                             .zip(content_cursor.get()),
-                        content_marked: content_pane.marked(shown_idx),
-                        content_page: (selected > 1).then_some((content_page, selected)),
+                        content_marked: content_pane.marked(dialogue_idx),
                         content_frame: &content_frame,
                     },
                 )
@@ -571,7 +547,7 @@ pub(crate) fn run(
                         content_mode,
                         active.scroll,
                         &dialogues,
-                        shown_dialogue_idx(&rows.dialogues, content_page),
+                        rows.dialogues.cursor(),
                     )? {
                         return Ok(picked);
                     }
@@ -674,7 +650,6 @@ pub(crate) fn run(
                                 &mut content_io_focus,
                                 &mut content_mode,
                                 &mut expanded_blocks,
-                                &mut content_page,
                                 &mut content_cursor,
                                 &mut content_pane,
                                 content_frame.texts.block_slices(),
@@ -766,11 +741,9 @@ pub(crate) fn run(
                     // Marked blocks take over the block-copy action: y joins
                     // every marked block's body instead of copying one block.
                     if action == WorkspaceHelpAction::CopyBlock && content_pane.marked_count() > 0 {
-                        if let Some(picked) = workspace_picked_content_for_marked_blocks(
-                            &dialogues,
-                            &rows.dialogues.active(),
-                            &content_pane,
-                        ) {
+                        if let Some(picked) =
+                            workspace_picked_content_for_marked_blocks(&dialogues, &content_pane)
+                        {
                             return Ok(picked);
                         }
                     }
@@ -784,7 +757,6 @@ pub(crate) fn run(
                         &mut content_io_focus,
                         &mut content_mode,
                         &mut expanded_blocks,
-                        &mut content_page,
                         &mut content_cursor,
                         &mut content_pane,
                         content_frame.texts.block_slices(),
@@ -884,11 +856,9 @@ pub(crate) fn run(
                                     WorkspaceFocus::Content,
                                 );
                                 content_cursor.set(block);
-                                // Dot marks belong to the shown dialogue
-                                // (multi-select pages one dialogue at a
-                                // time, so ids never repeat on screen).
-                                let shown = shown_dialogue_idx(&rows.dialogues, content_page);
-                                content_pane.toggle_mark(shown, block);
+                                // Dot marks belong to the dialogue on screen —
+                                // the one under the dialogue cursor.
+                                content_pane.toggle_mark(rows.dialogues.cursor(), block);
                                 continue;
                             }
                         }
@@ -1447,14 +1417,14 @@ mod tests {
         });
 
         // Nothing marked: the copy path yields None.
-        assert!(workspace_picked_content_for_marked_blocks(&dialogues, &[0], &pane).is_none());
+        assert!(workspace_picked_content_for_marked_blocks(&dialogues, &pane).is_none());
 
         // Mark the tool block (output half): copy joins the call + result
         // bodies. Ids are dialogue-global — the input user block is 0, so the
         // output pair is 1.
         pane.toggle_mark(0, 1);
-        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &[0], &pane)
-            .expect("marked copy");
+        let picked =
+            workspace_picked_content_for_marked_blocks(&dialogues, &pane).expect("marked copy");
         assert_eq!(picked.units.len(), 1);
         let text = &picked.units[0].plain;
         assert!(text.contains("$ ls"), "tool call body missing: {text}");
@@ -1469,8 +1439,8 @@ mod tests {
 
         // Mark the user block (input half): both marked blocks are joined.
         pane.toggle_mark(0, 0);
-        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &[0], &pane)
-            .expect("marked copy");
+        let picked =
+            workspace_picked_content_for_marked_blocks(&dialogues, &pane).expect("marked copy");
         let text = &picked.units[0].plain;
         assert!(text.contains("user text"));
         assert!(text.contains("$ ls"));
@@ -1536,8 +1506,8 @@ mod tests {
         // block is 0, the assistant reply 1, so the tool run is 2. Copy joins
         // the run's tool bodies, never the user or assistant blocks.
         pane.toggle_mark(0, 2);
-        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &[0], &pane)
-            .expect("marked copy");
+        let picked =
+            workspace_picked_content_for_marked_blocks(&dialogues, &pane).expect("marked copy");
         let text = &picked.units[0].plain;
         assert!(text.contains("cmd 0") && text.contains("cmd 2"), "{text}");
         assert!(
@@ -1621,7 +1591,7 @@ mod tests {
         let hit_id = hit_id.expect("a block is hit in the output half");
         pane.toggle_mark(0, hit_id);
 
-        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &[0], &pane)
+        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &pane)
             .expect("marked copy must not be None after a real dot hit");
         let text = &picked.units[0].plain;
         assert!(text.contains("cmd 0") && text.contains("cmd 2"), "{text}");
@@ -1756,7 +1726,7 @@ mod tests {
             expanded: &expanded,
         });
         pane.toggle_mark(0, 2);
-        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &[0], &pane)
+        let picked = workspace_picked_content_for_marked_blocks(&dialogues, &pane)
             .expect("marked member copy");
         let text = &picked.units[0].plain;
         assert!(text.contains("pat 0"), "first member missing: {text}");

--- a/src/tui/workspace/help.rs
+++ b/src/tui/workspace/help.rs
@@ -26,10 +26,6 @@ pub(crate) enum WorkspaceHelpAction {
     ToggleContentIo,
     /// Content half: expand/collapse the cursor block.
     ToggleBlockFold,
-    /// Multi-select paging: flip the content pane to the next selected dialogue.
-    NextDialoguePage,
-    /// Multi-select paging: flip the content pane to the previous selected dialogue.
-    PreviousDialoguePage,
     Copy,
     CopyInput,
     CopyOutput,
@@ -281,20 +277,6 @@ pub(crate) fn workspace_help_entries() -> &'static [WorkspaceHelpEntry] {
             description: "expand/collapse block",
             action: WorkspaceHelpAction::ToggleBlockFold,
             footer_label: Some("fold"),
-            footer_panes: CNT,
-        },
-        WorkspaceHelpEntry {
-            key: "J",
-            description: "next selected dialogue",
-            action: WorkspaceHelpAction::NextDialoguePage,
-            footer_label: Some("page"),
-            footer_panes: CNT,
-        },
-        WorkspaceHelpEntry {
-            key: "K",
-            description: "previous selected dialogue",
-            action: WorkspaceHelpAction::PreviousDialoguePage,
-            footer_label: Some("page"),
             footer_panes: CNT,
         },
         WorkspaceHelpEntry {

--- a/src/tui/workspace/model.rs
+++ b/src/tui/workspace/model.rs
@@ -390,9 +390,6 @@ pub(crate) struct WorkspaceView<'a> {
     /// owned by the content pane's native selection; consumed by the dot
     /// gutter and copy.
     pub(crate) content_marked: &'a [bool],
-    /// Multi-select paging `(current_page, page_count)` when several
-    /// dialogues are selected; the content pane shows one at a time.
-    pub(crate) content_page: Option<(usize, usize)>,
     /// Dual IO layout + display texts, computed once per redraw by the picker
     /// and shared with the renderer (no per-frame duplicate layout).
     pub(crate) content_frame: &'a ContentIoFrame,

--- a/src/tui/workspace/render.rs
+++ b/src/tui/workspace/render.rs
@@ -98,11 +98,6 @@ pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
         .filter(|search| search.scope == WorkspaceSearchScope::Content)
         .and(search_regex.as_ref());
     let title_suffix = content_title_suffix(dialogues_pane.marked(), current_ref.as_ref());
-    // Multi-select paging: `Input (read) · 2/3 : 3 dialogues selected`.
-    let page_label = view
-        .content_page
-        .map(|(page, total)| format!(" · {}/{}", page + 1, total))
-        .unwrap_or_default();
 
     for half in [ContentIoFocus::Input, ContentIoFocus::Output] {
         let area = frame_io.areas.area(half);
@@ -125,10 +120,7 @@ pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
             area,
             Panel::new(
                 WorkspaceFocus::Content.key(),
-                format!(
-                    "{half_title} ({}){page_label}{title_suffix}",
-                    view.content_mode.label()
-                ),
+                format!("{half_title} ({}){title_suffix}", view.content_mode.label()),
                 content_active && view.content_io_focus == half,
             ),
             frame_io.layout(half),


### PR DESCRIPTION
## Purpose
Make the content cursor traverse dialogues continuously in both directions.

## Changes
- Step from the first or last block into the adjacent dialogue instead of clamping.
- Let the content pane follow the dialogue cursor directly.
- Remove multi-select paging state and its duplicate help and redraw paths.

## Validation
Validated on the stack tip with `cargo build --target-dir target/build-check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p sivtr --lib`.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **User Experience**
  - Content cursor movement now continues across adjacent dialogues when pressing `j`/`k`.
  - Dialogue content remains available while selecting multiple items, with selections preserved when applicable.
  - Content panel titles no longer display paging information.

- **Keybindings**
  - Removed `J`/`K` shortcuts for paging between selected dialogues in multi-select mode.
  - Updated workspace navigation documentation and help text to reflect the revised behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->