### PR TITLE
refactor(browse): unify selection projections

### DIFF
--- a/src/commands/browse/content.rs
+++ b/src/commands/browse/content.rs
@@ -29,6 +29,7 @@ pub(crate) enum PickedContent {
         source: WorkspaceSource,
         set: WorkSet,
         projection: WorkspacePickProjection,
+        line_filter: Option<String>,
     },
     Text {
         source: WorkspaceSource,
@@ -60,7 +61,7 @@ pub(super) fn workspace_picked_content_for_copy(
     shortcut: WorkspaceCopyShortcut,
     line_filter: Option<&str>,
     target: Option<WorkAt>,
-    content_mode: ContentViewMode,
+    _content_mode: ContentViewMode,
 ) -> Result<PickedContent> {
     let source = picked_source(dialogues, picked).context("copy needs at least one dialogue")?;
     let display_target = (picked.len() == 1
@@ -81,43 +82,32 @@ pub(super) fn workspace_picked_content_for_copy(
         }
     }
     let projection = match shortcut {
-        WorkspaceCopyShortcut::Displayed if line_filter.is_none() && target.is_none() => {
-            Some(WorkspacePickProjection::Whole)
-        }
-        WorkspaceCopyShortcut::Input => Some(WorkspacePickProjection::Input),
-        WorkspaceCopyShortcut::Output => Some(WorkspacePickProjection::Output),
-        WorkspaceCopyShortcut::Command => Some(WorkspacePickProjection::Command),
-        WorkspaceCopyShortcut::Displayed => None,
+        WorkspaceCopyShortcut::Displayed if target.is_none() => WorkspacePickProjection::Whole,
+        WorkspaceCopyShortcut::Displayed => WorkspacePickProjection::Parts,
+        WorkspaceCopyShortcut::Input => WorkspacePickProjection::Input,
+        WorkspaceCopyShortcut::Output => WorkspacePickProjection::Output,
+        WorkspaceCopyShortcut::Command => WorkspacePickProjection::Command,
     };
-    if let Some(projection) = projection {
-        if line_filter.is_none() {
-            if !complete {
-                anyhow::bail!("structured copy needs materialized dialogues");
-            }
-            let cwd = std::env::current_dir().context("copy needs a current directory")?;
-            let mut set = WorkSet::with_anchors(cwd.display().to_string(), Vec::new(), Vec::new());
-            for record in records {
-                set.include_whole(record);
-            }
-            return Ok(PickedContent::WorkSet {
-                source,
-                set,
-                projection,
-            });
+    if !complete {
+        anyhow::bail!("structured copy needs materialized dialogues");
+    }
+    if let Some(spec) = line_filter {
+        filter_lines_by_spec(&crate::tui::workspace::TextPair::default(), spec)?;
+    }
+    let cwd = std::env::current_dir().context("copy needs a current directory")?;
+    let mut set = WorkSet::with_anchors(cwd.display().to_string(), Vec::new(), Vec::new());
+    for record in records {
+        match display_target {
+            Some(WorkAt::Part(seq)) => set.include_parts(record, [seq]),
+            _ => set.include_whole(record),
         }
     }
-    let units = picked
-        .iter()
-        .filter_map(|&idx| dialogues.get(idx))
-        .map(|dialogue| match shortcut {
-            WorkspaceCopyShortcut::Displayed => dialogue.display_unit(content_mode, display_target),
-            WorkspaceCopyShortcut::Input => dialogue.copy.input.clone(),
-            WorkspaceCopyShortcut::Output => dialogue.copy.output.clone(),
-            WorkspaceCopyShortcut::Command => dialogue.copy.command.clone(),
-        })
-        .collect();
-    let units = apply_workspace_line_filter(units, line_filter)?;
-    Ok(PickedContent::Text { source, units })
+    Ok(PickedContent::WorkSet {
+        source,
+        set,
+        projection,
+        line_filter: line_filter.map(str::to_string),
+    })
 }
 
 /// The Part subset of the canonical selection, attributed to its first
@@ -135,6 +125,7 @@ pub(super) fn workspace_picked_content_for_selected_parts(
         source,
         set,
         projection: WorkspacePickProjection::Parts,
+        line_filter: None,
     })
 }
 
@@ -155,6 +146,7 @@ pub(super) fn workspace_picked_content_for_cursor_block(
         source,
         set,
         projection: WorkspacePickProjection::Parts,
+        line_filter: None,
     }))
 }
 
@@ -196,20 +188,6 @@ fn find_block(block: &Block, id: usize) -> Option<&Block> {
 
 pub(super) fn line_filter_spec(line_filter: &str) -> Option<&str> {
     (!line_filter.is_empty()).then_some(line_filter)
-}
-
-pub(super) fn apply_workspace_line_filter(
-    units: Vec<crate::tui::workspace::TextPair>,
-    line_filter: Option<&str>,
-) -> Result<Vec<crate::tui::workspace::TextPair>> {
-    let Some(spec) = line_filter else {
-        return Ok(units);
-    };
-
-    units
-        .into_iter()
-        .map(|unit| filter_lines_by_spec(&unit, spec))
-        .collect()
 }
 
 pub(super) fn handle_line_filter_key(
@@ -307,7 +285,12 @@ pub(super) fn active_workspace_content_at(
 
 #[cfg(test)]
 pub(super) fn workspace_dialogue_vim_view(dialogue: &WorkspaceDialogue) -> VimView {
-    dialogue_text_vim_view(dialogue.content_text(ContentViewMode::Reading, None))
+    dialogue_text_vim_view(crate::tui::content::text::workspace_content_text(
+        std::slice::from_ref(dialogue),
+        0,
+        ContentViewMode::Reading,
+        None,
+    ))
 }
 
 pub(super) fn dialogue_text_vim_view(text: String) -> VimView {
@@ -332,7 +315,7 @@ pub(super) fn dialogue_text_vim_view(text: String) -> VimView {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tui::workspace::{WorkspaceCopyParts, WorkspaceSource};
+    use crate::tui::workspace::WorkspaceSource;
     use crate::workset::WorkSet;
     use sivtr_core::ai::AgentProvider;
     use sivtr_core::record::{
@@ -383,7 +366,6 @@ mod tests {
             source: WorkspaceSource::agent(AgentProvider::Codex),
             work_ref: Some(record.work_ref.clone()),
             record: Some(record),
-            copy: WorkspaceCopyParts::default(),
         }
     }
 

--- a/src/commands/browse/help.rs
+++ b/src/commands/browse/help.rs
@@ -14,13 +14,14 @@ use crate::tui::workspace::{
 use sivtr_core::record::WorkAt;
 
 use super::content::{
-    dialogue_text_vim_view, workspace_block_parts, workspace_picked_content_for_copy,
+    dialogue_text_vim_view, workspace_picked_content_for_copy,
     workspace_picked_content_for_cursor_block, PickedContent, WorkspaceCopyShortcut,
 };
 use super::nav::{invalidate_panes_below, move_workspace_cursor, ContentBlockCursor};
 use super::panes::ContentPane;
 use super::selection::{
-    select_sources, source_records, toggle_row_selection, WorkspaceSourceSelection,
+    apply_selection_action, select_sources, SelectionAction, SelectionContext,
+    WorkspaceSourceSelection,
 };
 use super::vim::open_vim_view;
 use super::PICK_CANCELLED_MESSAGE;
@@ -92,61 +93,26 @@ pub(super) fn apply_workspace_help_action(
                 set_focus(focus, fullscreen, rows, next_focus);
             }
         }
-        WorkspaceHelpAction::ToggleSelection => match *focus {
-            WorkspaceFocus::Content => {
-                // Pane-native selection: Space marks the focused block for
-                // batch copy, like Space toggles a list row. The content pane
-                // shows the dialogue under the dialogue cursor, so that row
-                // owns the mark.
-                if let Some(block) = content_cursor.get() {
-                    if let Some((_, record, parts)) =
-                        workspace_block_parts(dialogues, rows.dialogues.cursor(), block)
-                    {
-                        rows.selection.toggle_parts(record, parts);
-                    }
-                }
-            }
-            WorkspaceFocus::Dialogues => {
-                toggle_row_selection(
-                    *focus,
-                    rows.dialogues.cursor(),
+        WorkspaceHelpAction::ToggleSelection => {
+            if apply_selection_action(
+                SelectionAction::Toggle,
+                *focus,
+                SelectionContext {
                     rows,
                     sources,
                     sessions,
                     session_records,
                     dialogues,
-                );
-            }
-            WorkspaceFocus::Sessions => {
-                toggle_row_selection(
-                    *focus,
-                    rows.sessions.cursor(),
-                    rows,
-                    sources,
-                    sessions,
-                    session_records,
-                    dialogues,
-                );
-                if toggle_list_row(*focus, rows.sessions.cursor(), rows, content_scrolls) {
-                    return Ok(HelpDispatch::Refresh);
-                }
-            }
-            WorkspaceFocus::Source => {
-                let idx = rows.source.cursor();
-                toggle_row_selection(
-                    *focus,
-                    idx,
-                    rows,
-                    sources,
-                    sessions,
-                    session_records,
-                    dialogues,
-                );
+                    content_blocks: (content_blocks.0, content_blocks.1),
+                    content_cursor,
+                },
+            ) {
+                let idx = rows.pane(*focus).map_or(0, |pane| pane.cursor());
                 if toggle_list_row(*focus, idx, rows, content_scrolls) {
                     return Ok(HelpDispatch::Refresh);
                 }
             }
-        },
+        }
         WorkspaceHelpAction::SelectAgentSources | WorkspaceHelpAction::SelectTerminalSource => {
             select_sources(
                 sources,
@@ -160,108 +126,38 @@ pub(super) fn apply_workspace_help_action(
             invalidate_panes_below(WorkspaceFocus::Source, rows, content_scrolls);
             return Ok(HelpDispatch::Refresh);
         }
-        WorkspaceHelpAction::ToggleAll => match *focus {
-            WorkspaceFocus::Content => {
-                let dialogue_idx = rows.dialogues.cursor();
-                if let Some(record) = dialogues
-                    .get(dialogue_idx)
-                    .and_then(|dialogue| dialogue.record.as_ref())
-                {
-                    rows.selection.toggle_whole(record.clone());
-                }
+        WorkspaceHelpAction::ToggleAll => {
+            if apply_selection_action(
+                SelectionAction::ToggleAll,
+                *focus,
+                SelectionContext {
+                    rows,
+                    sources,
+                    sessions,
+                    session_records,
+                    dialogues,
+                    content_blocks: (content_blocks.0, content_blocks.1),
+                    content_cursor,
+                },
+            ) {
+                return Ok(HelpDispatch::Refresh);
             }
-            WorkspaceFocus::Dialogues => {
-                rows.selection.toggle_records(
-                    dialogues
-                        .iter()
-                        .filter_map(|dialogue| dialogue.record.clone())
-                        .collect(),
-                );
-            }
-            WorkspaceFocus::Sessions => {
-                rows.selection
-                    .toggle_records(session_records.iter().flatten().cloned().collect());
-                if let Some(list) = rows.pane_mut(WorkspaceFocus::Sessions) {
-                    list.toggle_all();
-                    rows.close_ranges();
-                    return Ok(HelpDispatch::Refresh);
-                }
-            }
-            WorkspaceFocus::Source => {
-                let records = (0..sources.len())
-                    .flat_map(|idx| source_records(sources, sessions, session_records, idx))
-                    .collect();
-                rows.selection.toggle_records(records);
-                if let Some(list) = rows.pane_mut(WorkspaceFocus::Source) {
-                    list.toggle_all();
-                    rows.close_ranges();
-                    return Ok(HelpDispatch::Refresh);
-                }
-            }
-        },
-        WorkspaceHelpAction::RangeSelect => match *focus {
-            WorkspaceFocus::Content => {
-                // The span covers block ids instead of list rows, and only
-                // visible blocks are in it: a folded run is one unit, and its
-                // header already carries every member's body.
-                if let Some(cursor_block) = content_cursor.get() {
-                    if let Some(span) = rows.range(*focus, cursor_block) {
-                        let mut record = None;
-                        let mut parts = Vec::new();
-                        for id in content_blocks
-                            .0
-                            .iter()
-                            .chain(content_blocks.1)
-                            .map(|block| block.id)
-                            .filter(|id| span.contains(id))
-                        {
-                            if let Some((_, selected, block_parts)) =
-                                workspace_block_parts(dialogues, rows.dialogues.cursor(), id)
-                            {
-                                record = Some(selected);
-                                parts.extend(block_parts);
-                            }
-                        }
-                        if let Some(record) = record {
-                            rows.selection.toggle_parts(record, parts);
-                        }
-                    }
-                }
-            }
-            WorkspaceFocus::Dialogues => {
-                if let Some(span) = rows.range(*focus, rows.dialogues.cursor()) {
-                    rows.selection.toggle_records(
-                        dialogues
-                            .iter()
-                            .enumerate()
-                            .filter(|(idx, _)| span.contains(idx))
-                            .filter_map(|(_, dialogue)| dialogue.record.clone())
-                            .collect(),
-                    );
-                }
-            }
-            WorkspaceFocus::Sessions => {
-                if let Some(span) = rows.range(*focus, rows.sessions.cursor()) {
-                    rows.selection.toggle_records(
-                        session_records
-                            .iter()
-                            .enumerate()
-                            .filter(|(idx, _)| span.contains(idx))
-                            .flat_map(|(_, records)| records.iter().cloned())
-                            .collect(),
-                    );
-                }
-            }
-            WorkspaceFocus::Source => {
-                if let Some(span) = rows.range(*focus, rows.source.cursor()) {
-                    let records = (0..sources.len())
-                        .filter(|idx| span.contains(idx))
-                        .flat_map(|idx| source_records(sources, sessions, session_records, idx))
-                        .collect();
-                    rows.selection.toggle_records(records);
-                }
-            }
-        },
+        }
+        WorkspaceHelpAction::RangeSelect => {
+            apply_selection_action(
+                SelectionAction::Range,
+                *focus,
+                SelectionContext {
+                    rows,
+                    sources,
+                    sessions,
+                    session_records,
+                    dialogues,
+                    content_blocks: (content_blocks.0, content_blocks.1),
+                    content_cursor,
+                },
+            );
+        }
         WorkspaceHelpAction::OpenVim if can_open_dialogue_vim(*focus, dialogue_count) => {
             let view = dialogue_text_vim_view(workspace_content_text(
                 dialogues,

--- a/src/commands/browse/help.rs
+++ b/src/commands/browse/help.rs
@@ -20,8 +20,7 @@ use super::content::{
 use super::nav::{invalidate_panes_below, move_workspace_cursor, ContentBlockCursor};
 use super::panes::ContentPane;
 use super::selection::{
-    select_sources, source_records, toggle_dialogue, toggle_session, toggle_source,
-    WorkspaceSourceSelection,
+    select_sources, source_records, toggle_row_selection, WorkspaceSourceSelection,
 };
 use super::vim::open_vim_view;
 use super::PICK_CANCELLED_MESSAGE;
@@ -108,17 +107,41 @@ pub(super) fn apply_workspace_help_action(
                 }
             }
             WorkspaceFocus::Dialogues => {
-                toggle_dialogue(rows, dialogues, rows.dialogues.cursor());
+                toggle_row_selection(
+                    *focus,
+                    rows.dialogues.cursor(),
+                    rows,
+                    sources,
+                    sessions,
+                    session_records,
+                    dialogues,
+                );
             }
             WorkspaceFocus::Sessions => {
-                toggle_session(rows, session_records, rows.sessions.cursor());
+                toggle_row_selection(
+                    *focus,
+                    rows.sessions.cursor(),
+                    rows,
+                    sources,
+                    sessions,
+                    session_records,
+                    dialogues,
+                );
                 if toggle_list_row(*focus, rows.sessions.cursor(), rows, content_scrolls) {
                     return Ok(HelpDispatch::Refresh);
                 }
             }
             WorkspaceFocus::Source => {
                 let idx = rows.source.cursor();
-                toggle_source(rows, sources, sessions, session_records, idx);
+                toggle_row_selection(
+                    *focus,
+                    idx,
+                    rows,
+                    sources,
+                    sessions,
+                    session_records,
+                    dialogues,
+                );
                 if toggle_list_row(*focus, idx, rows, content_scrolls) {
                     return Ok(HelpDispatch::Refresh);
                 }

--- a/src/commands/browse/load.rs
+++ b/src/commands/browse/load.rs
@@ -505,10 +505,10 @@ pub struct SessionColumn {
 
 /// One-frame context for session ensure.
 pub struct SessionCtx<'a> {
-    pub selected_sources: &'a [bool],
+    pub source_scope: &'a [bool],
     /// Merged sessions currently shown (for body keep mapping).
     pub sessions: &'a [WorkspaceSession],
-    pub selected_sessions: &'a [bool],
+    pub session_scope: &'a [bool],
     /// When true, skip meta growth (search filter owns the list).
     pub search_active: bool,
 }
@@ -572,19 +572,19 @@ impl Pane for SessionColumn {
 
     fn ensure(&mut self, ctx: SessionCtx<'_>, input: &PaneInput<'_>) {
         self.pump
-            .drop_unselected(ctx.selected_sources, &mut self.states);
+            .drop_unselected(ctx.source_scope, &mut self.states);
         if !ctx.search_active {
             if input.force {
                 self.pump.refresh_selected(
                     &self.sources,
-                    ctx.selected_sources,
+                    ctx.source_scope,
                     &mut self.states,
                     input.viewport,
                 );
             } else {
                 self.pump.kick(
                     &self.sources,
-                    ctx.selected_sources,
+                    ctx.source_scope,
                     &mut self.states,
                     input.viewport,
                     false,
@@ -595,7 +595,7 @@ impl Pane for SessionColumn {
             &self.sources,
             ctx.sessions,
             input.focus,
-            ctx.selected_sessions,
+            ctx.session_scope,
             input.neighbor_radius,
         );
         self.pump

--- a/src/commands/browse/panes.rs
+++ b/src/commands/browse/panes.rs
@@ -15,10 +15,7 @@ use crate::tui::workspace::{
     WorkspaceDialogue, WorkspaceSession, WorkspaceSource,
 };
 use crate::workset::WorkSet;
-use sivtr_core::ai::AgentSelection;
 use sivtr_core::record::{WorkAt, WorkRecord, WorkRef};
-
-use super::text::record_to_copy_parts;
 
 // ── Dialogues ───────────────────────────────────────────────────────────
 
@@ -143,12 +140,6 @@ fn shell_from_row(
         source: row.meta.source.clone(),
         work_ref: row.meta.work_ref.clone(),
         record: None,
-        copy: crate::tui::workspace::WorkspaceCopyParts::from_block(
-            crate::tui::workspace::TextPair {
-                plain: String::new(),
-                ansi: String::new(),
-            },
-        ),
     }
 }
 
@@ -245,7 +236,6 @@ fn dialogue_from_record(session: &WorkspaceSession, record: &WorkRecord) -> Work
         source: session.source.clone(),
         work_ref: Some(record.work_ref.clone()),
         record: Some(record.clone()),
-        copy: record_to_copy_parts(record, AgentSelection::LastTurn),
     }
 }
 

--- a/src/commands/browse/panes.rs
+++ b/src/commands/browse/panes.rs
@@ -151,7 +151,7 @@ fn shell_from_row(
 pub struct DialogueCtx<'a> {
     pub sessions: &'a [WorkspaceSession],
     pub session_idx: usize,
-    pub selected_sessions: &'a [bool],
+    pub session_scope: &'a [bool],
     /// Body lookup; returned slice lives as long as the storage behind the
     /// callback (`SessionColumn` / fixture table), not the `&session` arg.
     pub records: &'a dyn Fn(&WorkspaceSession) -> Option<&'a [WorkRecord]>,
@@ -164,7 +164,7 @@ impl Pane for DialoguePane {
         let next = fingerprint(
             ctx.sessions,
             ctx.session_idx,
-            ctx.selected_sessions,
+            ctx.session_scope,
             ctx.records,
         );
         let force = if next != self.fingerprint {
@@ -182,7 +182,7 @@ impl Pane for DialoguePane {
                 meta_prefix(
                     ctx.sessions,
                     ctx.session_idx,
-                    ctx.selected_sessions,
+                    ctx.session_scope,
                     ctx.records,
                     budget,
                 )
@@ -198,7 +198,7 @@ impl Pane for DialoguePane {
             let body = body_for_key(
                 ctx.sessions,
                 ctx.session_idx,
-                ctx.selected_sessions,
+                ctx.session_scope,
                 ctx.records,
                 key,
             );
@@ -508,7 +508,7 @@ mod tests {
             DialogueCtx {
                 sessions,
                 session_idx: 0,
-                selected_sessions: &[true],
+                session_scope: &[true],
                 records: &records,
             },
             &PaneInput::new(viewport, focus).with_selected(selected),
@@ -637,7 +637,7 @@ mod tests {
             DialogueCtx {
                 sessions: empty,
                 session_idx: 0,
-                selected_sessions: &[],
+                session_scope: &[],
                 records: &records,
             },
             &PaneInput::new(
@@ -704,7 +704,7 @@ mod tests {
                 DialogueCtx {
                     sessions: &sessions,
                     session_idx: 0,
-                    selected_sessions: &[false],
+                    session_scope: &[false],
                     records: &records,
                 },
                 &PaneInput::new(vp, 0).with_selected(&[false]),

--- a/src/commands/browse/perf.rs
+++ b/src/commands/browse/perf.rs
@@ -77,7 +77,7 @@ fn primed_dialogue_pane(n: usize) -> DialoguePane {
         DialogueCtx {
             sessions: &sessions,
             session_idx: 0,
-            selected_sessions: &selected_sessions,
+            session_scope: &selected_sessions,
             records: &records,
         },
         &PaneInput::new(vp, 0)
@@ -153,7 +153,7 @@ pub fn run_ensure_growth() -> (usize, usize) {
         DialogueCtx {
             sessions: &sessions,
             session_idx: 0,
-            selected_sessions: &selected_sessions,
+            session_scope: &selected_sessions,
             records: &records,
         },
         &PaneInput::new(
@@ -170,7 +170,7 @@ pub fn run_ensure_growth() -> (usize, usize) {
         DialogueCtx {
             sessions: &sessions,
             session_idx: 0,
-            selected_sessions: &selected_sessions,
+            session_scope: &selected_sessions,
             records: &records,
         },
         &PaneInput::new(

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -1296,14 +1296,15 @@ mod tests {
     use super::super::nav::move_workspace_cursor;
     use super::super::panes::{ContentCtx, ContentPane, DialogueCtx, DialoguePane};
     use crate::pane::{Pane, PaneInput, Viewport};
+    use crate::tui::content::text::workspace_content_text;
     use crate::tui::content::view::ContentViewMode;
     use crate::tui::search::{
         workspace_search_fingerprint, workspace_search_query, workspace_search_regex,
         WorkspaceSearchIndex, WorkspaceSearchMatch, WorkspaceSearchScope,
     };
     use crate::tui::workspace::{
-        ContentIoFocus, ContentScrolls, Rows, TextPair, WorkspaceCopyParts, WorkspaceDialogue,
-        WorkspaceFocus, WorkspaceSession, WorkspaceSource, WorkspaceSourceKind,
+        ContentIoFocus, ContentScrolls, Rows, TextPair, WorkspaceDialogue, WorkspaceFocus,
+        WorkspaceSession, WorkspaceSource, WorkspaceSourceKind,
     };
     use crossterm::event::{KeyCode, KeyModifiers};
     use sivtr_core::ai::AgentProvider;
@@ -1448,9 +1449,13 @@ mod tests {
             dialogues[0].record.as_ref().map(|r| r.title.as_str()),
             Some("o1")
         );
-        assert!(dialogues[0]
-            .content_text(ContentViewMode::Reading, None)
-            .contains("old:o1"));
+        assert!(workspace_content_text(
+            std::slice::from_ref(&dialogues[0]),
+            0,
+            ContentViewMode::Reading,
+            None,
+        )
+        .contains("old:o1"));
         assert_eq!(
             dialogues[0].work_ref.as_ref().unwrap().to_string(),
             "claude/test/1"
@@ -1482,7 +1487,14 @@ mod tests {
         assert_eq!(titles, [Some("c1"), Some("c2"), Some("a1")]);
         let texts: Vec<_> = dialogues
             .iter()
-            .map(|dialogue| dialogue.content_text(ContentViewMode::Reading, None))
+            .map(|dialogue| {
+                workspace_content_text(
+                    std::slice::from_ref(dialogue),
+                    0,
+                    ContentViewMode::Reading,
+                    None,
+                )
+            })
             .collect();
         assert!(texts[0].contains("codex session:c1"));
         assert!(texts[1].contains("codex session:c2"));
@@ -1538,7 +1550,6 @@ mod tests {
             source: WorkspaceSource::agent(AgentProvider::Codex),
             work_ref: Some(record.work_ref.clone()),
             record: Some(record.clone()),
-            copy: WorkspaceCopyParts::default(),
         };
         let dialogues = [dialogue.clone()];
         let mut selection = crate::workset::WorkSet::new(".", Vec::new());
@@ -1607,7 +1618,6 @@ mod tests {
             source: WorkspaceSource::agent(AgentProvider::Codex),
             work_ref: Some(record.work_ref.clone()),
             record: Some(record.clone()),
-            copy: WorkspaceCopyParts::default(),
         };
         let dialogues = [dialogue.clone()];
         let mut pane = ContentPane::default();
@@ -1696,7 +1706,6 @@ mod tests {
             source: WorkspaceSource::agent(AgentProvider::Codex),
             work_ref: Some(record.work_ref.clone()),
             record: Some(record.clone()),
-            copy: WorkspaceCopyParts::default(),
         };
         let dialogues = [dialogue.clone()];
 
@@ -1755,7 +1764,6 @@ mod tests {
             source: WorkspaceSource::agent(AgentProvider::Codex),
             work_ref: Some(record.work_ref.clone()),
             record: Some(record.clone()),
-            copy: WorkspaceCopyParts::default(),
         };
         let dialogues = [dialogue.clone()];
 
@@ -1809,7 +1817,6 @@ mod tests {
             source: WorkspaceSource::agent(AgentProvider::Codex),
             work_ref: Some(record.work_ref.clone()),
             record: Some(record.clone()),
-            copy: WorkspaceCopyParts::default(),
         };
         let dialogues = [dialogue.clone()];
 
@@ -2275,17 +2282,6 @@ mod tests {
                 "question",
                 0,
             )),
-            copy: WorkspaceCopyParts {
-                input: TextPair {
-                    plain: "question".to_string(),
-                    ansi: String::new(),
-                },
-                output: TextPair {
-                    plain: "answer".to_string(),
-                    ansi: String::new(),
-                },
-                command: TextPair::default(),
-            },
         }];
 
         let input = workspace_picked_content_for_copy(
@@ -2330,20 +2326,6 @@ mod tests {
             "line 1\nline 2\nline 3",
             0,
         )];
-        // Override structured copy parts for input shortcut filtering.
-        let mut dialogues = dialogues;
-        dialogues[0].copy = WorkspaceCopyParts {
-            input: TextPair {
-                plain: "ask 1\nask 2\nask 3".to_string(),
-                ansi: String::new(),
-            },
-            output: TextPair {
-                plain: "answer 1\nanswer 2\nanswer 3".to_string(),
-                ansi: String::new(),
-            },
-            command: TextPair::default(),
-        };
-
         let displayed = workspace_picked_content_for_copy(
             &dialogues,
             &[0],
@@ -2365,7 +2347,7 @@ mod tests {
 
         // Displayed text is Reading-mode render of parts; filter applies to that text.
         assert!(picked_units(&displayed)[0].plain.lines().count() >= 1);
-        assert_eq!(picked_units(&input)[0].plain, "ask 1\nask 3");
+        assert_eq!(picked_units(&input)[0].plain, "line 1\nline 3");
     }
 
     #[test]
@@ -2463,20 +2445,6 @@ mod tests {
                 "cargo test",
                 0,
             )),
-            copy: WorkspaceCopyParts {
-                input: TextPair {
-                    plain: "PS C:\\repo> cargo test".to_string(),
-                    ansi: String::new(),
-                },
-                output: TextPair {
-                    plain: "ok".to_string(),
-                    ansi: String::new(),
-                },
-                command: TextPair {
-                    plain: "cargo test".to_string(),
-                    ansi: "cargo test".to_string(),
-                },
-            },
         }];
 
         let picked = workspace_picked_content_for_copy(
@@ -2504,7 +2472,12 @@ mod tests {
 
         let view = workspace_dialogue_vim_view(&dialogue);
         // Reading mode wraps dialogue with headings/markers — count lines from that render.
-        let expected = dialogue.content_text(ContentViewMode::Reading, None);
+        let expected = workspace_content_text(
+            std::slice::from_ref(&dialogue),
+            0,
+            ContentViewMode::Reading,
+            None,
+        );
         assert_eq!(view.raw, expected);
         assert_eq!(view.blocks.len(), 1);
         assert_eq!(view.blocks[0].start, 1);
@@ -2535,10 +2508,6 @@ mod tests {
             source: WorkspaceSource::agent(AgentProvider::Codex),
             work_ref: Some(WorkRef::agent(AgentProvider::Codex, "session", 1)),
             record: Some(record),
-            copy: WorkspaceCopyParts::from_block(TextPair {
-                plain: "visible text".to_string(),
-                ansi: String::new(),
-            }),
         }];
 
         let picked = workspace_picked_content_for_copy(
@@ -2551,9 +2520,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(picked_units(&picked)[0].plain.trim(), "<:tool:tool call:>");
-        // Displayed copy uses Reading mode: fold marker only, no payload.
-        assert!(!picked_units(&picked)[0].plain.contains("hidden cargo test"));
+        assert!(picked_units(&picked)[0].plain.contains("hidden cargo test"));
         assert!(!picked_units(&picked)[0].plain.contains("codex/"));
     }
 
@@ -2635,16 +2602,10 @@ mod tests {
             plain,
             index,
         );
-        let pair = crate::commands::browse::text::record_text_to_pair(record.copy_text(
-            sivtr_core::record::RecordTextMode::Combined,
-            false,
-            None,
-        ));
         WorkspaceDialogue {
             source: WorkspaceSource::agent(AgentProvider::Codex),
             work_ref: Some(record.work_ref.clone()),
             record: Some(record),
-            copy: WorkspaceCopyParts::from_block(pair),
         }
     }
 }

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -16,10 +16,11 @@ use crate::tui::search::{
 };
 use crate::tui::terminal::read_interaction;
 use crate::tui::workspace::{
-    help_action_for_key, panel_inner_rows, render_workspace, search_match_half, selected_index,
-    workspace_help_entries, workspace_hit_test, workspace_layout, ContentIoFocus, ContentIoFrame,
-    ContentScrolls, ExpandedBlocks, ListPane, Rows, WorkspaceDialogue, WorkspaceFocus,
-    WorkspaceHelpAction, WorkspaceSearchView, WorkspaceSession, WorkspaceSource, WorkspaceView,
+    active_rows, help_action_for_key, panel_inner_rows, render_workspace, search_match_half,
+    selected_index, workspace_help_entries, workspace_hit_test, workspace_layout, ContentIoFocus,
+    ContentIoFrame, ContentScrolls, ExpandedBlocks, ListPane, Rows, WorkspaceDialogue,
+    WorkspaceFocus, WorkspaceHelpAction, WorkspaceSearchView, WorkspaceSession, WorkspaceSource,
+    WorkspaceView,
 };
 
 use super::content::{
@@ -34,9 +35,7 @@ use super::nav::{
     open_link_target, row_list_index, source_list_index, ContentBlockCursor,
 };
 use super::panes::{ContentCtx, ContentPane, DialogueCtx, DialoguePane};
-use super::selection::{
-    refresh_next_level, selected_dialogues, toggle_dialogue, toggle_session, toggle_source,
-};
+use super::selection::{refresh_next_level, resolve_loaded_scopes, source_records};
 use super::visual::{
     apply_workspace_mouse_scroll, handle_content_mouse_select, handle_visual_select_key,
     MouseSelectionStart, VisualContentContext, VisualSelectMode, MOUSE_SCROLL_LINES,
@@ -62,16 +61,16 @@ pub(crate) fn run(
     terminal: &mut crate::tui::terminal::Tui,
     sources: Vec<WorkspaceSource>,
     source_states: Vec<SourceLoadState>,
-    selected_sources: Vec<bool>,
+    source_scope: Vec<bool>,
     cwd: PathBuf,
     initial_focus: WorkspaceFocus,
 ) -> Result<PickedContent> {
-    debug_assert_eq!(sources.len(), selected_sources.len());
+    debug_assert_eq!(sources.len(), source_scope.len());
     debug_assert_eq!(sources.len(), source_states.len());
     // One cursor + mark set + range anchor per list pane. The source presets
     // arrive as a mask, so that pane starts from it.
     let mut rows = Rows::default();
-    rows.source = ListPane::with_marks(selected_sources);
+    rows.source = ListPane::with_marks(source_scope);
     let mut help_state = ListState::default();
     help_state.select(Some(0));
     let mut focus = initial_focus;
@@ -225,9 +224,9 @@ pub(crate) fn run(
 
         sessions_pane.ensure(
             SessionCtx {
-                selected_sources: rows.source.mask(),
+                source_scope: rows.source.mask(),
                 sessions: &sessions,
-                selected_sessions: rows.sessions.mask(),
+                session_scope: rows.sessions.mask(),
                 search_active: search_has_query,
             },
             &PaneInput::new(
@@ -237,6 +236,7 @@ pub(crate) fn run(
             .with_selected(rows.sessions.mask())
             .with_neighbors(1),
         );
+        resolve_loaded_scopes(&mut rows, &sources, &sessions, &sessions_pane);
         let dialogue_focus_hint = pending_match
             .as_ref()
             .map(|matched| matched.dialogue_index)
@@ -250,7 +250,7 @@ pub(crate) fn run(
             DialogueCtx {
                 sessions: &sessions,
                 session_idx,
-                selected_sessions: rows.sessions.mask(),
+                session_scope: rows.sessions.mask(),
                 records: &records,
             },
             &PaneInput::new(dialogue_viewport, dialogue_focus_hint)
@@ -265,7 +265,7 @@ pub(crate) fn run(
                 DialogueCtx {
                     sessions: &sessions,
                     session_idx,
-                    selected_sessions: rows.sessions.mask(),
+                    session_scope: rows.sessions.mask(),
                     records: &records,
                 },
                 &PaneInput::new(
@@ -285,7 +285,7 @@ pub(crate) fn run(
             DialogueCtx {
                 sessions: &sessions,
                 session_idx,
-                selected_sessions: rows.sessions.mask(),
+                session_scope: rows.sessions.mask(),
                 records: &records,
             },
             &PaneInput::new(dialogue_viewport, dialogue_idx)
@@ -669,7 +669,7 @@ pub(crate) fn run(
                             let action = workspace_help_entries()[idx].action;
                             show_help = false;
                             let selected_dialogues =
-                                selected_dialogues(&dialogue_selection, dialogue_idx);
+                                active_rows(&dialogue_selection, dialogue_idx, dialogue_count);
                             let session_records = if matches!(
                                 action,
                                 WorkspaceHelpAction::ToggleSelection
@@ -810,7 +810,8 @@ pub(crate) fn run(
                             return Ok(picked);
                         }
                     }
-                    let selected_dialogues = selected_dialogues(&dialogue_selection, dialogue_idx);
+                    let selected_dialogues =
+                        active_rows(&dialogue_selection, dialogue_idx, dialogue_count);
                     let session_records = if matches!(
                         action,
                         WorkspaceHelpAction::ToggleSelection
@@ -1134,13 +1135,12 @@ pub(crate) fn run(
                                         if vertical && dot_gutter_hit(layout.source, mouse.column) {
                                             let session_records =
                                                 session_record_snapshot(&sessions, &sessions_pane);
-                                            toggle_source(
-                                                &mut rows,
+                                            rows.selection.toggle_records(source_records(
                                                 &sources,
                                                 &sessions,
                                                 &session_records,
                                                 idx,
-                                            );
+                                            ));
                                             if toggle_list_row(
                                                 WorkspaceFocus::Source,
                                                 idx,
@@ -1169,7 +1169,9 @@ pub(crate) fn run(
                                         if dot_gutter_hit(layout.sessions, mouse.column) {
                                             let session_records =
                                                 session_record_snapshot(&sessions, &sessions_pane);
-                                            toggle_session(&mut rows, &session_records, idx);
+                                            if let Some(records) = session_records.get(idx) {
+                                                rows.selection.toggle_records(records.clone());
+                                            }
                                             toggle_list_row(
                                                 WorkspaceFocus::Sessions,
                                                 idx,
@@ -1193,7 +1195,12 @@ pub(crate) fn run(
                                             &mut content_scrolls,
                                         );
                                         if dot_gutter_hit(layout.dialogues, mouse.column) {
-                                            toggle_dialogue(&mut rows, &dialogues, idx);
+                                            if let Some(record) = dialogues
+                                                .get(idx)
+                                                .and_then(|dialogue| dialogue.record.clone())
+                                            {
+                                                rows.selection.toggle_whole(record);
+                                            }
                                             invalidate_after_cursor_move(
                                                 WorkspaceFocus::Dialogues,
                                                 &mut rows,
@@ -1376,7 +1383,7 @@ mod tests {
     fn dialogues_for_test(
         sessions: &[WorkspaceSession],
         session_idx: usize,
-        selected_sessions: &[bool],
+        session_scope: &[bool],
     ) -> Vec<WorkspaceDialogue> {
         let mut pane = DialoguePane::default();
         let records = |s: &WorkspaceSession| {
@@ -1400,7 +1407,7 @@ mod tests {
             DialogueCtx {
                 sessions,
                 session_idx,
-                selected_sessions,
+                session_scope,
                 records: &records,
             },
             &PaneInput::new(vp, 0)
@@ -1413,7 +1420,7 @@ mod tests {
             DialogueCtx {
                 sessions,
                 session_idx,
-                selected_sessions,
+                session_scope,
                 records: &records,
             },
             &PaneInput::new(vp, 0)

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -35,7 +35,7 @@ use super::nav::{
     open_link_target, row_list_index, source_list_index, ContentBlockCursor,
 };
 use super::panes::{ContentCtx, ContentPane, DialogueCtx, DialoguePane};
-use super::selection::{refresh_next_level, resolve_loaded_scopes, source_records};
+use super::selection::{refresh_next_level, resolve_loaded_scopes, toggle_row_selection};
 use super::visual::{
     apply_workspace_mouse_scroll, handle_content_mouse_select, handle_visual_select_key,
     MouseSelectionStart, VisualContentContext, VisualSelectMode, MOUSE_SCROLL_LINES,
@@ -1135,12 +1135,15 @@ pub(crate) fn run(
                                         if vertical && dot_gutter_hit(layout.source, mouse.column) {
                                             let session_records =
                                                 session_record_snapshot(&sessions, &sessions_pane);
-                                            rows.selection.toggle_records(source_records(
+                                            toggle_row_selection(
+                                                WorkspaceFocus::Source,
+                                                idx,
+                                                &mut rows,
                                                 &sources,
                                                 &sessions,
                                                 &session_records,
-                                                idx,
-                                            ));
+                                                &dialogues,
+                                            );
                                             if toggle_list_row(
                                                 WorkspaceFocus::Source,
                                                 idx,
@@ -1169,9 +1172,15 @@ pub(crate) fn run(
                                         if dot_gutter_hit(layout.sessions, mouse.column) {
                                             let session_records =
                                                 session_record_snapshot(&sessions, &sessions_pane);
-                                            if let Some(records) = session_records.get(idx) {
-                                                rows.selection.toggle_records(records.clone());
-                                            }
+                                            toggle_row_selection(
+                                                WorkspaceFocus::Sessions,
+                                                idx,
+                                                &mut rows,
+                                                &sources,
+                                                &sessions,
+                                                &session_records,
+                                                &dialogues,
+                                            );
                                             toggle_list_row(
                                                 WorkspaceFocus::Sessions,
                                                 idx,
@@ -1195,12 +1204,15 @@ pub(crate) fn run(
                                             &mut content_scrolls,
                                         );
                                         if dot_gutter_hit(layout.dialogues, mouse.column) {
-                                            if let Some(record) = dialogues
-                                                .get(idx)
-                                                .and_then(|dialogue| dialogue.record.clone())
-                                            {
-                                                rows.selection.toggle_whole(record);
-                                            }
+                                            toggle_row_selection(
+                                                WorkspaceFocus::Dialogues,
+                                                idx,
+                                                &mut rows,
+                                                &sources,
+                                                &sessions,
+                                                &[],
+                                                &dialogues,
+                                            );
                                             invalidate_after_cursor_move(
                                                 WorkspaceFocus::Dialogues,
                                                 &mut rows,

--- a/src/commands/browse/selection.rs
+++ b/src/commands/browse/selection.rs
@@ -4,7 +4,7 @@
 //! [`crate::tui::workspace::active_rows`]). `R` reloads the next hierarchy
 //! level under those rows.
 
-use crate::tui::workspace::{active_rows, Rows, WorkspaceFocus, WorkspaceSession, WorkspaceSource};
+use crate::tui::workspace::{Rows, WorkspaceFocus, WorkspaceSession, WorkspaceSource};
 
 use super::load::SessionColumn;
 use crate::pane::Viewport;
@@ -88,34 +88,6 @@ pub(super) fn select_sources(
     }
 }
 
-/// The dialogue rows currently selected by the canonical WorkSet.
-pub(super) fn selected_dialogues(mask: &[bool], cursor: usize) -> Vec<usize> {
-    active_rows(mask, cursor, mask.len())
-}
-
-pub(super) fn toggle_dialogue(
-    rows: &mut Rows,
-    dialogues: &[crate::tui::workspace::WorkspaceDialogue],
-    idx: usize,
-) {
-    if let Some(record) = dialogues
-        .get(idx)
-        .and_then(|dialogue| dialogue.record.clone())
-    {
-        rows.selection.toggle_whole(record);
-    }
-}
-
-pub(super) fn toggle_session(
-    rows: &mut Rows,
-    session_records: &[Vec<sivtr_core::record::WorkRecord>],
-    idx: usize,
-) {
-    if let Some(records) = session_records.get(idx) {
-        rows.selection.toggle_records(records.clone());
-    }
-}
-
 pub(super) fn source_records(
     sources: &[WorkspaceSource],
     sessions: &[WorkspaceSession],
@@ -133,17 +105,30 @@ pub(super) fn source_records(
         .collect()
 }
 
-pub(super) fn toggle_source(
+/// Materialize records covered by marked source/session scopes. Scope masks
+/// drive loading; once bodies arrive, the canonical WorkSet owns the choice.
+pub(super) fn resolve_loaded_scopes(
     rows: &mut Rows,
     sources: &[WorkspaceSource],
     sessions: &[WorkspaceSession],
-    session_records: &[Vec<sivtr_core::record::WorkRecord>],
-    source_idx: usize,
+    sessions_pane: &SessionColumn,
 ) {
-    rows.selection.toggle_records(source_records(
-        sources,
-        sessions,
-        session_records,
-        source_idx,
-    ));
+    for (session_idx, session) in sessions.iter().enumerate() {
+        let source_idx = sources.iter().position(|source| source == &session.source);
+        let source_marked = source_idx
+            .and_then(|idx| rows.source.mask().get(idx))
+            .copied()
+            .unwrap_or(false);
+        let session_marked = rows
+            .sessions
+            .mask()
+            .get(session_idx)
+            .copied()
+            .unwrap_or(false);
+        if source_marked || session_marked {
+            if let Some(records) = sessions_pane.body_for(session) {
+                rows.selection.include_records(records.iter().cloned());
+            }
+        }
+    }
 }

--- a/src/commands/browse/selection.rs
+++ b/src/commands/browse/selection.rs
@@ -4,6 +4,7 @@
 //! [`crate::tui::workspace::active_rows`]). `R` reloads the next hierarchy
 //! level under those rows.
 
+use crate::tui::content::block::BlockText;
 use crate::tui::workspace::{
     Rows, WorkspaceDialogue, WorkspaceFocus, WorkspaceSession, WorkspaceSource,
 };
@@ -135,6 +136,172 @@ pub(super) fn toggle_row_selection(
             }
         }
         WorkspaceFocus::Content => {}
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum SelectionAction {
+    Toggle,
+    ToggleAll,
+    Range,
+}
+
+pub(super) struct SelectionContext<'a> {
+    pub(super) rows: &'a mut Rows,
+    pub(super) sources: &'a [WorkspaceSource],
+    pub(super) sessions: &'a [WorkspaceSession],
+    pub(super) session_records: &'a [Vec<sivtr_core::record::WorkRecord>],
+    pub(super) dialogues: &'a [WorkspaceDialogue],
+    pub(super) content_blocks: (&'a [BlockText], &'a [BlockText]),
+    pub(super) content_cursor: &'a mut super::nav::ContentBlockCursor,
+}
+
+pub(super) fn apply_selection_action(
+    action: SelectionAction,
+    focus: WorkspaceFocus,
+    context: SelectionContext<'_>,
+) -> bool {
+    let SelectionContext {
+        rows,
+        sources,
+        sessions,
+        session_records,
+        dialogues,
+        content_blocks,
+        content_cursor,
+    } = context;
+    match action {
+        SelectionAction::Toggle => {
+            if focus == WorkspaceFocus::Content {
+                if let Some(block) = content_cursor.get() {
+                    if let Some((_, record, parts)) = super::content::workspace_block_parts(
+                        dialogues,
+                        rows.dialogues.cursor(),
+                        block,
+                    ) {
+                        rows.selection.toggle_parts(record, parts);
+                    }
+                }
+                return false;
+            }
+            let idx = rows.pane(focus).map_or(0, |pane| pane.cursor());
+            toggle_row_selection(
+                focus,
+                idx,
+                rows,
+                sources,
+                sessions,
+                session_records,
+                dialogues,
+            );
+            matches!(focus, WorkspaceFocus::Source | WorkspaceFocus::Sessions)
+        }
+        SelectionAction::ToggleAll => {
+            match focus {
+                WorkspaceFocus::Content => {
+                    if let Some(record) = dialogues
+                        .get(rows.dialogues.cursor())
+                        .and_then(|dialogue| dialogue.record.as_ref())
+                    {
+                        rows.selection.toggle_whole(record.clone());
+                    }
+                }
+                WorkspaceFocus::Dialogues => rows.selection.toggle_records(
+                    dialogues
+                        .iter()
+                        .filter_map(|dialogue| dialogue.record.clone())
+                        .collect(),
+                ),
+                WorkspaceFocus::Sessions => rows
+                    .selection
+                    .toggle_records(session_records.iter().flatten().cloned().collect()),
+                WorkspaceFocus::Source => rows.selection.toggle_records(
+                    (0..sources.len())
+                        .flat_map(|idx| source_records(sources, sessions, session_records, idx))
+                        .collect(),
+                ),
+            }
+            if matches!(focus, WorkspaceFocus::Source | WorkspaceFocus::Sessions) {
+                if let Some(list) = rows.pane_mut(focus) {
+                    list.toggle_all();
+                    rows.close_ranges();
+                    return true;
+                }
+            }
+            false
+        }
+        SelectionAction::Range => {
+            match focus {
+                WorkspaceFocus::Content => {
+                    let Some(cursor_block) = content_cursor.get() else {
+                        return false;
+                    };
+                    let Some(span) = rows.range(focus, cursor_block) else {
+                        return false;
+                    };
+                    let mut record = None;
+                    let mut parts = Vec::new();
+                    for id in content_blocks
+                        .0
+                        .iter()
+                        .chain(content_blocks.1)
+                        .map(|block| block.id)
+                        .filter(|id| span.contains(id))
+                    {
+                        if let Some((_, selected, block_parts)) =
+                            super::content::workspace_block_parts(
+                                dialogues,
+                                rows.dialogues.cursor(),
+                                id,
+                            )
+                        {
+                            record = Some(selected);
+                            parts.extend(block_parts);
+                        }
+                    }
+                    if let Some(record) = record {
+                        rows.selection.toggle_parts(record, parts);
+                    }
+                }
+                WorkspaceFocus::Dialogues => {
+                    if let Some(span) = rows.range(focus, rows.dialogues.cursor()) {
+                        rows.selection.toggle_records(
+                            dialogues
+                                .iter()
+                                .enumerate()
+                                .filter(|(idx, _)| span.contains(idx))
+                                .filter_map(|(_, dialogue)| dialogue.record.clone())
+                                .collect(),
+                        );
+                    }
+                }
+                WorkspaceFocus::Sessions => {
+                    if let Some(span) = rows.range(focus, rows.sessions.cursor()) {
+                        rows.selection.toggle_records(
+                            session_records
+                                .iter()
+                                .enumerate()
+                                .filter(|(idx, _)| span.contains(idx))
+                                .flat_map(|(_, records)| records.iter().cloned())
+                                .collect(),
+                        );
+                    }
+                }
+                WorkspaceFocus::Source => {
+                    if let Some(span) = rows.range(focus, rows.source.cursor()) {
+                        rows.selection.toggle_records(
+                            (0..sources.len())
+                                .filter(|idx| span.contains(idx))
+                                .flat_map(|idx| {
+                                    source_records(sources, sessions, session_records, idx)
+                                })
+                                .collect(),
+                        );
+                    }
+                }
+            }
+            false
+        }
     }
 }
 

--- a/src/commands/browse/selection.rs
+++ b/src/commands/browse/selection.rs
@@ -4,7 +4,9 @@
 //! [`crate::tui::workspace::active_rows`]). `R` reloads the next hierarchy
 //! level under those rows.
 
-use crate::tui::workspace::{Rows, WorkspaceFocus, WorkspaceSession, WorkspaceSource};
+use crate::tui::workspace::{
+    Rows, WorkspaceDialogue, WorkspaceFocus, WorkspaceSession, WorkspaceSource,
+};
 
 use super::load::SessionColumn;
 use crate::pane::Viewport;
@@ -103,6 +105,37 @@ pub(super) fn source_records(
         .filter(|(_, session)| &session.source == source)
         .flat_map(|(idx, _)| session_records.get(idx).into_iter().flatten().cloned())
         .collect()
+}
+
+pub(super) fn toggle_row_selection(
+    focus: WorkspaceFocus,
+    idx: usize,
+    rows: &mut Rows,
+    sources: &[WorkspaceSource],
+    sessions: &[WorkspaceSession],
+    session_records: &[Vec<sivtr_core::record::WorkRecord>],
+    dialogues: &[WorkspaceDialogue],
+) {
+    match focus {
+        WorkspaceFocus::Source => {
+            rows.selection
+                .toggle_records(source_records(sources, sessions, session_records, idx))
+        }
+        WorkspaceFocus::Sessions => {
+            if let Some(records) = session_records.get(idx) {
+                rows.selection.toggle_records(records.clone());
+            }
+        }
+        WorkspaceFocus::Dialogues => {
+            if let Some(record) = dialogues
+                .get(idx)
+                .and_then(|dialogue| dialogue.record.clone())
+            {
+                rows.selection.toggle_whole(record);
+            }
+        }
+        WorkspaceFocus::Content => {}
+    }
 }
 
 /// Materialize records covered by marked source/session scopes. Scope masks

--- a/src/commands/browse/text.rs
+++ b/src/commands/browse/text.rs
@@ -1,10 +1,9 @@
 //! Text helpers shared by the browser (line filters, record → copy parts).
 
 use anyhow::{Context, Result};
-use sivtr_core::ai::AgentSelection;
-use sivtr_core::record::{RecordTextMode, WorkRecord};
+use sivtr_core::record::RecordText;
 
-use crate::tui::workspace::{TextPair, WorkspaceCopyParts};
+use crate::tui::workspace::TextPair;
 
 pub fn filter_lines_by_spec(text: &TextPair, spec: &str) -> Result<TextPair> {
     let lines: Vec<&str> = text.plain.lines().collect();
@@ -72,32 +71,10 @@ fn parse_line_number(value: &str) -> Result<usize> {
     })
 }
 
-pub fn record_to_copy_parts(
-    record: &WorkRecord,
-    selection_mode: AgentSelection,
-) -> WorkspaceCopyParts {
-    match selection_mode {
-        AgentSelection::LastBlocks(_) | AgentSelection::All => WorkspaceCopyParts::from_block(
-            record_text_to_pair(record.copy_text(RecordTextMode::Combined, false, None)),
-        ),
-        _ => WorkspaceCopyParts::from(record.copy_parts(false)),
-    }
-}
-
-pub fn record_text_to_pair(text: sivtr_core::record::RecordText) -> TextPair {
+pub fn record_text_to_pair(text: RecordText) -> TextPair {
     let ansi = text.ansi.unwrap_or_else(|| text.plain.clone());
     TextPair {
         plain: text.plain,
         ansi,
-    }
-}
-
-impl From<sivtr_core::record::WorkRecordCopyParts> for WorkspaceCopyParts {
-    fn from(parts: sivtr_core::record::WorkRecordCopyParts) -> Self {
-        WorkspaceCopyParts {
-            input: record_text_to_pair(parts.input),
-            output: record_text_to_pair(parts.output),
-            command: record_text_to_pair(parts.command),
-        }
     }
 }

--- a/src/commands/memory/copy/export.rs
+++ b/src/commands/memory/copy/export.rs
@@ -44,6 +44,7 @@ pub(crate) fn picked_units(picked: &PickedContent) -> Result<(Vec<TextPair>, Str
             source,
             set,
             projection,
+            line_filter,
         } => {
             let projection = match projection {
                 WorkspacePickProjection::Whole => super::plan::Projection::Both,
@@ -75,7 +76,11 @@ pub(crate) fn picked_units(picked: &PickedContent) -> Result<(Vec<TextPair>, Str
                     } else {
                         projection
                     };
-                    super::project::project_record(record, projection, None)
+                    let unit = super::project::project_record(record, projection, None)?;
+                    match line_filter.as_deref() {
+                        Some(filter) => filter_lines_by_spec(&unit, filter),
+                        None => Ok(unit),
+                    }
                 })
                 .collect::<Result<Vec<_>>>()?;
             Ok((units, source.label()))
@@ -210,6 +215,7 @@ mod tests {
             source: WorkspaceSource::terminal(),
             set: WorkSet::with_anchors("current", vec![record.clone()], vec![record.work_ref]),
             projection: WorkspacePickProjection::Command,
+            line_filter: None,
         };
 
         let (units, label) = picked_units(&picked).expect("projects workset");

--- a/src/commands/memory/var.rs
+++ b/src/commands/memory/var.rs
@@ -115,9 +115,7 @@ fn stdin_is_piped() -> bool {
     !io::stdin().is_terminal()
 }
 
-fn merge_sets(mut base: WorkSet, mut addition: WorkSet) -> WorkSet {
-    base.ensure_anchors();
-    addition.ensure_anchors();
+fn merge_sets(base: WorkSet, addition: WorkSet) -> WorkSet {
     let mut records_by_ref = records_by_ref(base.records);
     for record in addition.records {
         records_by_ref
@@ -132,8 +130,7 @@ fn merge_sets(mut base: WorkSet, mut addition: WorkSet) -> WorkSet {
     WorkSet::with_anchors(base.cwd, records, anchors)
 }
 
-fn remove_anchors(mut base: WorkSet, remove: &HashSet<String>) -> WorkSet {
-    base.ensure_anchors();
+fn remove_anchors(base: WorkSet, remove: &HashSet<String>) -> WorkSet {
     let records_by_ref = records_by_ref(base.records);
     let anchors = unique_anchors(
         base.anchors
@@ -145,8 +142,7 @@ fn remove_anchors(mut base: WorkSet, remove: &HashSet<String>) -> WorkSet {
     WorkSet::with_anchors(base.cwd, records, anchors)
 }
 
-fn dedup(mut set: WorkSet) -> WorkSet {
-    set.ensure_anchors();
+fn dedup(set: WorkSet) -> WorkSet {
     let records_by_ref = records_by_ref(set.records);
     let anchors = unique_anchors(set.anchors);
     let records = records_for_unique_anchors(records_by_ref, &anchors);

--- a/src/commands/memory/workset/mod.rs
+++ b/src/commands/memory/workset/mod.rs
@@ -15,7 +15,6 @@ use std::path::Path;
 pub use crate::workset::{WorkSet, WORKSET_SCHEMA_VERSION};
 
 fn apply_selection(mut set: WorkSet, selection: WorkSetSelection) -> WorkSet {
-    set.ensure_anchors();
     let WorkSetSelection::Indices(indices) = selection else {
         return set;
     };
@@ -89,7 +88,6 @@ impl WorkSet {
     pub fn save_as(&mut self, name: &str) -> Result<()> {
         store::validate_name(name)?;
         self.materialize_parts()?;
-        self.ensure_anchors();
         self.name = Some(name.to_string());
         save_named(name, self)
     }
@@ -97,7 +95,6 @@ impl WorkSet {
     pub fn save_last(&self) -> Result<()> {
         let mut set = self.clone();
         set.materialize_parts()?;
-        set.ensure_anchors();
         save_named("last", &set)
     }
 }
@@ -241,14 +238,16 @@ mod tests {
             time: WorkTime::default(),
             status: None,
             title: format!("record {index}"),
-            parts: vec![WorkPart {
-                seq: 1,
-                occurred_at: None,
-                data: sivtr_core::record::WorkPartData::Output {
-                    content: format!("record {index}"),
-                    ansi: None,
-                },
-            }],
+            parts: (1..=2)
+                .map(|seq| WorkPart {
+                    seq,
+                    occurred_at: None,
+                    data: sivtr_core::record::WorkPartData::Output {
+                        content: format!("record {index} part {seq}"),
+                        ansi: None,
+                    },
+                })
+                .collect(),
         }
     }
 
@@ -316,6 +315,15 @@ mod tests {
         let mut set = WorkSet::new(".", Vec::new());
         set.include_parts(first.clone(), [1, 1]);
         assert_eq!(set.anchors(), vec![first.work_ref.with_part(1)]);
+    }
+
+    #[test]
+    fn complete_part_selection_is_canonical_whole() {
+        let first = record(1);
+        let mut set = WorkSet::new(".", Vec::new());
+        set.include_parts(first.clone(), [1, 2, 1]);
+        assert_eq!(set.anchors(), vec![first.work_ref.whole()]);
+        assert!(set.contains(&first.work_ref.with_part(2)));
     }
 
     #[test]

--- a/src/commands/memory/workset/source.rs
+++ b/src/commands/memory/workset/source.rs
@@ -560,9 +560,8 @@ fn read_stdin() -> Result<WorkSet> {
     io::stdin()
         .read_to_string(&mut input)
         .context("Failed to read WorkSet from stdin")?;
-    let mut set: WorkSet =
+    let set: WorkSet =
         serde_json::from_str(&input).context("Failed to parse WorkSet from stdin")?;
-    set.ensure_anchors();
     Ok(set)
 }
 

--- a/src/commands/memory/workset/store.rs
+++ b/src/commands/memory/workset/store.rs
@@ -19,9 +19,8 @@ pub fn load_saved(name: &str) -> Result<WorkSet> {
     let path = set_path(name)?;
     let content = fs::read_to_string(&path)
         .with_context(|| format!("Failed to read WorkSet @{name} from {}", path.display()))?;
-    let mut set: WorkSet = serde_json::from_str(&content)
+    let set: WorkSet = serde_json::from_str(&content)
         .with_context(|| format!("Failed to parse WorkSet @{name} from {}", path.display()))?;
-    set.ensure_anchors();
     Ok(set)
 }
 

--- a/src/tui/workspace/model.rs
+++ b/src/tui/workspace/model.rs
@@ -174,23 +174,6 @@ pub(crate) struct TextPair {
     pub(crate) ansi: String,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub(crate) struct WorkspaceCopyParts {
-    pub(crate) input: TextPair,
-    pub(crate) output: TextPair,
-    pub(crate) command: TextPair,
-}
-
-impl WorkspaceCopyParts {
-    pub(crate) fn from_block(block: TextPair) -> Self {
-        Self {
-            input: block.clone(),
-            output: block,
-            command: TextPair::default(),
-        }
-    }
-}
-
 #[derive(Clone, Debug)]
 pub(crate) struct WorkspaceSession {
     pub(crate) source: WorkspaceSource,
@@ -210,25 +193,9 @@ pub(crate) struct WorkspaceDialogue {
     pub(crate) source: WorkspaceSource,
     pub(crate) work_ref: Option<WorkRef>,
     pub(crate) record: Option<WorkRecord>,
-    pub(crate) copy: WorkspaceCopyParts,
 }
 
 impl WorkspaceDialogue {
-    /// Text used for copy shortcuts / vim on the currently displayed content.
-    /// Always derived from `record.parts` when present — never a stale cache.
-    pub(crate) fn display_unit(&self, mode: ContentViewMode, target: Option<WorkAt>) -> TextPair {
-        let plain = self.content_text(mode, target);
-        TextPair {
-            ansi: plain.clone(),
-            plain,
-        }
-    }
-
-    pub(crate) fn content_text(&self, mode: ContentViewMode, target: Option<WorkAt>) -> String {
-        self.content_io_texts(mode, target, &ExpandedBlocks::default())
-            .join_displayed()
-    }
-
     /// Input / Output bodies for the dual content panes with per-block fold
     /// state (every workpart is a block; structure blocks fold by default in
     /// read mode).

--- a/src/tui/workspace/tests.rs
+++ b/src/tui/workspace/tests.rs
@@ -2,9 +2,7 @@
 
 use super::help::{help_action_for_key, parse_help_key, WorkspaceHelpAction};
 use super::layout::can_open_dialogue_vim;
-use super::model::{
-    WorkspaceCopyParts, WorkspaceDialogue, WorkspaceFocus, WorkspaceSearchView, WorkspaceSource,
-};
+use super::model::{WorkspaceDialogue, WorkspaceFocus, WorkspaceSearchView, WorkspaceSource};
 use super::render::{
     content_title, current_content_dialogue, current_content_ref, line_filter_prompt_text,
     search_box_body, search_box_title,
@@ -55,7 +53,6 @@ fn codex_dialogue(record: WorkRecord) -> WorkspaceDialogue {
         source: WorkspaceSource::agent(AgentProvider::Codex),
         work_ref: Some(record.work_ref.clone()),
         record: Some(record),
-        copy: WorkspaceCopyParts::default(),
     }
 }
 
@@ -586,13 +583,11 @@ fn current_content_dialogue_uses_single_selected_dialogue() {
             source: WorkspaceSource::agent(AgentProvider::Codex),
             work_ref: Some(WorkRef::agent(AgentProvider::Codex, "session", 1)),
             record: None,
-            copy: WorkspaceCopyParts::default(),
         },
         WorkspaceDialogue {
             source: WorkspaceSource::agent(AgentProvider::Codex),
             work_ref: Some(WorkRef::agent(AgentProvider::Codex, "session", 2)),
             record: None,
-            copy: WorkspaceCopyParts::default(),
         },
     ];
 
@@ -610,7 +605,6 @@ fn current_content_ref_round_trips_active_part_target() {
         source: WorkspaceSource::agent(AgentProvider::Codex),
         work_ref: Some(WorkRef::agent(AgentProvider::Codex, "session", 2)),
         record: None,
-        copy: WorkspaceCopyParts::default(),
     }];
 
     let current = current_content_ref(&dialogues, &[false], 0, Some(WorkAt::Part(1))).unwrap();

--- a/src/workset.rs
+++ b/src/workset.rs
@@ -49,7 +49,7 @@ impl WorkSet {
     /// Whether this selection covers an address. A Whole anchor covers every
     /// Part of the same record.
     pub fn contains(&self, anchor: &WorkRef) -> bool {
-        self.anchors().iter().any(|selected| {
+        self.anchors.iter().any(|selected| {
             selected == anchor
                 || (selected.at == WorkAt::Whole && selected.whole() == anchor.whole())
         })

--- a/src/workset.rs
+++ b/src/workset.rs
@@ -15,7 +15,6 @@ pub struct WorkSet {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     pub records: Vec<WorkRecord>,
-    #[serde(default)]
     pub anchors: Vec<WorkRef>,
 }
 
@@ -43,19 +42,8 @@ impl WorkSet {
         }
     }
 
-    pub fn ensure_anchors(&mut self) {
-        self.anchors = self.anchors();
-    }
-
     pub fn anchors(&self) -> Vec<WorkRef> {
-        if self.anchors.is_empty() {
-            self.records
-                .iter()
-                .map(|record| record.work_ref.whole())
-                .collect()
-        } else {
-            self.anchors.clone()
-        }
+        self.anchors.clone()
     }
 
     /// Whether this selection covers an address. A Whole anchor covers every
@@ -77,10 +65,28 @@ impl WorkSet {
         self.anchors.push(whole);
     }
 
+    pub fn include_records(&mut self, records: impl IntoIterator<Item = WorkRecord>) {
+        for record in records {
+            let whole = record.work_ref.whole();
+            if !self
+                .anchors
+                .iter()
+                .any(|anchor| anchor.at == WorkAt::Whole && anchor.whole() == whole)
+            {
+                self.include_whole(record);
+            }
+        }
+    }
+
     /// Include selected parts of a record. A Whole anchor already covers them
     /// and remains the only stored representation.
     pub fn include_parts(&mut self, record: WorkRecord, parts: impl IntoIterator<Item = usize>) {
+        let parts: Vec<_> = parts.into_iter().collect();
         let whole = record.work_ref.whole();
+        if !record.parts.is_empty() && record.parts.iter().all(|part| parts.contains(&part.seq)) {
+            self.include_whole(record);
+            return;
+        }
         if self
             .anchors()
             .iter()
@@ -121,6 +127,10 @@ impl WorkSet {
     pub fn toggle_parts(&mut self, record: WorkRecord, parts: impl IntoIterator<Item = usize>) {
         let parts: Vec<_> = parts.into_iter().collect();
         if parts.is_empty() {
+            return;
+        }
+        if !record.parts.is_empty() && record.parts.iter().all(|part| parts.contains(&part.seq)) {
+            self.toggle_whole(record);
             return;
         }
         if parts


### PR DESCRIPTION
## Purpose
Unify selection projections at the WorkSet boundary.

## Changes
- Preserve canonical Whole/Part anchors through copy and selection actions.
- Route source, session, and dialogue projections through shared targets.
- Remove duplicate picker selection plumbing.

## Validation
Validated on the stack tip with `cargo build --target-dir target/build-check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p sivtr --lib`.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent selection controls across sources, sessions, dialogues, and content, including toggle, select-all, and range selection.
  - Added support for selecting and copying specific content parts with optional line filtering.
  - Added bulk inclusion of records in saved selections.
- **Bug Fixes**
  - Improved workspace content rendering and copying to use current dialogue data.
  - Preserved selection anchors when importing or loading saved worksets.
  - Selecting all parts of a record now correctly represents the complete record.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->