### PR TITLE
refactor(browse): finalize pane state

### DIFF
--- a/src/commands/browse/content.rs
+++ b/src/commands/browse/content.rs
@@ -95,7 +95,7 @@ pub(super) fn workspace_picked_content_for_copy(
         filter_lines_by_spec(&crate::tui::workspace::TextPair::default(), spec)?;
     }
     let cwd = std::env::current_dir().context("copy needs a current directory")?;
-    let mut set = WorkSet::with_anchors(cwd.display().to_string(), Vec::new(), Vec::new());
+    let mut set = WorkSet::from_parts(cwd.display().to_string(), Vec::new(), Vec::new());
     for record in records {
         match display_target {
             Some(WorkAt::Part(seq)) => set.include_parts(record, [seq]),
@@ -140,7 +140,7 @@ pub(super) fn workspace_picked_content_for_cursor_block(
         return Ok(None);
     };
     let cwd = std::env::current_dir().context("copy needs a current directory")?;
-    let mut set = WorkSet::with_anchors(cwd.display().to_string(), Vec::new(), Vec::new());
+    let mut set = WorkSet::from_parts(cwd.display().to_string(), Vec::new(), Vec::new());
     set.include_parts(record, parts);
     Ok(Some(PickedContent::WorkSet {
         source,

--- a/src/commands/browse/content.rs
+++ b/src/commands/browse/content.rs
@@ -117,7 +117,7 @@ pub(super) fn workspace_picked_content_for_selected_parts(
     dialogues: &[WorkspaceDialogue],
 ) -> Option<PickedContent> {
     let set = selection.parts_only()?;
-    let anchor = set.anchors.first()?;
+    let anchor = set.anchors().first()?;
     let source = dialogues.iter().find_map(|dialogue| {
         (dialogue.work_ref.as_ref()?.whole() == anchor.whole()).then(|| dialogue.source.clone())
     })?;

--- a/src/commands/browse/help.rs
+++ b/src/commands/browse/help.rs
@@ -107,7 +107,7 @@ pub(super) fn apply_workspace_help_action(
                     content_cursor,
                 },
             ) {
-                let idx = rows.pane(*focus).map_or(0, |pane| pane.cursor());
+                let idx = rows.scope_pane(*focus).map_or(0, |pane| pane.cursor());
                 if toggle_list_row(*focus, idx, rows, content_scrolls) {
                     return Ok(HelpDispatch::Refresh);
                 }
@@ -116,7 +116,7 @@ pub(super) fn apply_workspace_help_action(
         WorkspaceHelpAction::SelectAgentSources | WorkspaceHelpAction::SelectTerminalSource => {
             select_sources(
                 sources,
-                rows.source.mask_mut(),
+                rows.source.scope_mask_mut(),
                 if action == WorkspaceHelpAction::SelectAgentSources {
                     WorkspaceSourceSelection::Agents
                 } else {
@@ -352,10 +352,10 @@ pub(super) fn toggle_list_row(
     rows: &mut Rows,
     content_scrolls: &mut ContentScrolls,
 ) -> bool {
-    let Some(pane) = rows.pane_mut(focus) else {
+    let Some(pane) = rows.scope_pane_mut(focus) else {
         return false;
     };
-    pane.toggle(idx);
+    pane.toggle_scope(idx);
     rows.close_ranges();
     invalidate_panes_below(focus, rows, content_scrolls)
 }

--- a/src/commands/browse/load.rs
+++ b/src/commands/browse/load.rs
@@ -305,8 +305,9 @@ impl SourceLoadPump {
                 ) {
                     Ok(mut results) => match results.pop() {
                         Some(QuerySourceResult::Ok(set)) => {
-                            let n = set.records.len();
-                            let mut sessions = sessions_from_records(&source, set.records);
+                            let n = set.records().len();
+                            let mut sessions =
+                                sessions_from_records(&source, set.records().to_vec());
                             for s in &mut sessions {
                                 s.records.clear();
                                 s.body_loaded = false;
@@ -362,7 +363,8 @@ impl SourceLoadPump {
                     Ok(mut results) => match results.pop() {
                         Some(QuerySourceResult::Ok(mut set)) => match set.materialize_parts() {
                             Ok(()) => {
-                                let mut sessions = sessions_from_records(&source, set.records);
+                                let mut sessions =
+                                    sessions_from_records(&source, set.records().to_vec());
                                 for s in &mut sessions {
                                     s.body_loaded = !s.records.is_empty();
                                 }

--- a/src/commands/browse/load.rs
+++ b/src/commands/browse/load.rs
@@ -181,13 +181,15 @@ impl SourceLoadPump {
     pub fn kick(
         &mut self,
         sources: &[WorkspaceSource],
-        selected: &[bool],
+        source_scope: &[bool],
         states: &mut [SourceLoadState],
         viewport: Viewport,
         force: bool,
     ) {
+        assert_eq!(sources.len(), source_scope.len());
+        assert_eq!(sources.len(), states.len());
         for (idx, source) in sources.iter().enumerate() {
-            if !selected.get(idx).copied().unwrap_or(false) {
+            if !source_scope[idx] {
                 continue;
             }
             let need: Option<MetaNeed> = if force {
@@ -204,12 +206,14 @@ impl SourceLoadPump {
     pub fn refresh_selected(
         &mut self,
         sources: &[WorkspaceSource],
-        selected: &[bool],
+        source_scope: &[bool],
         states: &mut [SourceLoadState],
         viewport: Viewport,
     ) {
+        assert_eq!(sources.len(), source_scope.len());
+        assert_eq!(sources.len(), states.len());
         for (idx, source) in sources.iter().enumerate() {
-            if !selected.get(idx).copied().unwrap_or(false) {
+            if !source_scope[idx] {
                 continue;
             }
             // An explicit refresh is a retry: drop recorded body failures so
@@ -229,6 +233,7 @@ impl SourceLoadPump {
         states: &mut [SourceLoadState],
         keep: &HashSet<(usize, String)>,
     ) {
+        assert_eq!(sources.len(), states.len());
         self.body_wanted.clone_from(keep);
         for (source_idx, state) in states.iter_mut().enumerate() {
             let keep_local: HashSet<String> = keep
@@ -237,9 +242,7 @@ impl SourceLoadPump {
                 .map(|(_, id)| id.clone())
                 .collect();
             let missing = state.pane.ensure_bodies(keep_local);
-            let Some(source) = sources.get(source_idx) else {
-                continue;
-            };
+            let source = &sources[source_idx];
             for session_id in missing {
                 if self.body_inflight.len() >= BODY_FETCH_CAP {
                     return;
@@ -254,23 +257,20 @@ impl SourceLoadPump {
         }
     }
 
-    pub fn drop_unselected(&mut self, selected: &[bool], states: &mut [SourceLoadState]) {
-        for (idx, sel) in selected.iter().enumerate() {
+    pub fn drop_unselected(&mut self, source_scope: &[bool], states: &mut [SourceLoadState]) {
+        assert_eq!(source_scope.len(), states.len());
+        for (idx, sel) in source_scope.iter().enumerate() {
             if *sel {
                 continue;
             }
-            if let Some(state) = states.get_mut(idx) {
-                state.pane.clear();
-            }
+            states[idx].pane.clear();
             self.body_inflight
                 .retain(|k| !k.starts_with(&format!("{idx}\0")));
             self.body_failed
                 .retain(|k, _| !k.starts_with(&format!("{idx}\0")));
             // Invalidate body jobs spawned for this source: their results
             // must not touch the state of a later re-selection.
-            if let Some(gen) = self.body_generation.get_mut(idx) {
-                *gen = gen.saturating_add(1);
-            }
+            self.body_generation[idx] = self.body_generation[idx].saturating_add(1);
         }
     }
 
@@ -532,9 +532,9 @@ impl SessionColumn {
         self.states.iter().map(SourceLoadState::marker).collect()
     }
 
-    pub fn collect(&self, selected: &[bool]) -> Vec<WorkspaceSession> {
+    pub fn collect(&self, source_scope: &[bool]) -> Vec<WorkspaceSession> {
         // Meta-only list projection — bodies stay in SlidingPane.
-        collect_ready_sessions(&self.sources, selected, &self.states)
+        collect_ready_sessions(&self.sources, source_scope, &self.states)
     }
 
     /// Records for a session if loaded (source resolved via session.source).
@@ -551,15 +551,20 @@ impl SessionColumn {
     }
 
     /// Bootstrap / force-load selected sources.
-    pub fn kick(&mut self, selected: &[bool], viewport: Viewport, force: bool) {
-        self.pump
-            .kick(&self.sources, selected, &mut self.states, viewport, force);
+    pub fn kick(&mut self, source_scope: &[bool], viewport: Viewport, force: bool) {
+        self.pump.kick(
+            &self.sources,
+            source_scope,
+            &mut self.states,
+            viewport,
+            force,
+        );
     }
 
     /// `R` reload of given source mask.
-    pub fn refresh(&mut self, selected: &[bool], viewport: Viewport) {
+    pub fn refresh(&mut self, source_scope: &[bool], viewport: Viewport) {
         self.pump
-            .refresh_selected(&self.sources, selected, &mut self.states, viewport);
+            .refresh_selected(&self.sources, source_scope, &mut self.states, viewport);
     }
 }
 
@@ -668,12 +673,14 @@ pub fn workspace_source_catalog(
 /// Meta-only merge of ready sources (bodies remain in each source pane).
 pub fn collect_ready_sessions(
     sources: &[WorkspaceSource],
-    selected: &[bool],
+    source_scope: &[bool],
     states: &[SourceLoadState],
 ) -> Vec<WorkspaceSession> {
+    assert_eq!(sources.len(), source_scope.len());
+    assert_eq!(sources.len(), states.len());
     let mut sessions = Vec::new();
     for (idx, _) in sources.iter().enumerate() {
-        if !selected.get(idx).copied().unwrap_or(false) {
+        if !source_scope[idx] {
             continue;
         }
         sessions.extend(states[idx].visible_session_metas());
@@ -815,8 +822,8 @@ mod tests {
                 body_loaded: false,
             },
         ];
-        let selected = [false, false, false];
-        let keep = body_keep_set(&sources, &sessions, 1, &selected, 1);
+        let session_scope = [false, false, false];
+        let keep = body_keep_set(&sources, &sessions, 1, &session_scope, 1);
         assert!(keep.contains(&(0, "a".into())));
         assert!(keep.contains(&(0, "b".into())));
         assert!(keep.contains(&(0, "c".into())));

--- a/src/commands/browse/mod.rs
+++ b/src/commands/browse/mod.rs
@@ -71,7 +71,7 @@ fn run_catalog(
         anyhow::bail!("No terminal or AI sources configured");
     }
 
-    let selected_sources: Vec<bool> = sources
+    let source_scope: Vec<bool> = sources
         .iter()
         .map(|source| select_remotes || !source.is_remote())
         .collect();
@@ -83,7 +83,7 @@ fn run_catalog(
         &mut terminal,
         sources,
         source_states,
-        selected_sources,
+        source_scope,
         cwd,
         initial_focus,
         wait_after_panic,
@@ -127,7 +127,7 @@ fn run_picker_guarded(
     terminal: &mut crate::tui::terminal::Tui,
     sources: Vec<WorkspaceSource>,
     source_states: Vec<SourceLoadState>,
-    selected_sources: Vec<bool>,
+    source_scope: Vec<bool>,
     cwd: std::path::PathBuf,
     initial_focus: WorkspaceFocus,
     wait_after_panic: bool,
@@ -140,7 +140,7 @@ fn run_picker_guarded(
             terminal,
             sources,
             source_states,
-            selected_sources,
+            source_scope,
             cwd,
             initial_focus,
         )

--- a/src/commands/browse/nav.rs
+++ b/src/commands/browse/nav.rs
@@ -162,7 +162,14 @@ pub(super) fn move_workspace_cursor(
         move_content_cursor(up, rows, content_scrolls, content_cursor, content_blocks);
         return;
     }
-    if rows.pane_mut(focus).is_some_and(|pane| pane.step(up)) {
+    let moved = match focus {
+        WorkspaceFocus::Dialogues => rows.dialogues.step(up),
+        WorkspaceFocus::Source | WorkspaceFocus::Sessions => {
+            rows.pane_mut(focus).is_some_and(|pane| pane.step(up))
+        }
+        WorkspaceFocus::Content => false,
+    };
+    if moved {
         invalidate_after_cursor_move(focus, rows, content_scrolls);
     }
 }
@@ -272,7 +279,7 @@ pub(super) fn source_list_index(
 mod tests {
     use super::{move_content_cursor, row_list_index, ContentBlockCursor};
     use crate::tui::content::block::BlockText;
-    use crate::tui::workspace::{ContentScrolls, ListPane, Rows};
+    use crate::tui::workspace::{ContentScrolls, CursorPane, Rows};
     use ratatui::layout::Rect;
     use sivtr_core::record::WorkPartKind;
 
@@ -294,7 +301,7 @@ mod tests {
     #[test]
     fn a_step_off_the_last_block_crosses_into_the_next_dialogue() {
         let mut rows = Rows::default();
-        rows.dialogues = ListPane::with_marks(vec![false, false]);
+        rows.dialogues = CursorPane::new(2);
         let mut scrolls = ContentScrolls::default();
         let mut cursor = ContentBlockCursor::default();
         let first = blocks(&[0]);

--- a/src/commands/browse/nav.rs
+++ b/src/commands/browse/nav.rs
@@ -133,7 +133,7 @@ pub(super) fn invalidate_after_cursor_move(
         WorkspaceFocus::Sessions => {
             // The dialogue list spans every marked session, so it only
             // follows the cursor row while nothing is marked.
-            if !rows.sessions.has_marks() {
+            if !rows.sessions.has_scope() {
                 rows.dialogues.reset(0);
             }
             content_scrolls.clear();
@@ -165,7 +165,7 @@ pub(super) fn move_workspace_cursor(
     let moved = match focus {
         WorkspaceFocus::Dialogues => rows.dialogues.step(up),
         WorkspaceFocus::Source | WorkspaceFocus::Sessions => {
-            rows.pane_mut(focus).is_some_and(|pane| pane.step(up))
+            rows.scope_pane_mut(focus).is_some_and(|pane| pane.step(up))
         }
         WorkspaceFocus::Content => false,
     };
@@ -279,7 +279,7 @@ pub(super) fn source_list_index(
 mod tests {
     use super::{move_content_cursor, row_list_index, ContentBlockCursor};
     use crate::tui::content::block::BlockText;
-    use crate::tui::workspace::{ContentScrolls, CursorPane, Rows};
+    use crate::tui::workspace::{ContentScrolls, RowCursor, Rows};
     use ratatui::layout::Rect;
     use sivtr_core::record::WorkPartKind;
 
@@ -301,7 +301,7 @@ mod tests {
     #[test]
     fn a_step_off_the_last_block_crosses_into_the_next_dialogue() {
         let mut rows = Rows::default();
-        rows.dialogues = CursorPane::new(2);
+        rows.dialogues = RowCursor::new(2);
         let mut scrolls = ContentScrolls::default();
         let mut cursor = ContentBlockCursor::default();
         let first = blocks(&[0]);

--- a/src/commands/browse/panes.rs
+++ b/src/commands/browse/panes.rs
@@ -80,7 +80,7 @@ impl DialoguePane {
     }
 
     /// Rebuild `out` from the engine rows. Callers cache `out` between calls
-    /// and only invoke this when `generation()`, the selected mask, or the
+    /// and only invoke this when `generation()`, the dialogue selection, or the
     /// focused index changed, so scrolling content does not re-clone bodies.
     pub fn materialize_into(
         &self,

--- a/src/commands/browse/perf.rs
+++ b/src/commands/browse/perf.rs
@@ -60,7 +60,7 @@ fn session_with_n(n: usize) -> WorkspaceSession {
 fn primed_dialogue_pane(n: usize) -> DialoguePane {
     let sessions = vec![session_with_n(n)];
     let mut pane = DialoguePane::default();
-    let selected_sessions = [true];
+    let session_scope = [true];
     let selected = vec![true; n];
     let vp = Viewport {
         first: 0,
@@ -77,7 +77,7 @@ fn primed_dialogue_pane(n: usize) -> DialoguePane {
         DialogueCtx {
             sessions: &sessions,
             session_idx: 0,
-            session_scope: &selected_sessions,
+            session_scope: &session_scope,
             records: &records,
         },
         &PaneInput::new(vp, 0)
@@ -139,7 +139,7 @@ impl HotPane {
 /// Grow meta twice (includes setup; measures ensure path).
 pub fn run_ensure_growth() -> (usize, usize) {
     let sessions = vec![session_with_n(500)];
-    let selected_sessions = [true];
+    let session_scope = [true];
     let mut pane = DialoguePane::default();
     let empty = [];
     let records = |s: &WorkspaceSession| {
@@ -153,7 +153,7 @@ pub fn run_ensure_growth() -> (usize, usize) {
         DialogueCtx {
             sessions: &sessions,
             session_idx: 0,
-            session_scope: &selected_sessions,
+            session_scope: &session_scope,
             records: &records,
         },
         &PaneInput::new(
@@ -170,7 +170,7 @@ pub fn run_ensure_growth() -> (usize, usize) {
         DialogueCtx {
             sessions: &sessions,
             session_idx: 0,
-            session_scope: &selected_sessions,
+            session_scope: &session_scope,
             records: &records,
         },
         &PaneInput::new(

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -70,7 +70,7 @@ pub(crate) fn run(
     // One cursor + mark set + range anchor per list pane. The source presets
     // arrive as a mask, so that pane starts from it.
     let mut rows = Rows::default();
-    rows.source = ListPane::with_marks(source_scope);
+    rows.source = ListPane::from_scope(source_scope);
     let mut help_state = ListState::default();
     help_state.select(Some(0));
     let mut focus = initial_focus;
@@ -84,9 +84,9 @@ pub(crate) fn run(
         first: 0,
         visible: 24,
     };
-    sessions_pane.kick(rows.source.mask(), bootstrap, true);
+    sessions_pane.kick(rows.source.scope_mask(), bootstrap, true);
     // Meta-only list — dialogue bodies live in SessionColumn, not here.
-    let mut all_sessions = sessions_pane.collect(rows.source.mask());
+    let mut all_sessions = sessions_pane.collect(rows.source.scope_mask());
     let mut sessions = all_sessions.clone();
     let mut sessions_dirty = false;
     rows.source.fit(sources.len());
@@ -135,7 +135,7 @@ pub(crate) fn run(
     // that skip redrawing (idle with no state change).
     let mut dialogues: Vec<WorkspaceDialogue> = Vec::new();
     let mut content_frame = ContentIoFrame::default();
-    // (engine generation, selected mask, focused index) for the projection in
+    // (engine generation, dialogue selection, focused index) for the projection in
     // `dialogues`; unchanged redraws reuse it instead of re-cloning bodies.
     let mut dialogues_key: Option<(u64, Vec<bool>, usize)> = None;
 
@@ -148,7 +148,7 @@ pub(crate) fn run(
             redraw = true;
         }
         if sessions_dirty {
-            all_sessions = sessions_pane.collect(rows.source.mask());
+            all_sessions = sessions_pane.collect(rows.source.scope_mask());
             sessions_dirty = false;
             reproject = true;
         }
@@ -224,16 +224,16 @@ pub(crate) fn run(
 
         sessions_pane.ensure(
             SessionCtx {
-                source_scope: rows.source.mask(),
+                source_scope: rows.source.scope_mask(),
                 sessions: &sessions,
-                session_scope: rows.sessions.mask(),
+                session_scope: rows.sessions.scope_mask(),
                 search_active: search_has_query,
             },
             &PaneInput::new(
                 Viewport::from_panel(rows.sessions.offset(), panel_inner_rows(layout.sessions)),
                 session_idx,
             )
-            .with_selected(rows.sessions.mask())
+            .with_selected(rows.sessions.scope_mask())
             .with_neighbors(1),
         );
         resolve_loaded_scopes(&mut rows, &sources, &sessions, &sessions_pane);
@@ -250,7 +250,7 @@ pub(crate) fn run(
             DialogueCtx {
                 sessions: &sessions,
                 session_idx,
-                session_scope: rows.sessions.mask(),
+                session_scope: rows.sessions.scope_mask(),
                 records: &records,
             },
             &PaneInput::new(dialogue_viewport, dialogue_focus_hint)
@@ -265,7 +265,7 @@ pub(crate) fn run(
                 DialogueCtx {
                     sessions: &sessions,
                     session_idx,
-                    session_scope: rows.sessions.mask(),
+                    session_scope: rows.sessions.scope_mask(),
                     records: &records,
                 },
                 &PaneInput::new(
@@ -285,7 +285,7 @@ pub(crate) fn run(
             DialogueCtx {
                 sessions: &sessions,
                 session_idx,
-                session_scope: rows.sessions.mask(),
+                session_scope: rows.sessions.scope_mask(),
                 records: &records,
             },
             &PaneInput::new(dialogue_viewport, dialogue_idx)
@@ -305,7 +305,7 @@ pub(crate) fn run(
         );
 
         // Materialize the dialogue projection only when the engine, the
-        // selected mask, or the focused row changed. Content scrolling and
+        // dialogue selection, or the focused row changed. Content scrolling and
         // other-pane activity reuse the last projection instead of cloning
         // dialogue bodies on every redraw.
         let materialize_key = (
@@ -437,7 +437,7 @@ pub(crate) fn run(
                         sessions: &sessions,
                         body_failures,
                         dialogue_titles: &dialogue_titles,
-                        dialogue_selected: &dialogue_selection,
+                        dialogue_selection: &dialogue_selection,
                         dialogues: &dialogues,
                         focus,
                         content_scrolls,

--- a/src/commands/browse/selection.rs
+++ b/src/commands/browse/selection.rs
@@ -34,9 +34,9 @@ pub(super) fn refresh_next_level(
 ) {
     let sources = sessions_pane.sources();
     let sources_to_reload = match focus {
-        WorkspaceFocus::Source => rows.source.active_mask(),
+        WorkspaceFocus::Source => rows.source.active_scope_mask(),
         WorkspaceFocus::Sessions | WorkspaceFocus::Dialogues => {
-            parent_source_mask(sources, sessions, &rows.sessions.active())
+            parent_source_mask(sources, sessions, &rows.sessions.active_scope_rows())
         }
         WorkspaceFocus::Content => return,
     };
@@ -47,7 +47,7 @@ pub(super) fn refresh_next_level(
 
     sessions_pane.refresh(&sources_to_reload, viewport);
     // Meta list only; search rebuild (with bodies) happens on search_dirty in picker.
-    *all_sessions = sessions_pane.collect(rows.source.mask());
+    *all_sessions = sessions_pane.collect(rows.source.scope_mask());
     *search_dirty = true;
 }
 
@@ -73,21 +73,15 @@ pub(super) enum WorkspaceSourceSelection {
 
 pub(super) fn select_sources(
     sources: &[WorkspaceSource],
-    selected_sources: &mut [bool],
+    source_scope: &mut [bool],
     selection: WorkspaceSourceSelection,
 ) {
-    // The mask is normally built from `sources`, but a length mismatch must
-    // not index out of bounds in release builds (debug_assert! is compiled
-    // out): apply over the overlap and clear any stale flags beyond it.
-    let overlap = sources.len().min(selected_sources.len());
-    for (idx, source) in sources.iter().take(overlap).enumerate() {
-        selected_sources[idx] = match selection {
+    assert_eq!(sources.len(), source_scope.len());
+    for (flag, source) in source_scope.iter_mut().zip(sources) {
+        *flag = match selection {
             WorkspaceSourceSelection::Agents => source.is_agent(),
             WorkspaceSourceSelection::Terminal => source.is_terminal(),
         };
-    }
-    for flag in &mut selected_sources[overlap..] {
-        *flag = false;
     }
 }
 
@@ -187,7 +181,7 @@ pub(super) fn apply_selection_action(
             let idx = match focus {
                 WorkspaceFocus::Dialogues => rows.dialogues.cursor(),
                 WorkspaceFocus::Source | WorkspaceFocus::Sessions => {
-                    rows.pane(focus).map_or(0, |pane| pane.cursor())
+                    rows.scope_pane(focus).map_or(0, |pane| pane.cursor())
                 }
                 WorkspaceFocus::Content => 0,
             };
@@ -228,8 +222,8 @@ pub(super) fn apply_selection_action(
                 ),
             }
             if matches!(focus, WorkspaceFocus::Source | WorkspaceFocus::Sessions) {
-                if let Some(list) = rows.pane_mut(focus) {
-                    list.toggle_all();
+                if let Some(list) = rows.scope_pane_mut(focus) {
+                    list.toggle_scope_all();
                     rows.close_ranges();
                     return true;
                 }
@@ -320,17 +314,9 @@ pub(super) fn resolve_loaded_scopes(
     sessions_pane: &SessionColumn,
 ) {
     for (session_idx, session) in sessions.iter().enumerate() {
-        let source_idx = sources.iter().position(|source| source == &session.source);
-        let source_marked = source_idx
-            .and_then(|idx| rows.source.mask().get(idx))
-            .copied()
-            .unwrap_or(false);
-        let session_marked = rows
-            .sessions
-            .mask()
-            .get(session_idx)
-            .copied()
-            .unwrap_or(false);
+        let source_idx = super::load::source_index_for_session(sources, session);
+        let source_marked = source_idx.is_some_and(|idx| rows.source.scope_mask()[idx]);
+        let session_marked = rows.sessions.scope_mask()[session_idx];
         if source_marked || session_marked {
             if let Some(records) = sessions_pane.body_for(session) {
                 rows.selection.include_records(records.iter().cloned());

--- a/src/commands/browse/selection.rs
+++ b/src/commands/browse/selection.rs
@@ -184,7 +184,13 @@ pub(super) fn apply_selection_action(
                 }
                 return false;
             }
-            let idx = rows.pane(focus).map_or(0, |pane| pane.cursor());
+            let idx = match focus {
+                WorkspaceFocus::Dialogues => rows.dialogues.cursor(),
+                WorkspaceFocus::Source | WorkspaceFocus::Sessions => {
+                    rows.pane(focus).map_or(0, |pane| pane.cursor())
+                }
+                WorkspaceFocus::Content => 0,
+            };
             toggle_row_selection(
                 focus,
                 idx,

--- a/src/commands/memory/copy/export.rs
+++ b/src/commands/memory/copy/export.rs
@@ -213,7 +213,7 @@ mod tests {
         .expect("test record");
         let picked = PickedContent::WorkSet {
             source: WorkspaceSource::terminal(),
-            set: WorkSet::with_anchors("current", vec![record.clone()], vec![record.work_ref]),
+            set: WorkSet::from_parts("current", vec![record.clone()], vec![record.work_ref]),
             projection: WorkspacePickProjection::Command,
             line_filter: None,
         };

--- a/src/commands/memory/copy/export.rs
+++ b/src/commands/memory/copy/export.rs
@@ -60,7 +60,7 @@ pub(crate) fn picked_units(picked: &PickedContent) -> Result<(Vec<TextPair>, Str
                 .iter()
                 .map(|anchor| {
                     let record = set
-                        .records
+                        .records()
                         .iter()
                         .find(|record| record.work_ref.whole() == anchor.whole())
                         .with_context(|| {

--- a/src/commands/memory/copy/load.rs
+++ b/src/commands/memory/copy/load.rs
@@ -63,11 +63,11 @@ pub(crate) fn load_dialogues(
 ) -> Result<Vec<WorkRecord>> {
     let expanded = sivtr_core::record::expand_source(source)?;
     let set = workset::query(&expanded, Filter::none(), cwd)?;
-    if set.records.is_empty() {
+    if set.records().is_empty() {
         return Ok(Vec::new());
     }
 
-    let mut records = set.records;
+    let mut records = set.records().to_vec();
     // Oldest → newest so relative select (from end) matches historical terminal semantics.
     records.sort_by_key(|r| (r.session.id.clone(), r.work_ref.index()));
     // Bare sources (e.g. `codex`, multi-session terminal) → newest session only.
@@ -118,7 +118,7 @@ fn load_pinned_ref(
     }
 
     let set = workset::query(expanded, Filter::none(), Some(cwd))?;
-    let record = workset::record_for_anchor(&set.records, work_ref)
+    let record = workset::record_for_anchor(set.records(), work_ref)
         .with_context(|| format!("No record found for ref `{expanded}`"))?
         .clone();
 

--- a/src/commands/memory/eval.rs
+++ b/src/commands/memory/eval.rs
@@ -59,7 +59,7 @@ fn create_snapshot(path: &Path) -> Result<()> {
     let mut records = Vec::new();
     for source in ["terminal", "agent"] {
         let set = workset::query(source, filter::Filter::none(), Some(&cwd))?;
-        records.extend(set.records);
+        records.extend(set.records().iter().cloned());
     }
     let snapshot = EvalSnapshot {
         queries: Vec::new(),

--- a/src/commands/memory/filter.rs
+++ b/src/commands/memory/filter.rs
@@ -182,7 +182,7 @@ pub(crate) fn apply(
     let hits = searcher.search(&filter, &anchors, &cwd)?;
     let anchors: Vec<WorkRef> = hits.into_iter().map(|hit| hit.anchor).collect();
     let selected_records = workset::records_for_anchors(&records, &anchors);
-    Ok(WorkSet::with_anchors(
+    Ok(WorkSet::from_parts(
         cwd.display().to_string(),
         selected_records,
         anchors,

--- a/src/commands/memory/nav.rs
+++ b/src/commands/memory/nav.rs
@@ -23,8 +23,14 @@ pub fn execute(args: &NavArgs) -> Result<()> {
         args.cwd.as_deref(),
     )?;
     let cwd = PathBuf::from(&source.cwd);
-    let all_records = workset::load_context_records(&source.records, &source.anchors, &cwd)?;
-    let anchors = navigate(&source.records, &source.anchors, &all_records, &args.motion)?;
+    let source_anchors = source.anchors().to_vec();
+    let all_records = workset::load_context_records(source.records(), &source_anchors, &cwd)?;
+    let anchors = navigate(
+        source.records(),
+        &source_anchors,
+        &all_records,
+        &args.motion,
+    )?;
     let records = workset::records_for_anchors(&all_records, &anchors);
     let mut set = WorkSet::with_anchors(source.cwd, records, anchors);
     set.save_last()?;

--- a/src/commands/memory/nav.rs
+++ b/src/commands/memory/nav.rs
@@ -32,7 +32,7 @@ pub fn execute(args: &NavArgs) -> Result<()> {
         &args.motion,
     )?;
     let records = workset::records_for_anchors(&all_records, &anchors);
-    let mut set = WorkSet::with_anchors(source.cwd, records, anchors);
+    let mut set = WorkSet::from_parts(source.cwd, records, anchors);
     set.save_last()?;
     show::print_workset(
         &mut set,
@@ -100,7 +100,7 @@ fn child(
     }
     match anchor.at {
         WorkAt::Whole => {
-            let record = record_for_anchor(anchor, source_records, all_records)?;
+            let record = workset::require_record([source_records, all_records], anchor)?;
             let Some(part) = record.parts.get(index - 1) else {
                 return Ok(Vec::new());
             };
@@ -118,7 +118,7 @@ fn sibling(
 ) -> Result<Vec<WorkRef>> {
     match anchor.at {
         WorkAt::Whole => {
-            let record = record_for_anchor(anchor, source_records, all_records)?;
+            let record = workset::require_record([source_records, all_records], anchor)?;
             let session_records = session_records_for(record, all_records);
             let Some(position) = session_records
                 .iter()
@@ -132,7 +132,7 @@ fn sibling(
             Ok(vec![session_records[target].work_ref.whole()])
         }
         WorkAt::Part(seq) => {
-            let record = record_for_anchor(anchor, source_records, all_records)?;
+            let record = workset::require_record([source_records, all_records], anchor)?;
             let Some(position) = record.parts.iter().position(|part| part.seq == seq) else {
                 return Ok(Vec::new());
             };
@@ -156,7 +156,7 @@ fn window(
     }
     match anchor.at {
         WorkAt::Whole => {
-            let record = record_for_anchor(anchor, source_records, all_records)?;
+            let record = workset::require_record([source_records, all_records], anchor)?;
             let session_records = session_records_for(record, all_records);
             let position = session_records
                 .iter()
@@ -170,7 +170,7 @@ fn window(
                 .collect())
         }
         WorkAt::Part(seq) => {
-            let record = record_for_anchor(anchor, source_records, all_records)?;
+            let record = workset::require_record([source_records, all_records], anchor)?;
             let position = record
                 .parts
                 .iter()
@@ -191,24 +191,11 @@ fn session(
     source_records: &[WorkRecord],
     all_records: &[WorkRecord],
 ) -> Result<Vec<WorkRef>> {
-    let record = record_for_anchor(anchor, source_records, all_records)?;
+    let record = workset::require_record([source_records, all_records], anchor)?;
     Ok(session_records_for(record, all_records)
         .into_iter()
         .map(|record| record.work_ref.whole())
         .collect())
-}
-
-fn record_for_anchor<'a>(
-    anchor: &WorkRef,
-    source_records: &'a [WorkRecord],
-    all_records: &'a [WorkRecord],
-) -> Result<&'a WorkRecord> {
-    let record_ref = anchor.whole();
-    source_records
-        .iter()
-        .chain(all_records.iter())
-        .find(|record| record.work_ref.whole() == record_ref)
-        .with_context(|| format!("No record found for ref `{record_ref}`"))
 }
 
 fn session_records_for<'a>(

--- a/src/commands/memory/show.rs
+++ b/src/commands/memory/show.rs
@@ -121,11 +121,14 @@ pub fn print_workset(set: &mut workset::WorkSet, format: WorkSetOutputFormat) ->
 
 fn anchor_items(set: &workset::WorkSet) -> Result<Vec<AnchorItem<'_>>> {
     set.anchors()
-        .into_iter()
+        .iter()
         .map(|anchor| {
-            let record = workset::record_for_anchor(&set.records, &anchor)
+            let record = workset::record_for_anchor(set.records(), anchor)
                 .with_context(|| format!("No record found for anchor `{anchor}`"))?;
-            Ok(AnchorItem { anchor, record })
+            Ok(AnchorItem {
+                anchor: anchor.clone(),
+                record,
+            })
         })
         .collect()
 }
@@ -256,7 +259,7 @@ fn print_markdown(set: &workset::WorkSet) -> Result<()> {
 }
 
 fn print_refs(set: &workset::WorkSet) {
-    for anchor in set.anchors() {
+    for anchor in set.anchors().iter() {
         println!("{anchor}");
     }
 }

--- a/src/commands/memory/var.rs
+++ b/src/commands/memory/var.rs
@@ -116,37 +116,43 @@ fn stdin_is_piped() -> bool {
 }
 
 fn merge_sets(base: WorkSet, addition: WorkSet) -> WorkSet {
-    let mut records_by_ref = records_by_ref(base.records);
-    for record in addition.records {
+    let cwd = base.cwd.clone();
+    let (base_records, mut anchors) = base.into_parts();
+    let (addition_records, addition_anchors) = addition.into_parts();
+    let mut records_by_ref = records_by_ref(base_records);
+    for record in addition_records {
         records_by_ref
             .entry(record.work_ref.whole().to_string())
             .or_insert(record);
     }
 
-    let mut anchors = base.anchors;
-    anchors.extend(addition.anchors);
+    anchors.extend(addition_anchors);
     anchors = unique_anchors(anchors);
     let records = records_for_unique_anchors(records_by_ref, &anchors);
-    WorkSet::with_anchors(base.cwd, records, anchors)
+    WorkSet::from_parts(cwd, records, anchors)
 }
 
 fn remove_anchors(base: WorkSet, remove: &HashSet<String>) -> WorkSet {
-    let records_by_ref = records_by_ref(base.records);
+    let cwd = base.cwd.clone();
+    let (base_records, anchors) = base.into_parts();
+    let records_by_ref = records_by_ref(base_records);
     let anchors = unique_anchors(
-        base.anchors
+        anchors
             .into_iter()
             .filter(|anchor| !remove.contains(&anchor.to_string()))
             .collect(),
     );
     let records = records_for_unique_anchors(records_by_ref, &anchors);
-    WorkSet::with_anchors(base.cwd, records, anchors)
+    WorkSet::from_parts(cwd, records, anchors)
 }
 
 fn dedup(set: WorkSet) -> WorkSet {
-    let records_by_ref = records_by_ref(set.records);
-    let anchors = unique_anchors(set.anchors);
+    let cwd = set.cwd.clone();
+    let (set_records, set_anchors) = set.into_parts();
+    let records_by_ref = records_by_ref(set_records);
+    let anchors = unique_anchors(set_anchors);
     let records = records_for_unique_anchors(records_by_ref, &anchors);
-    WorkSet::with_anchors(set.cwd, records, anchors)
+    WorkSet::from_parts(cwd, records, anchors)
 }
 
 pub(crate) fn unique_anchors(anchors: Vec<WorkRef>) -> Vec<WorkRef> {

--- a/src/commands/memory/var.rs
+++ b/src/commands/memory/var.rs
@@ -92,7 +92,7 @@ fn drop(name: &str, sources: &[String]) -> Result<()> {
             crate::commands::memory::filter::Filter::none(),
             None,
         )?;
-        remove.extend(set.anchors().into_iter().map(|anchor| anchor.to_string()));
+        remove.extend(set.anchors().iter().map(ToString::to_string));
     }
     let mut result = remove_anchors(before, &remove);
     result.name = Some(name.to_string());

--- a/src/commands/memory/work.rs
+++ b/src/commands/memory/work.rs
@@ -56,7 +56,7 @@ fn execute_sessions(args: &WorkSessionsArgs) -> Result<()> {
     let cwd = resolve_cwd(args.cwd.as_deref())?;
     let (display_cwd, records) = if let Some(source) = args.source.as_deref() {
         let set = workset::query(source, filter::Filter::none(), Some(&cwd))?;
-        (set.cwd, set.records)
+        (set.cwd.clone(), set.records().to_vec())
     } else {
         let providers = args.provider.providers();
         let records = current_work_record_index(&providers, &cwd, None)?;

--- a/src/commands/memory/workset/mod.rs
+++ b/src/commands/memory/workset/mod.rs
@@ -21,11 +21,10 @@ fn apply_selection(mut set: WorkSet, selection: WorkSetSelection) -> WorkSet {
 
     let anchors = indices
         .into_iter()
-        .map(|index| set.anchors[index - 1].clone())
+        .map(|index| set.anchors()[index - 1].clone())
         .collect::<Vec<_>>();
-    let records = records_for_anchors(&set.records, &anchors);
-    set.records = records;
-    set.anchors = anchors;
+    let records = records_for_anchors(set.records(), &anchors);
+    set.replace_selection(records, anchors);
     set
 }
 
@@ -53,7 +52,7 @@ impl WorkSet {
         // Group light records by their session file path, then load each
         // session's full records once and patch matching parts back.
         let mut needed: HashMap<String, Vec<usize>> = HashMap::new();
-        for (index, record) in self.records.iter().enumerate() {
+        for (index, record) in self.records().iter().enumerate() {
             if !record.parts.is_empty() {
                 continue;
             }
@@ -65,14 +64,14 @@ impl WorkSet {
 
         for (path, indices) in &needed {
             // Any record in the group gives us the namespace; pick the first.
-            let namespace = session_namespace(&self.records[indices[0]].work_ref.path);
+            let namespace = session_namespace(&self.records()[indices[0]].work_ref.path);
             let Some(namespace) = namespace else {
                 continue;
             };
             let full = load_session_records(namespace, Path::new(path), LoadMode::Full)
                 .with_context(|| format!("Failed to load full session {path} for {namespace}"))?;
             for index in indices {
-                if let Some(record) = self.records.get_mut(*index) {
+                if let Some(record) = self.records_mut().get_mut(*index) {
                     if let Some(full_record) = full
                         .iter()
                         .find(|r| r.work_ref.path.index() == record.work_ref.path.index())
@@ -215,10 +214,10 @@ fn validate_selection(reference: &str, set: &WorkSet, selection: &WorkSetSelecti
         WorkSetSelection::All => Ok(()),
         WorkSetSelection::Indices(indices) => {
             for index in indices {
-                if *index > set.anchors.len() {
+                if *index > set.anchors().len() {
                     bail!(
                         "Invalid WorkSet reference `{reference}`; index {index} exceeds WorkSet length {}",
-                        set.anchors.len()
+                        set.anchors().len()
                     );
                 }
             }

--- a/src/commands/memory/workset/mod.rs
+++ b/src/commands/memory/workset/mod.rs
@@ -121,10 +121,26 @@ pub fn record_for_anchor<'a>(
     records: &'a [WorkRecord],
     anchor: &WorkRef,
 ) -> Option<&'a WorkRecord> {
+    find_record([records], anchor)
+}
+
+pub fn find_record<'a, I>(record_sets: I, anchor: &WorkRef) -> Option<&'a WorkRecord>
+where
+    I: IntoIterator<Item = &'a [WorkRecord]>,
+{
     let record_ref = anchor.whole();
-    records
-        .iter()
+    record_sets
+        .into_iter()
+        .flat_map(|records| records.iter())
         .find(|record| record.work_ref.whole() == record_ref)
+}
+
+pub fn require_record<'a, I>(record_sets: I, anchor: &WorkRef) -> Result<&'a WorkRecord>
+where
+    I: IntoIterator<Item = &'a [WorkRecord]>,
+{
+    find_record(record_sets, anchor)
+        .with_context(|| format!("No record found for ref `{}`", anchor.whole()))
 }
 
 pub fn load_reference(reference: &str) -> Result<WorkSet> {
@@ -284,7 +300,7 @@ mod tests {
             records[1].work_ref.with_part(1),
             records[0].work_ref.with_part(1),
         ];
-        let set = WorkSet::with_anchors(".", records, anchors);
+        let set = WorkSet::from_parts(".", records, anchors);
         let selected = apply_selection(set, WorkSetSelection::Indices(vec![2, 1]));
 
         let refs = selected
@@ -301,7 +317,7 @@ mod tests {
     #[test]
     fn whole_anchor_covers_and_replaces_parts() {
         let first = record(1);
-        let mut set = WorkSet::with_anchors(".", vec![first.clone()], vec![]);
+        let mut set = WorkSet::from_parts(".", vec![first.clone()], vec![]);
         set.include_parts(first.clone(), [1]);
         assert!(set.contains(&first.work_ref.with_part(1)));
         set.include_whole(first.clone());

--- a/src/commands/memory/workset/source.rs
+++ b/src/commands/memory/workset/source.rs
@@ -238,7 +238,7 @@ fn merge_and_apply(results: Vec<QuerySourceResult>, cwd: &Path, filter: Filter) 
         output::warning(format!("skipped an origin: {error}"));
     }
     apply_loaded(
-        WorkSet::with_anchors(
+        WorkSet::from_parts(
             cwd.display().to_string(),
             records,
             crate::commands::memory::var::unique_anchors(anchors),
@@ -334,7 +334,7 @@ fn normalize_source_result(result: Result<WorkSet>, cwd: &Path) -> QuerySourceRe
         Err(error) => {
             let message = error.to_string();
             if message.starts_with(NO_RECORD_FOR_SELECTOR) {
-                QuerySourceResult::Ok(WorkSet::with_anchors(
+                QuerySourceResult::Ok(WorkSet::from_parts(
                     cwd.display().to_string(),
                     Vec::new(),
                     Vec::new(),
@@ -425,7 +425,7 @@ fn run_local(source: &str, root: &Path, filter: Filter, mode: LoadMode) -> Resul
     let result = load_workspace_source(root, source, mode)?;
     warn_skipped(&result.skipped);
     apply_loaded(
-        WorkSet::with_anchors(root.display().to_string(), result.records, result.anchors),
+        WorkSet::from_parts(root.display().to_string(), result.records, result.anchors),
         filter,
     )
 }
@@ -459,7 +459,7 @@ fn try_remote_timed(
         },
         read_timeout,
     )? {
-        LocalResponse::Query(response) => Ok(WorkSet::with_anchors(
+        LocalResponse::Query(response) => Ok(WorkSet::from_parts(
             cwd.display().to_string(),
             response.records,
             response.anchors,
@@ -517,7 +517,7 @@ fn group_query(
                     response.skipped.join(", ")
                 ));
             }
-            Ok(WorkSet::with_anchors(
+            Ok(WorkSet::from_parts(
                 cwd.display().to_string(),
                 response.query.records,
                 response.query.anchors,
@@ -659,7 +659,7 @@ mod tests {
         let second = record(2);
         let part = first.work_ref.with_part(2);
         let results = vec![
-            QuerySourceResult::Ok(WorkSet::with_anchors(
+            QuerySourceResult::Ok(WorkSet::from_parts(
                 "/repo",
                 vec![first],
                 vec![part.clone()],

--- a/src/commands/memory/workset/source.rs
+++ b/src/commands/memory/workset/source.rs
@@ -218,8 +218,8 @@ fn merge_and_apply(results: Vec<QuerySourceResult>, cwd: &Path, filter: Filter) 
         match result {
             QuerySourceResult::Ok(set) => {
                 any_ok = true;
-                anchors.extend(set.anchors());
-                for record in set.records {
+                anchors.extend(set.anchors().iter().cloned());
+                for record in set.into_records() {
                     if seen.insert(record.work_ref.whole()) {
                         records.push(record);
                     }
@@ -405,13 +405,14 @@ pub fn run_on_share(
     match run_local(source, root, filter.for_remote_peer(), LoadMode::Full) {
         Ok(mut set) => {
             if redact {
-                set.records = set
-                    .records
+                let records = set
+                    .records()
                     .iter()
                     .map(crate::remote::redact::redact_record)
                     .collect();
+                set.replace_records(records);
             }
-            Ok((set.records, set.anchors))
+            Ok(set.into_parts())
         }
         Err(error) if error.to_string().starts_with(NO_RECORD_FOR_SELECTOR) => {
             Ok((Vec::new(), Vec::new()))
@@ -430,7 +431,9 @@ fn run_local(source: &str, root: &Path, filter: Filter, mode: LoadMode) -> Resul
 }
 
 fn apply_loaded(set: WorkSet, filter: Filter) -> Result<WorkSet> {
-    filter::apply(PathBuf::from(&set.cwd), set.records, set.anchors, filter)
+    let cwd = PathBuf::from(&set.cwd);
+    let (records, anchors) = set.into_parts();
+    filter::apply(cwd, records, anchors, filter)
 }
 
 fn try_remote_timed(
@@ -597,7 +600,7 @@ pub fn load_context_records(
         // filter-driven light mode and force a full load.
         let mut set = query(&source, Filter::none(), Some(cwd))?;
         set.materialize_parts()?;
-        for record in set.records {
+        for record in set.into_records() {
             let key = record.work_ref.whole().to_string();
             if seen_records.insert(key) {
                 records.push(record);

--- a/src/commands/memory/zoom.rs
+++ b/src/commands/memory/zoom.rs
@@ -29,17 +29,12 @@ pub fn run(args: &ZoomArgs) -> Result<WorkSet> {
     let before = args.before.unwrap_or(base_context);
     let after = args.after.unwrap_or(base_context);
 
-    let expanded = if source.records.is_empty() || source.anchors.is_empty() {
+    let anchors = source.anchors().to_vec();
+    let expanded = if source.records().is_empty() || anchors.is_empty() {
         Vec::new()
     } else {
-        let all_records = workset::load_context_records(&source.records, &source.anchors, &cwd)?;
-        expand_around(
-            &source.records,
-            &source.anchors,
-            &all_records,
-            before,
-            after,
-        )?
+        let all_records = workset::load_context_records(source.records(), &anchors, &cwd)?;
+        expand_around(source.records(), &anchors, &all_records, before, after)?
     };
 
     let mut workset = WorkSet::new(source.cwd, expanded);

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -320,7 +320,7 @@ pub fn memory_result(
     let detail = detail.unwrap_or("timeline");
     let anchors = set
         .anchors()
-        .into_iter()
+        .iter()
         .map(|anchor| anchor.to_string())
         .collect::<Vec<_>>();
     let count = anchors.len();
@@ -360,7 +360,7 @@ pub fn show_result(set: &WorkSet, mode: Option<&str>) -> anyhow::Result<ShowResu
     let mode = mode.unwrap_or("full");
     let anchors = set
         .anchors()
-        .into_iter()
+        .iter()
         .map(|anchor| anchor.to_string())
         .collect::<Vec<_>>();
     let count = anchors.len();

--- a/src/remote/fanout.rs
+++ b/src/remote/fanout.rs
@@ -223,8 +223,8 @@ pub(crate) async fn group_fan_out(
     let merged = filter::apply(PathBuf::new(), records, anchors, full)?;
     Ok(GroupQueryResponse {
         query: QueryResponse {
-            records: merged.records,
-            anchors: merged.anchors,
+            records: merged.records().to_vec(),
+            anchors: merged.anchors().to_vec(),
         },
         skipped,
     })

--- a/src/tui/workspace/model.rs
+++ b/src/tui/workspace/model.rs
@@ -327,7 +327,7 @@ pub(crate) struct WorkspaceView<'a> {
     /// Dialogue list titles only (no body materialize on paint).
     pub(crate) dialogue_titles: &'a [&'a str],
     /// WorkSet-derived dialogue selection for this frame.
-    pub(crate) dialogue_selected: &'a [bool],
+    pub(crate) dialogue_selection: &'a [bool],
     /// Materialized dialogues for content/copy (focus ∪ multi-select bodies).
     pub(crate) dialogues: &'a [WorkspaceDialogue],
     pub(crate) focus: WorkspaceFocus,

--- a/src/tui/workspace/render.rs
+++ b/src/tui/workspace/render.rs
@@ -28,7 +28,7 @@ use crate::tui::workspace::model::{
     selected_indices, SourceLoadMarker, WorkspaceDialogue, WorkspaceFocus, WorkspaceFooterView,
     WorkspaceSearchView, WorkspaceSession, WorkspaceSource, WorkspaceView,
 };
-use crate::tui::workspace::rows::ListPane;
+use crate::tui::workspace::rows::{CursorPane, ListPane};
 use sivtr_core::record::{WorkAt, WorkRef};
 
 pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
@@ -700,7 +700,7 @@ fn render_dialogue_list(
     area: Rect,
     titles: &[&str],
     selected_dialogues: &[bool],
-    pane: &ListPane,
+    pane: &CursorPane,
     marked_sessions: usize,
     range_anchor: Option<usize>,
     search: Option<&WorkspaceSearchView<'_>>,

--- a/src/tui/workspace/render.rs
+++ b/src/tui/workspace/render.rs
@@ -28,7 +28,7 @@ use crate::tui::workspace::model::{
     selected_indices, SourceLoadMarker, WorkspaceDialogue, WorkspaceFocus, WorkspaceFooterView,
     WorkspaceSearchView, WorkspaceSession, WorkspaceSource, WorkspaceView,
 };
-use crate::tui::workspace::rows::{CursorPane, ListPane};
+use crate::tui::workspace::rows::{ListPane, RowCursor};
 use sivtr_core::record::{WorkAt, WorkRef};
 
 pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
@@ -45,7 +45,7 @@ pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
     let dialogue_idx = dialogues_pane.cursor();
     let current_ref = current_content_ref(
         view.dialogues,
-        view.dialogue_selected,
+        view.dialogue_selection,
         dialogue_idx,
         view.content_at,
     );
@@ -68,7 +68,7 @@ pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
         frame,
         layout.sessions,
         view.sessions,
-        view.rows.source.marked(),
+        view.rows.source.scope_count(),
         &view.rows.sessions,
         &view.body_failures,
         view.search.as_ref(),
@@ -80,9 +80,9 @@ pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
         frame,
         layout.dialogues,
         view.dialogue_titles,
-        view.dialogue_selected,
+        view.dialogue_selection,
         dialogues_pane,
-        view.rows.sessions.marked(),
+        view.rows.sessions.scope_count(),
         view.rows.range_start(WorkspaceFocus::Dialogues),
         view.search.as_ref(),
         search_regex.as_ref(),
@@ -99,7 +99,7 @@ pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
         .filter(|search| search.scope == WorkspaceSearchScope::Content)
         .and(search_regex.as_ref());
     let title_suffix = content_title_suffix(
-        view.dialogue_selected
+        view.dialogue_selection
             .iter()
             .filter(|selected| **selected)
             .count(),
@@ -559,7 +559,7 @@ fn render_source_list(
         .iter()
         .enumerate()
         .map(|(idx, source)| {
-            let selected = pane.mask().get(idx).copied().unwrap_or(false);
+            let selected = pane.scope_mask().get(idx).copied().unwrap_or(false);
             let load = source_markers
                 .get(idx)
                 .copied()
@@ -603,7 +603,7 @@ fn render_source_strip(
         if idx > 0 {
             spans.push(Span::styled("  ", Style::default().fg(theme::dim())));
         }
-        let selected = pane.mask().get(idx).copied().unwrap_or(false);
+        let selected = pane.scope_mask().get(idx).copied().unwrap_or(false);
         let focused = idx == current && active;
         let load = source_markers
             .get(idx)
@@ -660,7 +660,7 @@ fn render_session_list(
         .iter()
         .enumerate()
         .map(|(idx, choice)| {
-            let selected = pane.mask().get(idx).copied().unwrap_or(false);
+            let selected = pane.scope_mask().get(idx).copied().unwrap_or(false);
             let base_style = row_highlight(idx, cursor_idx, range_anchor).unwrap_or_default();
             let highlight = search
                 .filter(|search| search.scope == WorkspaceSearchScope::Session)
@@ -700,7 +700,7 @@ fn render_dialogue_list(
     area: Rect,
     titles: &[&str],
     selected_dialogues: &[bool],
-    pane: &CursorPane,
+    pane: &RowCursor,
     marked_sessions: usize,
     range_anchor: Option<usize>,
     search: Option<&WorkspaceSearchView<'_>>,

--- a/src/tui/workspace/rows.rs
+++ b/src/tui/workspace/rows.rs
@@ -126,8 +126,6 @@ impl RowCursor {
     }
 }
 
-pub(crate) type CursorPane = RowCursor;
-
 /// One selectable scope list: a cursor plus scope marks.
 #[derive(Default)]
 pub(crate) struct ListPane {
@@ -150,9 +148,8 @@ impl DerefMut for ListPane {
 }
 
 impl ListPane {
-    /// A pane over `marks` — the caller already knows which rows start marked
-    /// (source presets); its length is the row count.
-    pub(crate) fn with_marks(marks: Vec<bool>) -> Self {
+    /// A scope pane over its initial row mask.
+    pub(crate) fn from_scope(marks: Vec<bool>) -> Self {
         let cursor = RowCursor::new(marks.len());
         let mut pane = Self {
             cursor,
@@ -162,32 +159,32 @@ impl ListPane {
         pane
     }
 
-    pub(crate) fn mask(&self) -> &[bool] {
+    pub(crate) fn scope_mask(&self) -> &[bool] {
         self.marks.mask()
     }
 
     /// Mask for the policies that set flags in place (source presets).
-    pub(crate) fn mask_mut(&mut self) -> &mut [bool] {
+    pub(crate) fn scope_mask_mut(&mut self) -> &mut [bool] {
         self.marks.mask_mut()
     }
 
-    pub(crate) fn marked(&self) -> usize {
+    pub(crate) fn scope_count(&self) -> usize {
         self.marks.count()
     }
 
-    pub(crate) fn has_marks(&self) -> bool {
+    pub(crate) fn has_scope(&self) -> bool {
         self.marks.any()
     }
 
     /// [`active_rows`] for this pane.
-    pub(crate) fn active(&self) -> Vec<usize> {
-        active_rows(self.mask(), self.cursor(), self.len())
+    pub(crate) fn active_scope_rows(&self) -> Vec<usize> {
+        active_rows(self.scope_mask(), self.cursor(), self.len())
     }
 
-    /// [`Self::active`] as a mask, for the transports that reload by mask.
-    pub(crate) fn active_mask(&self) -> Vec<bool> {
+    /// [`Self::active_scope_rows`] as a mask for the transports that reload.
+    pub(crate) fn active_scope_mask(&self) -> Vec<bool> {
         let mut mask = vec![false; self.len()];
-        for row in self.active() {
+        for row in self.active_scope_rows() {
             if let Some(flag) = mask.get_mut(row) {
                 *flag = true;
             }
@@ -195,13 +192,13 @@ impl ListPane {
         mask
     }
 
-    pub(crate) fn toggle(&mut self, idx: usize) {
+    pub(crate) fn toggle_scope(&mut self, idx: usize) {
         self.marks.toggle(idx);
     }
 
     /// Mark every row, or clear them all when they are already marked — the
     /// same one-state rule a `v` range follows, over the whole pane.
-    pub(crate) fn toggle_all(&mut self) {
+    pub(crate) fn toggle_scope_all(&mut self) {
         let len = self.len();
         self.marks.toggle_ids(0..len);
     }
@@ -251,7 +248,7 @@ impl ListPane {
 pub(crate) struct Rows {
     pub(crate) source: ListPane,
     pub(crate) sessions: ListPane,
-    pub(crate) dialogues: CursorPane,
+    pub(crate) dialogues: RowCursor,
     /// The only content-selection state. List and block marks are derived
     /// views; cursor/range state never decides what copy or MCP receives.
     pub(crate) selection: WorkSet,
@@ -263,7 +260,7 @@ impl Default for Rows {
         Self {
             source: ListPane::default(),
             sessions: ListPane::default(),
-            dialogues: CursorPane::default(),
+            dialogues: RowCursor::default(),
             selection: WorkSet::new(".", Vec::new()),
             content_anchor: None,
         }
@@ -271,9 +268,7 @@ impl Default for Rows {
 }
 
 impl Rows {
-    /// The pane `focus` names, or `None` for Content — it has no rows, it
-    /// marks blocks.
-    pub(crate) fn pane(&self, focus: WorkspaceFocus) -> Option<&ListPane> {
+    pub(crate) fn scope_pane(&self, focus: WorkspaceFocus) -> Option<&ListPane> {
         match focus {
             WorkspaceFocus::Source => Some(&self.source),
             WorkspaceFocus::Sessions => Some(&self.sessions),
@@ -281,7 +276,7 @@ impl Rows {
         }
     }
 
-    pub(crate) fn pane_mut(&mut self, focus: WorkspaceFocus) -> Option<&mut ListPane> {
+    pub(crate) fn scope_pane_mut(&mut self, focus: WorkspaceFocus) -> Option<&mut ListPane> {
         match focus {
             WorkspaceFocus::Source => Some(&mut self.source),
             WorkspaceFocus::Sessions => Some(&mut self.sessions),
@@ -320,8 +315,7 @@ impl Rows {
         self.content_anchor = None;
     }
 
-    /// One `v` press on `row` of `focus`. Rows are list rows for the three list
-    /// panes, block ids for Content.
+    /// One `v` press on `row` of `focus`. Rows are list rows or content block ids.
     pub(crate) fn range(
         &mut self,
         focus: WorkspaceFocus,
@@ -330,11 +324,12 @@ impl Rows {
         range_step(self.anchor_mut(focus), row)
     }
 
-    /// [`ListPane::range_select`] for the focused list pane; Content marks
-    /// blocks through [`Self::range`] instead.
+    /// [`ListPane::range_select`] for a scope pane; Dialogue and Content use
+    /// [`Self::range`] directly.
     #[cfg(test)]
     pub(crate) fn range_select(&mut self, focus: WorkspaceFocus) -> bool {
-        self.pane_mut(focus).is_some_and(ListPane::range_select)
+        self.scope_pane_mut(focus)
+            .is_some_and(ListPane::range_select)
     }
 }
 
@@ -347,14 +342,14 @@ mod tests {
 
     fn rows_of(marks: Vec<bool>) -> Rows {
         Rows {
-            source: ListPane::with_marks(marks),
+            source: ListPane::from_scope(marks),
             ..Rows::default()
         }
     }
 
     #[test]
     fn cursor_is_clamped_to_the_row_count() {
-        let mut pane = ListPane::with_marks(vec![false; 3]);
+        let mut pane = ListPane::from_scope(vec![false; 3]);
         // A non-empty pane always has a cursor, before any move.
         assert_eq!(pane.cursor(), 0);
         pane.select(9);
@@ -367,27 +362,27 @@ mod tests {
 
     #[test]
     fn active_rows_are_the_marks_or_the_cursor_alone() {
-        let mut pane = ListPane::with_marks(vec![false; 4]);
+        let mut pane = ListPane::from_scope(vec![false; 4]);
         pane.select(2);
-        assert_eq!(pane.active(), vec![2]);
-        pane.toggle(0);
-        pane.toggle(3);
-        assert_eq!(pane.active(), vec![0, 3]);
-        assert_eq!(pane.active_mask(), vec![true, false, false, true]);
+        assert_eq!(pane.active_scope_rows(), vec![2]);
+        pane.toggle_scope(0);
+        pane.toggle_scope(3);
+        assert_eq!(pane.active_scope_rows(), vec![0, 3]);
+        assert_eq!(pane.active_scope_mask(), vec![true, false, false, true]);
     }
 
     #[test]
     fn fit_keeps_the_rows_and_reset_starts_over() {
-        let mut pane = ListPane::with_marks(vec![false; 4]);
+        let mut pane = ListPane::from_scope(vec![false; 4]);
         pane.select(3);
-        pane.toggle(3);
+        pane.toggle_scope(3);
         // Same length: marks and cursor survive.
         pane.fit(4);
-        assert_eq!(pane.marked(), 1);
+        assert_eq!(pane.scope_count(), 1);
         assert_eq!(pane.cursor(), 3);
         // Shorter list: marks named other rows, so they go; the cursor clamps.
         pane.fit(2);
-        assert_eq!(pane.marked(), 0);
+        assert_eq!(pane.scope_count(), 0);
         assert_eq!(pane.cursor(), 1);
         // Reset returns to the first row of a freshly built list.
         pane.reset(5);
@@ -410,11 +405,11 @@ mod tests {
 
     #[test]
     fn toggle_all_marks_then_clears_every_row() {
-        let mut pane = ListPane::with_marks(vec![false, true, false]);
-        pane.toggle_all();
-        assert_eq!(pane.marked(), 3);
-        pane.toggle_all();
-        assert_eq!(pane.marked(), 0);
+        let mut pane = ListPane::from_scope(vec![false, true, false]);
+        pane.toggle_scope_all();
+        assert_eq!(pane.scope_count(), 3);
+        pane.toggle_scope_all();
+        assert_eq!(pane.scope_count(), 0);
     }
 
     #[test]
@@ -425,19 +420,19 @@ mod tests {
         // First `v` only anchors; nothing is marked yet.
         assert!(!rows.range_select(PANE));
         assert_eq!(rows.range_start(PANE), Some(4));
-        assert!(!rows.source.has_marks());
+        assert!(!rows.source.has_scope());
 
         // Moving the cursor does not disturb the anchor.
         rows.source.select(1);
         assert!(rows.range_select(PANE));
         assert_eq!(rows.range_start(PANE), None);
         // Span 1..=4 marked; row 0 untouched.
-        assert_eq!(rows.source.mask(), &[false, true, true, true, true]);
+        assert_eq!(rows.source.scope_mask(), &[false, true, true, true, true]);
     }
 
     #[test]
     fn second_v_inverts_an_already_marked_span() {
-        let mut pane = ListPane::with_marks(vec![true, true, false, false, true]);
+        let mut pane = ListPane::from_scope(vec![true, true, false, false, true]);
         let span = |pane: &mut ListPane, from: usize, to: usize| {
             pane.select(from);
             pane.range_select();
@@ -446,10 +441,10 @@ mod tests {
         };
         span(&mut pane, 4, 2);
         // Span 2..=4 was false/false/true (mixed) → mark all.
-        assert_eq!(pane.mask()[2..], [true, true, true]);
+        assert_eq!(pane.scope_mask()[2..], [true, true, true]);
         span(&mut pane, 4, 2);
         // Span is now all marked → clear it.
-        assert!(pane.mask()[0]);
-        assert_eq!(pane.mask()[2..], [false, false, false]);
+        assert!(pane.scope_mask()[0]);
+        assert_eq!(pane.scope_mask()[2..], [false, false, false]);
     }
 }

--- a/src/tui/workspace/rows.rs
+++ b/src/tui/workspace/rows.rs
@@ -1,11 +1,8 @@
 //! List-pane row state: cursor, marks, and the live range anchor.
 //!
-//! Three panes (Source / Sessions / Dialogues) are lists of rows. Each keeps a
-//! cursor, a mark mask, and its own `v` anchor, and they never move apart:
-//! every row key needs cursor and mask both, and a change in the row count
-//! clamps the one, resizes the other, and voids the anchor. [`ListPane`] holds
-//! them together — which is what lets the row helpers drop their `len`
-//! parameter, since the mask's length *is* the pane's row count.
+//! Source and Sessions are selectable scope lists; Dialogue is a cursor-only
+//! list. All share the same cursor/range state, while only scope lists carry
+//! marks. [`ListPane`] holds cursor state and marks together for those lists.
 //!
 //! [`Rows`] holds the three panes plus Content's block anchor, so "the focused
 //! pane's rows" is one lookup instead of a four-arm match at every call site.
@@ -131,7 +128,7 @@ impl RowCursor {
 
 pub(crate) type CursorPane = RowCursor;
 
-/// One selectable list pane: a cursor plus scope marks.
+/// One selectable scope list: a cursor plus scope marks.
 #[derive(Default)]
 pub(crate) struct ListPane {
     cursor: RowCursor,
@@ -245,7 +242,7 @@ impl ListPane {
     }
 }
 
-/// The three list panes and Content's block-range anchor.
+/// The scope lists, cursor-only Dialogue list, and Content's block-range anchor.
 ///
 /// Every list pane owns its own `v` anchor, so a stale one can never complete a
 /// span in another pane; only one is ever open at a time because moving focus

--- a/src/tui/workspace/rows.rs
+++ b/src/tui/workspace/rows.rs
@@ -10,7 +10,7 @@
 //! [`Rows`] holds the three panes plus Content's block anchor, so "the focused
 //! pane's rows" is one lookup instead of a four-arm match at every call site.
 
-use std::ops::RangeInclusive;
+use std::ops::{Deref, DerefMut, RangeInclusive};
 
 use ratatui::widgets::ListState;
 
@@ -49,54 +49,120 @@ fn range_step(anchor: &mut Option<usize>, row: usize) -> Option<RangeInclusive<u
     }
 }
 
-/// One list pane's cursor, row marks, and open `v` anchor.
+/// Cursor, row count, and open `v` anchor shared by every row pane.
+#[derive(Default)]
+pub(crate) struct RowCursor {
+    state: ListState,
+    len: usize,
+    anchor: Option<usize>,
+}
+
+impl RowCursor {
+    pub(crate) fn new(len: usize) -> Self {
+        Self {
+            state: ListState::default(),
+            len,
+            anchor: None,
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.len
+    }
+
+    pub(crate) fn cursor(&self) -> usize {
+        self.state
+            .selected()
+            .unwrap_or(0)
+            .min(self.len.saturating_sub(1))
+    }
+
+    pub(crate) fn select(&mut self, idx: usize) {
+        self.state
+            .select((self.len > 0).then(|| idx.min(self.len.saturating_sub(1))));
+    }
+
+    pub(crate) fn offset(&self) -> usize {
+        self.state.offset()
+    }
+
+    pub(crate) fn state(&self) -> &ListState {
+        &self.state
+    }
+
+    pub(crate) fn step(&mut self, up: bool) -> bool {
+        if self.len == 0 {
+            self.state.select(None);
+            return false;
+        }
+        let current = self.cursor();
+        let next = if up {
+            current.saturating_sub(1)
+        } else {
+            (current + 1).min(self.len - 1)
+        };
+        if next == current {
+            return false;
+        }
+        self.state.select(Some(next));
+        true
+    }
+
+    fn clamp(&mut self) {
+        self.select(self.cursor());
+    }
+
+    pub(crate) fn fit(&mut self, len: usize) {
+        if self.len == len {
+            self.clamp();
+            return;
+        }
+        self.len = len;
+        self.clamp();
+        self.anchor = None;
+    }
+
+    pub(crate) fn reset(&mut self, len: usize) {
+        self.len = len;
+        self.state.select((len > 0).then_some(0));
+        self.anchor = None;
+    }
+}
+
+pub(crate) type CursorPane = RowCursor;
+
+/// One selectable list pane: a cursor plus scope marks.
 #[derive(Default)]
 pub(crate) struct ListPane {
-    state: ListState,
+    cursor: RowCursor,
     marks: Selection,
-    anchor: Option<usize>,
+}
+
+impl Deref for ListPane {
+    type Target = RowCursor;
+
+    fn deref(&self) -> &Self::Target {
+        &self.cursor
+    }
+}
+
+impl DerefMut for ListPane {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.cursor
+    }
 }
 
 impl ListPane {
     /// A pane over `marks` — the caller already knows which rows start marked
     /// (source presets); its length is the row count.
     pub(crate) fn with_marks(marks: Vec<bool>) -> Self {
+        let cursor = RowCursor::new(marks.len());
         let mut pane = Self {
-            state: ListState::default(),
+            cursor,
             marks: marks.into(),
-            anchor: None,
         };
-        pane.clamp();
+        pane.cursor.clamp();
         pane
-    }
-
-    pub(crate) fn len(&self) -> usize {
-        self.marks.mask().len()
-    }
-
-    /// Cursor row, clamped to the row count (0 when the pane is empty).
-    pub(crate) fn cursor(&self) -> usize {
-        self.state
-            .selected()
-            .unwrap_or(0)
-            .min(self.len().saturating_sub(1))
-    }
-
-    /// Move the cursor to `idx`, clamped; an empty pane has no cursor.
-    pub(crate) fn select(&mut self, idx: usize) {
-        let len = self.len();
-        self.state
-            .select((len > 0).then(|| idx.min(len.saturating_sub(1))));
-    }
-
-    /// Scroll offset of the rendered list.
-    pub(crate) fn offset(&self) -> usize {
-        self.state.offset()
-    }
-
-    /// List state for the paint; the widget owns the offset.
-    pub(crate) fn state(&self) -> &ListState {
-        &self.state
     }
 
     pub(crate) fn mask(&self) -> &[bool] {
@@ -143,52 +209,22 @@ impl ListPane {
         self.marks.toggle_ids(0..len);
     }
 
-    /// Step the cursor one row (`up` or down); `false` when it did not move,
-    /// so bumping the first or last row never invalidates the panes below.
-    pub(crate) fn step(&mut self, up: bool) -> bool {
-        let len = self.len();
-        if len == 0 {
-            self.state.select(None);
-            return false;
-        }
-        let current = self.cursor();
-        let next = if up {
-            current.saturating_sub(1)
-        } else {
-            (current + 1).min(len - 1)
-        };
-        if next == current {
-            return false;
-        }
-        self.state.select(Some(next));
-        true
-    }
-
-    /// Normalize the cursor against the current row count: an empty pane has
-    /// none, a non-empty pane always has one (row 0 before the first move).
-    fn clamp(&mut self) {
-        let cursor = self.cursor();
-        self.select(cursor);
-    }
-
     /// The row count changed under the pane: marks no longer name the same
     /// rows, so drop them, clamp the cursor, and void an open range.
     pub(crate) fn fit(&mut self, len: usize) {
         if self.len() == len {
-            self.clamp();
+            RowCursor::clamp(self);
             return;
         }
         self.marks.reset(len);
-        self.clamp();
-        self.anchor = None;
+        RowCursor::fit(self, len);
     }
 
     /// The pane was rebuilt from its parent's selection: nothing it held still
     /// means anything, and the cursor starts at the first row.
     pub(crate) fn reset(&mut self, len: usize) {
         self.marks.reset(len);
-        self.state.select((len > 0).then_some(0));
-        self.anchor = None;
+        RowCursor::reset(self, len);
     }
 
     /// `v` over list rows: first press anchors at the cursor, the next marks
@@ -197,7 +233,7 @@ impl ListPane {
     #[cfg(test)]
     pub(crate) fn range_select(&mut self) -> bool {
         let cursor = self.cursor();
-        let Some(span) = range_step(&mut self.anchor, cursor) else {
+        let Some(span) = range_step(&mut self.cursor.anchor, cursor) else {
             return false;
         };
         // Reject out-of-bounds endpoints before iterating: a stray large index
@@ -218,7 +254,7 @@ impl ListPane {
 pub(crate) struct Rows {
     pub(crate) source: ListPane,
     pub(crate) sessions: ListPane,
-    pub(crate) dialogues: ListPane,
+    pub(crate) dialogues: CursorPane,
     /// The only content-selection state. List and block marks are derived
     /// views; cursor/range state never decides what copy or MCP receives.
     pub(crate) selection: WorkSet,
@@ -230,7 +266,7 @@ impl Default for Rows {
         Self {
             source: ListPane::default(),
             sessions: ListPane::default(),
-            dialogues: ListPane::default(),
+            dialogues: CursorPane::default(),
             selection: WorkSet::new(".", Vec::new()),
             content_anchor: None,
         }
@@ -244,8 +280,7 @@ impl Rows {
         match focus {
             WorkspaceFocus::Source => Some(&self.source),
             WorkspaceFocus::Sessions => Some(&self.sessions),
-            WorkspaceFocus::Dialogues => Some(&self.dialogues),
-            WorkspaceFocus::Content => None,
+            WorkspaceFocus::Dialogues | WorkspaceFocus::Content => None,
         }
     }
 
@@ -253,15 +288,14 @@ impl Rows {
         match focus {
             WorkspaceFocus::Source => Some(&mut self.source),
             WorkspaceFocus::Sessions => Some(&mut self.sessions),
-            WorkspaceFocus::Dialogues => Some(&mut self.dialogues),
-            WorkspaceFocus::Content => None,
+            WorkspaceFocus::Dialogues | WorkspaceFocus::Content => None,
         }
     }
 
     fn anchor_mut(&mut self, focus: WorkspaceFocus) -> &mut Option<usize> {
         match focus {
-            WorkspaceFocus::Source => &mut self.source.anchor,
-            WorkspaceFocus::Sessions => &mut self.sessions.anchor,
+            WorkspaceFocus::Source => &mut self.source.cursor.anchor,
+            WorkspaceFocus::Sessions => &mut self.sessions.cursor.anchor,
             WorkspaceFocus::Dialogues => &mut self.dialogues.anchor,
             WorkspaceFocus::Content => &mut self.content_anchor,
         }
@@ -270,8 +304,12 @@ impl Rows {
     /// Row an open range started at — the range highlight, and the endpoint the
     /// next `v` completes against.
     pub(crate) fn range_start(&self, focus: WorkspaceFocus) -> Option<usize> {
-        self.pane(focus)
-            .map_or(self.content_anchor, |pane| pane.anchor)
+        match focus {
+            WorkspaceFocus::Source => self.source.cursor.anchor,
+            WorkspaceFocus::Sessions => self.sessions.cursor.anchor,
+            WorkspaceFocus::Dialogues => self.dialogues.anchor,
+            WorkspaceFocus::Content => self.content_anchor,
+        }
     }
 
     pub(crate) fn close_range(&mut self, focus: WorkspaceFocus) {
@@ -279,8 +317,8 @@ impl Rows {
     }
 
     pub(crate) fn close_ranges(&mut self) {
-        self.source.anchor = None;
-        self.sessions.anchor = None;
+        self.source.cursor.anchor = None;
+        self.sessions.cursor.anchor = None;
         self.dialogues.anchor = None;
         self.content_anchor = None;
     }
@@ -308,11 +346,11 @@ mod tests {
     use super::{ListPane, Rows};
     use crate::tui::workspace::WorkspaceFocus;
 
-    const PANE: WorkspaceFocus = WorkspaceFocus::Dialogues;
+    const PANE: WorkspaceFocus = WorkspaceFocus::Source;
 
     fn rows_of(marks: Vec<bool>) -> Rows {
         Rows {
-            dialogues: ListPane::with_marks(marks),
+            source: ListPane::with_marks(marks),
             ..Rows::default()
         }
     }
@@ -366,10 +404,10 @@ mod tests {
     #[test]
     fn fit_voids_a_range_anchored_into_the_old_rows() {
         let mut rows = rows_of(vec![false; 5]);
-        rows.dialogues.select(4);
+        rows.source.select(4);
         assert!(!rows.range_select(PANE));
         // The list changed shape under the anchor: it no longer names row 4.
-        rows.dialogues.fit(2);
+        rows.source.fit(2);
         assert_eq!(rows.range_start(PANE), None);
     }
 
@@ -385,19 +423,19 @@ mod tests {
     #[test]
     fn first_v_anchors_second_v_selects_span() {
         let mut rows = rows_of(vec![false; 5]);
-        rows.dialogues.select(4);
+        rows.source.select(4);
 
         // First `v` only anchors; nothing is marked yet.
         assert!(!rows.range_select(PANE));
         assert_eq!(rows.range_start(PANE), Some(4));
-        assert!(!rows.dialogues.has_marks());
+        assert!(!rows.source.has_marks());
 
         // Moving the cursor does not disturb the anchor.
-        rows.dialogues.select(1);
+        rows.source.select(1);
         assert!(rows.range_select(PANE));
         assert_eq!(rows.range_start(PANE), None);
         // Span 1..=4 marked; row 0 untouched.
-        assert_eq!(rows.dialogues.mask(), &[false, true, true, true, true]);
+        assert_eq!(rows.source.mask(), &[false, true, true, true, true]);
     }
 
     #[test]

--- a/src/workset.rs
+++ b/src/workset.rs
@@ -14,8 +14,8 @@ pub struct WorkSet {
     pub cwd: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    pub records: Vec<WorkRecord>,
-    pub anchors: Vec<WorkRef>,
+    records: Vec<WorkRecord>,
+    anchors: Vec<WorkRef>,
 }
 
 impl WorkSet {
@@ -44,6 +44,31 @@ impl WorkSet {
 
     pub fn anchors(&self) -> Vec<WorkRef> {
         self.anchors.clone()
+    }
+
+    pub fn records(&self) -> &[WorkRecord] {
+        &self.records
+    }
+
+    pub(crate) fn records_mut(&mut self) -> &mut [WorkRecord] {
+        &mut self.records
+    }
+
+    pub fn into_records(self) -> Vec<WorkRecord> {
+        self.records
+    }
+
+    pub fn into_parts(self) -> (Vec<WorkRecord>, Vec<WorkRef>) {
+        (self.records, self.anchors)
+    }
+
+    pub(crate) fn replace_records(&mut self, records: Vec<WorkRecord>) {
+        self.records = records;
+    }
+
+    pub(crate) fn replace_selection(&mut self, records: Vec<WorkRecord>, anchors: Vec<WorkRef>) {
+        self.records = records;
+        self.anchors = anchors;
     }
 
     /// Whether this selection covers an address. A Whole anchor covers every
@@ -88,7 +113,7 @@ impl WorkSet {
             return;
         }
         if self
-            .anchors()
+            .anchors
             .iter()
             .any(|anchor| anchor.at == WorkAt::Whole && anchor.whole() == whole)
         {
@@ -112,7 +137,7 @@ impl WorkSet {
     /// Toggle a complete record selection.
     pub fn toggle_whole(&mut self, record: WorkRecord) {
         if self
-            .anchors()
+            .anchors
             .iter()
             .any(|anchor| anchor.at == WorkAt::Whole && anchor.whole() == record.work_ref.whole())
         {
@@ -154,7 +179,7 @@ impl WorkSet {
             return;
         }
         let all_selected = records.iter().all(|record| {
-            self.anchors().iter().any(|anchor| {
+            self.anchors.iter().any(|anchor| {
                 anchor.at == WorkAt::Whole && anchor.whole() == record.work_ref.whole()
             })
         });

--- a/src/workset.rs
+++ b/src/workset.rs
@@ -14,7 +14,9 @@ pub struct WorkSet {
     pub cwd: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// Materialized records backing every anchor.
     records: Vec<WorkRecord>,
+    /// Active selection positions; Whole covers every Part of its record.
     anchors: Vec<WorkRef>,
 }
 
@@ -24,10 +26,10 @@ impl WorkSet {
             .iter()
             .map(|record| record.work_ref.whole())
             .collect();
-        Self::with_anchors(cwd, records, anchors)
+        Self::from_parts(cwd, records, anchors)
     }
 
-    pub fn with_anchors(
+    pub fn from_parts(
         cwd: impl Into<String>,
         records: Vec<WorkRecord>,
         anchors: Vec<WorkRef>,
@@ -216,7 +218,7 @@ impl WorkSet {
             })
             .cloned()
             .collect();
-        Some(Self::with_anchors(self.cwd.clone(), records, anchors))
+        Some(Self::from_parts(self.cwd.clone(), records, anchors))
     }
 
     /// Remove a record and every Part anchor belonging to it.

--- a/src/workset.rs
+++ b/src/workset.rs
@@ -42,8 +42,8 @@ impl WorkSet {
         }
     }
 
-    pub fn anchors(&self) -> Vec<WorkRef> {
-        self.anchors.clone()
+    pub fn anchors(&self) -> &[WorkRef] {
+        &self.anchors
     }
 
     pub fn records(&self) -> &[WorkRecord] {
@@ -199,8 +199,9 @@ impl WorkSet {
     pub fn parts_only(&self) -> Option<Self> {
         let anchors: Vec<_> = self
             .anchors()
-            .into_iter()
+            .iter()
             .filter(|anchor| anchor.at != WorkAt::Whole)
+            .cloned()
             .collect();
         if anchors.is_empty() {
             return None;


### PR DESCRIPTION
## Purpose
Make pane state ownership explicit after selection projection changes.

## Changes
- Consolidate cursor, range, and scope state in pane models.
- Remove stale forwarding and duplicate pane invalidation paths.
- Keep navigation behavior independent from business selection.

## Validation
Validated on the stack tip with `cargo build --target-dir target/build-check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p sivtr --lib`.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined workspace navigation and selection behavior across sources, sessions, and dialogues.
  * Improved handling of selected items during loading, refreshing, filtering, and navigation.
  * Enhanced workspace rendering with clearer selection counts and more consistent row interactions.

* **Refactor**
  * Improved internal data handling to provide more reliable access to worksets and selections without changing expected workflows.

* **Documentation**
  * Updated terminology describing dialogue selection and workspace interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->