### PR TITLE
refactor(workset): validate selection pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ crates/sivtr-core/src/     ← Core library (no CLI deps)
   query/                   ← Workspace record/source loading
   search/                  ← Filter/Searcher pipeline, BM25 ranking (types.rs, filter.rs, bm25.rs, eval.rs)
   workspace.rs             ← Workspace resolution (git root → sessions), data_dir()
+  workset.rs               ← WorkSet / WorkSelection* canonical selection model
   config/                  ← SivtrConfig, serde TOML
   history/                 ← SQLite command history
   session.rs               ← Session log reading

--- a/crates/sivtr-core/src/lib.rs
+++ b/crates/sivtr-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod session;
 pub mod session_source;
 pub mod time;
 pub mod workspace;
+pub mod workset;
 
 pub use agents::claude;
 pub use agents::codex;

--- a/crates/sivtr-core/src/lib.rs
+++ b/crates/sivtr-core/src/lib.rs
@@ -12,8 +12,8 @@ pub mod search;
 pub mod session;
 pub mod session_source;
 pub mod time;
-pub mod workspace;
 pub mod workset;
+pub mod workspace;
 
 pub use agents::claude;
 pub use agents::codex;

--- a/crates/sivtr-core/src/workset.rs
+++ b/crates/sivtr-core/src/workset.rs
@@ -169,6 +169,7 @@ impl WorkSet {
     pub fn select_anchors(&mut self, anchors: Vec<WorkRef>) {
         self.records = records_for_anchors(&self.records, &anchors);
         self.anchors = anchors;
+        self.normalize_anchors();
     }
 
     pub fn validate(&self) -> Result<()> {

--- a/crates/sivtr-core/src/workset.rs
+++ b/crates/sivtr-core/src/workset.rs
@@ -304,10 +304,6 @@ impl WorkSet {
         if parts.is_empty() {
             return;
         }
-        if !record.parts.is_empty() && record.parts.iter().all(|part| parts.contains(&part.seq)) {
-            self.toggle_whole(record);
-            return;
-        }
         if parts
             .iter()
             .all(|seq| self.contains(&record.work_ref.with_part(*seq)))

--- a/crates/sivtr-core/src/workset.rs
+++ b/crates/sivtr-core/src/workset.rs
@@ -3,9 +3,12 @@
 use anyhow::{bail, Context, Result};
 use chrono::{SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
-use sivtr_core::ai::AgentProvider;
-use sivtr_core::record::{WorkAt, WorkPath, WorkRecord, WorkRef, WorkScope};
-use std::collections::HashSet;
+
+use crate::ai::AgentProvider;
+use crate::query::{load_session_records, LoadMode};
+use crate::record::{WorkAt, WorkPath, WorkRecord, WorkRef, WorkScope};
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
 
 pub const WORKSET_SCHEMA_VERSION: u32 = 2;
 
@@ -151,7 +154,7 @@ impl WorkSet {
         &self.records
     }
 
-    pub(crate) fn records_mut(&mut self) -> &mut [WorkRecord] {
+    pub fn records_mut(&mut self) -> &mut [WorkRecord] {
         &mut self.records
     }
 
@@ -163,12 +166,12 @@ impl WorkSet {
         (self.records, self.anchors)
     }
 
-    pub(crate) fn select_anchors(&mut self, anchors: Vec<WorkRef>) {
+    pub fn select_anchors(&mut self, anchors: Vec<WorkRef>) {
         self.records = records_for_anchors(&self.records, &anchors);
         self.anchors = anchors;
     }
 
-    pub(crate) fn validate(&self) -> Result<()> {
+    pub fn validate(&self) -> Result<()> {
         if self.schema_version != WORKSET_SCHEMA_VERSION {
             bail!(
                 "unsupported WorkSet schema version {}; expected {}",
@@ -393,6 +396,56 @@ impl WorkSet {
         self.records
             .retain(|record| record.work_ref.whole() != whole);
         self.anchors.retain(|anchor| anchor.whole() != whole);
+    }
+
+    /// Fill in `parts` for any light-loaded record (empty `parts`) whose
+    /// session file path is known. Each session file is loaded once (full
+    /// view), then matching records are patched in place. Records without a
+    /// session path (stdin sets) are already complete and stay untouched.
+    pub fn materialize_parts(&mut self) -> Result<()> {
+        // Group light records by their session file path, then load each
+        // session's full records once and patch matching parts back.
+        let mut needed: HashMap<String, Vec<usize>> = HashMap::new();
+        for (index, record) in self.records().iter().enumerate() {
+            if !record.parts.is_empty() {
+                continue;
+            }
+            let Some(path) = record.session.path.as_deref() else {
+                continue;
+            };
+            needed.entry(path.to_string()).or_default().push(index);
+        }
+
+        for (path, indices) in &needed {
+            // Any record in the group gives us the namespace; pick the first.
+            let namespace = session_namespace(&self.records()[indices[0]].work_ref.path);
+            let Some(namespace) = namespace else {
+                continue;
+            };
+            let full = load_session_records(namespace, Path::new(path), LoadMode::Full)
+                .with_context(|| format!("Failed to load full session {path} for {namespace}"))?;
+            for index in indices {
+                if let Some(record) = self.records_mut().get_mut(*index) {
+                    if let Some(full_record) = full
+                        .iter()
+                        .find(|r| r.work_ref.path.index() == record.work_ref.path.index())
+                    {
+                        record.parts = full_record.parts.clone();
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Cache namespace for a record's session file, used by
+/// [`WorkSet::materialize_parts`] to pick the right cache view when
+/// re-loading full records.
+fn session_namespace(path: &WorkPath) -> Option<&'static str> {
+    match path {
+        WorkPath::Agent { provider, .. } => Some(provider.command_name()),
+        WorkPath::Terminal { .. } => Some("terminal"),
     }
 }
 

--- a/src/commands/browse/content.rs
+++ b/src/commands/browse/content.rs
@@ -9,7 +9,7 @@ use crate::tui::search::{WorkspaceSearchMatch, WorkspaceSearchOutput};
 use crate::tui::workspace::{WorkspaceDialogue, WorkspaceSession, WorkspaceSource};
 use sivtr_core::record::{WorkAt, WorkRecord, WorkRef};
 
-use crate::commands::memory::workset::WorkSet;
+use crate::commands::memory::workset::{WorkSelectionAction, WorkSelectionTarget, WorkSet};
 
 use super::text::filter_lines_by_spec;
 use super::vim::{VimBlock, VimView};
@@ -98,8 +98,19 @@ pub(super) fn workspace_picked_content_for_copy(
     let mut set = WorkSet::from_parts(cwd.display().to_string(), Vec::new(), Vec::new());
     for record in records {
         match display_target {
-            Some(WorkAt::Part(seq)) => set.include_parts(record, [seq]),
-            _ => set.include_whole(record),
+            Some(WorkAt::Part(seq)) => set.apply_target(
+                WorkSelectionAction::Include,
+                WorkSelectionTarget::Parts {
+                    record,
+                    parts: vec![seq],
+                },
+                [],
+            ),
+            _ => set.apply_target(
+                WorkSelectionAction::Include,
+                WorkSelectionTarget::Whole(record),
+                [],
+            ),
         }
     }
     Ok(PickedContent::WorkSet {
@@ -141,7 +152,11 @@ pub(super) fn workspace_picked_content_for_cursor_block(
     };
     let cwd = std::env::current_dir().context("copy needs a current directory")?;
     let mut set = WorkSet::from_parts(cwd.display().to_string(), Vec::new(), Vec::new());
-    set.include_parts(record, parts);
+    set.apply_target(
+        WorkSelectionAction::Include,
+        WorkSelectionTarget::Parts { record, parts },
+        [],
+    );
     Ok(Some(PickedContent::WorkSet {
         source,
         set,
@@ -316,7 +331,7 @@ pub(super) fn dialogue_text_vim_view(text: String) -> VimView {
 mod tests {
     use super::*;
     use crate::tui::workspace::WorkspaceSource;
-    use crate::workset::WorkSet;
+    use crate::workset::{WorkSelectionAction, WorkSelectionTarget, WorkSet};
     use sivtr_core::ai::AgentProvider;
     use sivtr_core::record::{
         WorkChannel, WorkPart, WorkPartData, WorkRecord, WorkRecordKind, WorkRef, WorkSessionRef,
@@ -375,8 +390,17 @@ mod tests {
         let b = dialogue(record("B", "Bash", "git status", 1));
         let dialogues = [a, b];
         let mut selection = WorkSet::new(".", Vec::new());
-        selection.include_parts(dialogues[0].record.clone().unwrap(), [2]);
-        selection.include_parts(dialogues[1].record.clone().unwrap(), [2]);
+        for dialogue in &dialogues {
+            let record = dialogue.record.clone().unwrap();
+            selection.apply_target(
+                WorkSelectionAction::Include,
+                WorkSelectionTarget::Parts {
+                    record,
+                    parts: vec![2],
+                },
+                [],
+            );
+        }
         let picked = workspace_picked_content_for_selected_parts(&selection, &dialogues)
             .expect("selected parts");
         let PickedContent::WorkSet {
@@ -406,7 +430,14 @@ mod tests {
         });
         let dialogues = [dialogue(base)];
         let mut selection = WorkSet::new(".", Vec::new());
-        selection.include_parts(dialogues[0].record.clone().unwrap(), [2, 3, 2]);
+        selection.apply_target(
+            WorkSelectionAction::Include,
+            WorkSelectionTarget::Parts {
+                record: dialogues[0].record.clone().unwrap(),
+                parts: vec![2, 3, 2],
+            },
+            [],
+        );
         let picked = workspace_picked_content_for_selected_parts(&selection, &dialogues)
             .expect("selected run");
         let PickedContent::WorkSet {

--- a/src/commands/browse/content.rs
+++ b/src/commands/browse/content.rs
@@ -335,12 +335,12 @@ pub(super) fn dialogue_text_vim_view(text: String) -> VimView {
 mod tests {
     use super::*;
     use crate::tui::workspace::WorkspaceSource;
-    use sivtr_core::workset::{WorkSelectionAction, WorkSelectionTarget, WorkSet};
     use sivtr_core::ai::AgentProvider;
     use sivtr_core::record::{
         WorkChannel, WorkPart, WorkPartData, WorkRecord, WorkRecordKind, WorkRef, WorkSessionRef,
         WorkSource, WorkTime,
     };
+    use sivtr_core::workset::{WorkSelectionAction, WorkSelectionTarget, WorkSet};
 
     fn record(title: &str, tool: &str, command: &str, index: usize) -> WorkRecord {
         let mut record = WorkRecord {

--- a/src/commands/browse/content.rs
+++ b/src/commands/browse/content.rs
@@ -128,11 +128,7 @@ pub(super) fn workspace_picked_content_for_selected_parts(
     dialogues: &[WorkspaceDialogue],
 ) -> Option<PickedContent> {
     let set = selection.parts_only()?;
-<<<<<<< HEAD
-    let anchor = set.anchors().first()?;
-=======
     let anchor = set.anchors().first()?.clone();
->>>>>>> 9e7825f (refactor(browse): align final workset accessors)
     let source = dialogues.iter().find_map(|dialogue| {
         (dialogue.work_ref.as_ref()?.whole() == anchor.whole()).then(|| dialogue.source.clone())
     })?;

--- a/src/commands/browse/content.rs
+++ b/src/commands/browse/content.rs
@@ -128,7 +128,11 @@ pub(super) fn workspace_picked_content_for_selected_parts(
     dialogues: &[WorkspaceDialogue],
 ) -> Option<PickedContent> {
     let set = selection.parts_only()?;
+<<<<<<< HEAD
     let anchor = set.anchors().first()?;
+=======
+    let anchor = set.anchors().first()?.clone();
+>>>>>>> 9e7825f (refactor(browse): align final workset accessors)
     let source = dialogues.iter().find_map(|dialogue| {
         (dialogue.work_ref.as_ref()?.whole() == anchor.whole()).then(|| dialogue.source.clone())
     })?;

--- a/src/commands/browse/content.rs
+++ b/src/commands/browse/content.rs
@@ -335,7 +335,7 @@ pub(super) fn dialogue_text_vim_view(text: String) -> VimView {
 mod tests {
     use super::*;
     use crate::tui::workspace::WorkspaceSource;
-    use crate::workset::{WorkSelectionAction, WorkSelectionTarget, WorkSet};
+    use sivtr_core::workset::{WorkSelectionAction, WorkSelectionTarget, WorkSet};
     use sivtr_core::ai::AgentProvider;
     use sivtr_core::record::{
         WorkChannel, WorkPart, WorkPartData, WorkRecord, WorkRecordKind, WorkRef, WorkSessionRef,

--- a/src/commands/browse/load.rs
+++ b/src/commands/browse/load.rs
@@ -48,12 +48,6 @@ pub struct SourceLoadState {
 }
 
 impl SourceLoadState {
-    pub fn idle() -> Self {
-        Self {
-            pane: SessionPane::default(),
-        }
-    }
-
     pub fn ready_from_sessions(sessions: Vec<WorkspaceSession>, budget: usize) -> Self {
         let rows = sessions
             .into_iter()

--- a/src/commands/browse/load.rs
+++ b/src/commands/browse/load.rs
@@ -300,8 +300,7 @@ impl SourceLoadPump {
                     Ok(mut results) => match results.pop() {
                         Some(QuerySourceResult::Ok(set)) => {
                             let n = set.records().len();
-                            let mut sessions =
-                                sessions_from_records(&source, set.records().to_vec());
+                            let mut sessions = sessions_from_records(&source, set.into_records());
                             for s in &mut sessions {
                                 s.records.clear();
                                 s.body_loaded = false;
@@ -358,7 +357,7 @@ impl SourceLoadPump {
                         Some(QuerySourceResult::Ok(mut set)) => match set.materialize_parts() {
                             Ok(()) => {
                                 let mut sessions =
-                                    sessions_from_records(&source, set.records().to_vec());
+                                    sessions_from_records(&source, set.into_records());
                                 for s in &mut sessions {
                                     s.body_loaded = !s.records.is_empty();
                                 }
@@ -620,11 +619,11 @@ pub fn body_keep_set(
     sources: &[WorkspaceSource],
     sessions: &[WorkspaceSession],
     focus_idx: usize,
-    selected_sessions: &[bool],
+    session_scope: &[bool],
     neighbor_radius: usize,
 ) -> HashSet<(usize, String)> {
     let index_keys: Vec<usize> = (0..sessions.len()).collect();
-    let keep_idx = keep_keys(&index_keys, focus_idx, selected_sessions, neighbor_radius);
+    let keep_idx = keep_keys(&index_keys, focus_idx, session_scope, neighbor_radius);
     keep_idx
         .into_iter()
         .filter_map(|i| {

--- a/src/commands/browse/mod.rs
+++ b/src/commands/browse/mod.rs
@@ -75,8 +75,7 @@ fn run_catalog(
         .iter()
         .map(|source| select_remotes || !source.is_remote())
         .collect();
-    let source_states: Vec<SourceLoadState> =
-        sources.iter().map(|_| SourceLoadState::idle()).collect();
+    let source_states: Vec<SourceLoadState> = sources.iter().map(|_| Default::default()).collect();
 
     let mut terminal = init_tui()?;
     let result = run_picker_guarded(

--- a/src/commands/browse/nav.rs
+++ b/src/commands/browse/nav.rs
@@ -356,8 +356,6 @@ mod tests {
         let mut rows = Rows::default();
         let mut scrolls = ContentScrolls::default();
         let mut cursor = ContentBlockCursor::default();
-        let mut rows = Rows::default();
-        let mut scrolls = ContentScrolls::default();
         cursor.set(3);
 
         move_content_cursor(true, &mut rows, &mut scrolls, &mut cursor, (&[], &blocks));

--- a/src/commands/browse/nav.rs
+++ b/src/commands/browse/nav.rs
@@ -279,7 +279,7 @@ pub(super) fn source_list_index(
 mod tests {
     use super::{move_content_cursor, row_list_index, ContentBlockCursor};
     use crate::tui::content::block::BlockText;
-    use crate::tui::workspace::{ContentScrolls, RowCursor, Rows};
+    use crate::tui::workspace::{ContentScrolls, Rows};
     use ratatui::layout::Rect;
     use sivtr_core::record::WorkPartKind;
 
@@ -301,7 +301,7 @@ mod tests {
     #[test]
     fn a_step_off_the_last_block_crosses_into_the_next_dialogue() {
         let mut rows = Rows::default();
-        rows.dialogues = RowCursor::new(2);
+        rows.dialogues.fit(2);
         let mut scrolls = ContentScrolls::default();
         let mut cursor = ContentBlockCursor::default();
         let first = blocks(&[0]);
@@ -356,6 +356,8 @@ mod tests {
         let mut rows = Rows::default();
         let mut scrolls = ContentScrolls::default();
         let mut cursor = ContentBlockCursor::default();
+        let mut rows = Rows::default();
+        let mut scrolls = ContentScrolls::default();
         cursor.set(3);
 
         move_content_cursor(true, &mut rows, &mut scrolls, &mut cursor, (&[], &blocks));

--- a/src/commands/browse/panes.rs
+++ b/src/commands/browse/panes.rs
@@ -93,11 +93,12 @@ impl DialoguePane {
         if rows.is_empty() {
             return;
         }
+        assert_eq!(selected.len(), rows.len());
         let focus = focus.min(rows.len() - 1);
         for (i, row) in rows.iter().enumerate() {
             // The cursor dialogue's body is always needed: the content pane
             // shows it even when the selection marks other dialogues.
-            let need_body = i == focus || selected.get(i).copied().unwrap_or(false);
+            let need_body = i == focus || selected[i];
             let item = if need_body {
                 if let Some(body) = row.body.clone() {
                     body

--- a/src/commands/browse/panes.rs
+++ b/src/commands/browse/panes.rs
@@ -14,7 +14,7 @@ use crate::tui::workspace::{
     active_rows, workspace_content_io_texts, ContentIoFocus, ContentIoFrame, ExpandedBlocks,
     WorkspaceDialogue, WorkspaceSession, WorkspaceSource,
 };
-use crate::workset::WorkSet;
+use sivtr_core::workset::WorkSet;
 use sivtr_core::record::{WorkAt, WorkRecord, WorkRef};
 
 // ── Dialogues ───────────────────────────────────────────────────────────
@@ -370,7 +370,7 @@ pub struct ContentCtx<'a> {
 ///
 /// Not a [`crate::pane::Pane`]: its rows are the shown dialogue's rendered
 /// lines, not a window over a growing list, so there is nothing to grow,
-/// keep, or hydrate — `ensure` hands the caller the frame to render.
+/// keep, or hydrate — `frame` hands the caller the rendered layout.
 #[derive(Default)]
 pub struct ContentPane {
     input_lines: usize,
@@ -388,7 +388,7 @@ impl ContentPane {
     /// Build the frame for this context, resizing the block selection mask
     /// of the shown dialogue's block ids. Rebuilds the cached layouts; call
     /// it only when the content actually changed.
-    pub fn ensure(&mut self, ctx: ContentCtx<'_>) -> ContentIoFrame {
+    pub fn frame(&mut self, ctx: ContentCtx<'_>) -> ContentIoFrame {
         let texts = workspace_content_io_texts(
             ctx.dialogues,
             ctx.highlighted_idx,
@@ -416,8 +416,9 @@ impl ContentPane {
         else {
             return Vec::new();
         };
-        let mut marked = vec![false; crate::tui::content::block::dialogue_block_count(record)];
         let (input, output) = crate::tui::content::block::dialogue_blocks(record);
+        let mut marked =
+            vec![false; crate::tui::content::block::dialogue_block_count(&input, &output)];
         for block in input.iter().chain(&output) {
             mark_selected_blocks(block, record, selection, &mut marked);
         }

--- a/src/commands/browse/panes.rs
+++ b/src/commands/browse/panes.rs
@@ -404,7 +404,7 @@ impl ContentPane {
     /// WorkSet-derived block highlights for one dialogue. A Whole selection
     /// covers every block; a run highlights only when every part it owns is
     /// selected, while its children remain independently derived.
-    pub fn selection_mask(
+    pub fn block_selection_mask(
         dialogues: &[WorkspaceDialogue],
         dialogue_idx: usize,
         selection: &WorkSet,

--- a/src/commands/browse/panes.rs
+++ b/src/commands/browse/panes.rs
@@ -243,11 +243,11 @@ fn dialogue_from_record(session: &WorkspaceSession, record: &WorkRecord) -> Work
 fn fingerprint<'a>(
     sessions: &[WorkspaceSession],
     session_idx: usize,
-    selected_sessions: &[bool],
+    session_scope: &[bool],
     records: &dyn Fn(&WorkspaceSession) -> Option<&'a [WorkRecord]>,
 ) -> DialogueFingerprint {
     DialogueFingerprint {
-        sessions: active_rows(selected_sessions, session_idx, sessions.len())
+        sessions: active_rows(session_scope, session_idx, sessions.len())
             .into_iter()
             .filter_map(|i| {
                 let s = sessions.get(i)?;
@@ -261,14 +261,14 @@ fn fingerprint<'a>(
 fn meta_prefix<'a>(
     sessions: &[WorkspaceSession],
     session_idx: usize,
-    selected_sessions: &[bool],
+    session_scope: &[bool],
     records: &dyn Fn(&WorkspaceSession) -> Option<&'a [WorkRecord]>,
     budget: usize,
 ) -> (
     Vec<WindowRow<DialogueKey, DialogueMeta, WorkspaceDialogue>>,
     bool,
 ) {
-    let indices = active_rows(selected_sessions, session_idx, sessions.len());
+    let indices = active_rows(session_scope, session_idx, sessions.len());
     if indices.is_empty() {
         return (Vec::new(), true);
     }
@@ -330,11 +330,11 @@ fn meta_prefix<'a>(
 fn body_for_key<'a>(
     sessions: &[WorkspaceSession],
     session_idx: usize,
-    selected_sessions: &[bool],
+    session_scope: &[bool],
     records: &dyn Fn(&WorkspaceSession) -> Option<&'a [WorkRecord]>,
     key: &DialogueKey,
 ) -> Option<WorkspaceDialogue> {
-    for i in active_rows(selected_sessions, session_idx, sessions.len()) {
+    for i in active_rows(session_scope, session_idx, sessions.len()) {
         let Some(session) = sessions.get(i) else {
             continue;
         };

--- a/src/commands/browse/panes.rs
+++ b/src/commands/browse/panes.rs
@@ -14,8 +14,8 @@ use crate::tui::workspace::{
     active_rows, workspace_content_io_texts, ContentIoFocus, ContentIoFrame, ExpandedBlocks,
     WorkspaceDialogue, WorkspaceSession, WorkspaceSource,
 };
-use sivtr_core::workset::WorkSet;
 use sivtr_core::record::{WorkAt, WorkRecord, WorkRef};
+use sivtr_core::workset::WorkSet;
 
 // ── Dialogues ───────────────────────────────────────────────────────────
 

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -417,7 +417,7 @@ pub(crate) fn run(
 
             let source_markers = sessions_pane.markers();
             let content_marked =
-                ContentPane::selection_mask(&dialogues, dialogue_idx, &rows.selection);
+                ContentPane::block_selection_mask(&dialogues, dialogue_idx, &rows.selection);
             let body_failures: HashSet<(WorkspaceSource, String)> = sessions
                 .iter()
                 .filter_map(|s| {

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -25,8 +25,8 @@ use crate::tui::workspace::{
 
 use super::content::{
     active_workspace_content_at, handle_line_filter_key, handle_line_filter_paste,
-    line_filter_spec, workspace_block_parts, workspace_picked_content_for_selected_parts,
-    workspace_search_target_ref, PickedContent,
+    line_filter_spec, workspace_picked_content_for_selected_parts, workspace_search_target_ref,
+    PickedContent,
 };
 use super::help::{apply_workspace_help_action, set_focus, toggle_list_row, HelpDispatch};
 use super::load::{SessionColumn, SessionCtx, SourceLoadState};
@@ -35,7 +35,9 @@ use super::nav::{
     open_link_target, row_list_index, source_list_index, ContentBlockCursor,
 };
 use super::panes::{ContentCtx, ContentPane, DialogueCtx, DialoguePane};
-use super::selection::{refresh_next_level, resolve_loaded_scopes, toggle_row_selection};
+use super::selection::{
+    refresh_next_level, resolve_loaded_scopes, toggle_block_selection, toggle_row_selection,
+};
 use super::visual::{
     apply_workspace_mouse_scroll, handle_content_mouse_select, handle_visual_select_key,
     MouseSelectionStart, VisualContentContext, VisualSelectMode, MOUSE_SCROLL_LINES,
@@ -956,13 +958,7 @@ pub(crate) fn run(
                                     WorkspaceFocus::Content,
                                 );
                                 content_cursor.set(block);
-                                if let Some((_, record, parts)) = workspace_block_parts(
-                                    &dialogues,
-                                    rows.dialogues.cursor(),
-                                    block,
-                                ) {
-                                    rows.selection.toggle_parts(record, parts);
-                                }
+                                toggle_block_selection(&mut rows, &dialogues, block);
                                 continue;
                             }
                         }

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -373,7 +373,7 @@ pub(crate) fn run(
                 expanded_blocks.clone(),
             );
             if last_content_key.as_ref() != Some(&content_key) {
-                content_frame = content_pane.ensure(ContentCtx {
+                content_frame = content_pane.frame(ContentCtx {
                     dialogues: &dialogues,
                     highlighted_idx: dialogue_idx,
                     mode: content_mode,
@@ -1614,10 +1614,10 @@ mod tests {
             record: Some(record.clone()),
         };
         let dialogues = [dialogue.clone()];
-        let mut selection = crate::workset::WorkSet::new(".", Vec::new());
+        let mut selection = sivtr_core::workset::WorkSet::new(".", Vec::new());
         selection.apply_target(
-            crate::workset::WorkSelectionAction::Include,
-            crate::workset::WorkSelectionTarget::Parts {
+            sivtr_core::workset::WorkSelectionAction::Include,
+            sivtr_core::workset::WorkSelectionTarget::Parts {
                 record: record.clone(),
                 parts: record.parts.iter().skip(2).map(|part| part.seq).collect(),
             },
@@ -1688,7 +1688,7 @@ mod tests {
         let dialogues = [dialogue.clone()];
         let mut pane = ContentPane::default();
         let area = ratatui::layout::Rect::new(0, 0, 60, 20);
-        let frame = pane.ensure(ContentCtx {
+        let frame = pane.frame(ContentCtx {
             dialogues: &dialogues,
             highlighted_idx: 0,
             mode: ContentViewMode::Reading,
@@ -1711,10 +1711,10 @@ mod tests {
         let hit_id = hit_id.expect("a block is hit in the output half");
         let (_, selected, parts) =
             workspace_block_parts(&dialogues, 0, hit_id).expect("selected block");
-        let mut selection = crate::workset::WorkSet::new(".", Vec::new());
+        let mut selection = sivtr_core::workset::WorkSet::new(".", Vec::new());
         selection.apply_target(
-            crate::workset::WorkSelectionAction::Include,
-            crate::workset::WorkSelectionTarget::Parts {
+            sivtr_core::workset::WorkSelectionAction::Include,
+            sivtr_core::workset::WorkSelectionTarget::Parts {
                 record: selected,
                 parts,
             },
@@ -1850,10 +1850,10 @@ mod tests {
 
         let (_, selected, parts) =
             workspace_block_parts(&dialogues, 0, 2).expect("selected member");
-        let mut selection = crate::workset::WorkSet::new(".", Vec::new());
+        let mut selection = sivtr_core::workset::WorkSet::new(".", Vec::new());
         selection.apply_target(
-            crate::workset::WorkSelectionAction::Include,
-            crate::workset::WorkSelectionTarget::Parts {
+            sivtr_core::workset::WorkSelectionAction::Include,
+            sivtr_core::workset::WorkSelectionTarget::Parts {
                 record: selected,
                 parts,
             },

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -1303,6 +1303,7 @@ mod tests {
     };
     use super::super::nav::move_workspace_cursor;
     use super::super::panes::{ContentCtx, ContentPane, DialogueCtx, DialoguePane};
+    use crate::commands::browse::selection::toggle_row_selection;
     use crate::pane::{Pane, PaneInput, Viewport};
     use crate::tui::content::text::workspace_content_text;
     use crate::tui::content::view::ContentViewMode;
@@ -1311,8 +1312,8 @@ mod tests {
         WorkspaceSearchIndex, WorkspaceSearchMatch, WorkspaceSearchScope,
     };
     use crate::tui::workspace::{
-        ContentIoFocus, ContentScrolls, Rows, TextPair, WorkspaceDialogue, WorkspaceFocus,
-        WorkspaceSession, WorkspaceSource, WorkspaceSourceKind,
+        ContentIoFocus, ContentScrolls, ListPane, Rows, TextPair, WorkspaceDialogue,
+        WorkspaceFocus, WorkspaceSession, WorkspaceSource, WorkspaceSourceKind,
     };
     use crossterm::event::{KeyCode, KeyModifiers};
     use sivtr_core::ai::AgentProvider;
@@ -1517,6 +1518,58 @@ mod tests {
     }
 
     #[test]
+    fn session_selection_projects_to_every_dialogue_record() {
+        let source = WorkspaceSource::agent(AgentProvider::Codex);
+        let sessions = vec![workspace_test_session("test", source, &["d1", "d2"])];
+        let records: Vec<Vec<_>> = sessions
+            .iter()
+            .map(|session| session.records.clone())
+            .collect();
+        let mut rows = Rows::default();
+        rows.sessions = ListPane::from_scope(vec![false]);
+
+        toggle_row_selection(
+            WorkspaceFocus::Sessions,
+            0,
+            &mut rows,
+            &[],
+            &sessions,
+            &records,
+            &[],
+        );
+
+        assert_eq!(rows.selection.anchors().len(), 2);
+        assert!(sessions[0]
+            .records
+            .iter()
+            .all(|record| rows.selection.contains(&record.work_ref)));
+        let dialogues: Vec<_> = sessions[0]
+            .records
+            .iter()
+            .map(|record| WorkspaceDialogue {
+                source: sessions[0].source.clone(),
+                work_ref: Some(record.work_ref.clone()),
+                record: Some(record.clone()),
+            })
+            .collect();
+        assert_eq!(
+            dialogues
+                .iter()
+                .map(|dialogue| dialogue
+                    .work_ref
+                    .as_ref()
+                    .is_some_and(|reference| rows.selection.contains(reference)))
+                .collect::<Vec<_>>(),
+            vec![true, true]
+        );
+        assert!(
+            ContentPane::block_selection_mask(&dialogues, 0, &rows.selection)
+                .into_iter()
+                .all(|marked| marked)
+        );
+    }
+
+    #[test]
     fn marked_block_copy_with_real_sized_record_keeps_unmarked_blocks_out() {
         // A dialogue-sized record: user, assistant, then a run of three tool
         // pairs (output half). Marking one block must copy only its bodies.
@@ -1561,9 +1614,13 @@ mod tests {
         };
         let dialogues = [dialogue.clone()];
         let mut selection = crate::workset::WorkSet::new(".", Vec::new());
-        selection.include_parts(
-            record.clone(),
-            record.parts.iter().skip(2).map(|part| part.seq),
+        selection.apply_target(
+            crate::workset::WorkSelectionAction::Include,
+            crate::workset::WorkSelectionTarget::Parts {
+                record: record.clone(),
+                parts: record.parts.iter().skip(2).map(|part| part.seq).collect(),
+            },
+            [],
         );
         let picked = workspace_picked_content_for_selected_parts(&selection, &dialogues)
             .expect("selected parts");
@@ -1654,7 +1711,14 @@ mod tests {
         let (_, selected, parts) =
             workspace_block_parts(&dialogues, 0, hit_id).expect("selected block");
         let mut selection = crate::workset::WorkSet::new(".", Vec::new());
-        selection.include_parts(selected, parts);
+        selection.apply_target(
+            crate::workset::WorkSelectionAction::Include,
+            crate::workset::WorkSelectionTarget::Parts {
+                record: selected,
+                parts,
+            },
+            [],
+        );
         let picked = workspace_picked_content_for_selected_parts(&selection, &dialogues)
             .expect("selected parts");
         let text = picked_units(&picked)
@@ -1786,7 +1850,14 @@ mod tests {
         let (_, selected, parts) =
             workspace_block_parts(&dialogues, 0, 2).expect("selected member");
         let mut selection = crate::workset::WorkSet::new(".", Vec::new());
-        selection.include_parts(selected, parts);
+        selection.apply_target(
+            crate::workset::WorkSelectionAction::Include,
+            crate::workset::WorkSelectionTarget::Parts {
+                record: selected,
+                parts,
+            },
+            [],
+        );
         let picked = workspace_picked_content_for_selected_parts(&selection, &dialogues)
             .expect("selected member copy");
         let text = &picked_units(&picked)[0].plain;

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -176,7 +176,8 @@ pub(crate) fn run(
                         .map(|s| {
                             let mut full = s.clone();
                             if let Some(recs) = sessions_pane.body_for(s) {
-                                full.records = recs.to_vec();
+                                full.records.clear();
+                                full.records.extend(recs.iter().cloned());
                             }
                             full
                         })

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -35,9 +35,7 @@ use super::nav::{
     open_link_target, row_list_index, source_list_index, ContentBlockCursor,
 };
 use super::panes::{ContentCtx, ContentPane, DialogueCtx, DialoguePane};
-use super::selection::{
-    refresh_next_level, resolve_loaded_scopes, toggle_block_selection, toggle_row_selection,
-};
+use super::selection::{refresh_next_level, toggle_block_selection, toggle_row_selection};
 use super::visual::{
     apply_workspace_mouse_scroll, handle_content_mouse_select, handle_visual_select_key,
     MouseSelectionStart, VisualContentContext, VisualSelectMode, MOUSE_SCROLL_LINES,
@@ -239,7 +237,6 @@ pub(crate) fn run(
             .with_selected(rows.sessions.scope_mask())
             .with_neighbors(1),
         );
-        resolve_loaded_scopes(&mut rows, &sources, &sessions, &sessions_pane);
         let dialogue_focus_hint = pending_match
             .as_ref()
             .map(|matched| matched.dialogue_index)
@@ -1567,6 +1564,26 @@ mod tests {
             ContentPane::block_selection_mask(&dialogues, 0, &rows.selection)
                 .into_iter()
                 .all(|marked| marked)
+        );
+    }
+
+    #[test]
+    fn initial_selection_is_empty_until_a_row_is_toggled() {
+        let source = WorkspaceSource::agent(AgentProvider::Codex);
+        let sessions = vec![workspace_test_session("test", source, &["d1", "d2"])];
+        let dialogues = dialogues_for_test(&sessions, 0, &[true]);
+
+        let rows = Rows::default();
+        assert!(
+            rows.selection.anchors().is_empty(),
+            "Rows::default() must start with an empty selection"
+        );
+        assert!(
+            dialogues.iter().all(|dialogue| dialogue
+                .work_ref
+                .as_ref()
+                .is_none_or(|reference| !rows.selection.contains(reference))),
+            "nothing should be selected until a row is toggled"
         );
     }
 

--- a/src/commands/browse/selection.rs
+++ b/src/commands/browse/selection.rs
@@ -8,7 +8,7 @@ use crate::tui::content::block::BlockText;
 use crate::tui::workspace::{
     Rows, WorkspaceDialogue, WorkspaceFocus, WorkspaceSession, WorkspaceSource,
 };
-use crate::workset::{WorkSelectionAction, WorkSelectionTarget};
+use sivtr_core::workset::{WorkSelectionAction, WorkSelectionTarget};
 
 use super::load::SessionColumn;
 use crate::pane::Viewport;

--- a/src/commands/browse/selection.rs
+++ b/src/commands/browse/selection.rs
@@ -133,6 +133,18 @@ pub(super) fn toggle_row_selection(
     }
 }
 
+pub(super) fn toggle_block_selection(
+    rows: &mut Rows,
+    dialogues: &[WorkspaceDialogue],
+    block_id: usize,
+) {
+    if let Some((_, record, parts)) =
+        super::content::workspace_block_parts(dialogues, rows.dialogues.cursor(), block_id)
+    {
+        rows.selection.toggle_parts(record, parts);
+    }
+}
+
 #[derive(Clone, Copy)]
 pub(super) enum SelectionAction {
     Toggle,
@@ -168,13 +180,7 @@ pub(super) fn apply_selection_action(
         SelectionAction::Toggle => {
             if focus == WorkspaceFocus::Content {
                 if let Some(block) = content_cursor.get() {
-                    if let Some((_, record, parts)) = super::content::workspace_block_parts(
-                        dialogues,
-                        rows.dialogues.cursor(),
-                        block,
-                    ) {
-                        rows.selection.toggle_parts(record, parts);
-                    }
+                    toggle_block_selection(rows, dialogues, block);
                 }
                 return false;
             }

--- a/src/commands/browse/selection.rs
+++ b/src/commands/browse/selection.rs
@@ -336,32 +336,3 @@ pub(super) fn apply_selection_action(
         }
     }
 }
-
-/// Materialize records covered by marked source/session scopes. Scope masks
-/// drive loading; once bodies arrive, the canonical WorkSet owns the choice.
-pub(super) fn resolve_loaded_scopes(
-    rows: &mut Rows,
-    sources: &[WorkspaceSource],
-    sessions: &[WorkspaceSession],
-    sessions_pane: &SessionColumn,
-) {
-    for (session_idx, session) in sessions.iter().enumerate() {
-        let source_idx = super::load::source_index_for_session(sources, session);
-        let source_marked = source_idx.is_some_and(|idx| rows.source.scope_mask()[idx]);
-        let session_marked = rows.sessions.scope_mask()[session_idx];
-        if source_marked || session_marked {
-            if let Some(records) = sessions_pane.body_for(session) {
-                let target = if source_marked {
-                    session.source.selection_target(None)
-                } else {
-                    session.source.selection_target(Some(&session.session_id))
-                };
-                rows.selection.apply_target(
-                    WorkSelectionAction::Include,
-                    target,
-                    records.iter().cloned(),
-                );
-            }
-        }
-    }
-}

--- a/src/commands/browse/selection.rs
+++ b/src/commands/browse/selection.rs
@@ -8,6 +8,7 @@ use crate::tui::content::block::BlockText;
 use crate::tui::workspace::{
     Rows, WorkspaceDialogue, WorkspaceFocus, WorkspaceSession, WorkspaceSource,
 };
+use crate::workset::{WorkSelectionAction, WorkSelectionTarget};
 
 use super::load::SessionColumn;
 use crate::pane::Viewport;
@@ -85,23 +86,6 @@ pub(super) fn select_sources(
     }
 }
 
-pub(super) fn source_records(
-    sources: &[WorkspaceSource],
-    sessions: &[WorkspaceSession],
-    session_records: &[Vec<sivtr_core::record::WorkRecord>],
-    source_idx: usize,
-) -> Vec<sivtr_core::record::WorkRecord> {
-    let Some(source) = sources.get(source_idx) else {
-        return Vec::new();
-    };
-    sessions
-        .iter()
-        .enumerate()
-        .filter(|(_, session)| &session.source == source)
-        .flat_map(|(idx, _)| session_records.get(idx).into_iter().flatten().cloned())
-        .collect()
-}
-
 pub(super) fn toggle_row_selection(
     focus: WorkspaceFocus,
     idx: usize,
@@ -111,25 +95,23 @@ pub(super) fn toggle_row_selection(
     session_records: &[Vec<sivtr_core::record::WorkRecord>],
     dialogues: &[WorkspaceDialogue],
 ) {
-    match focus {
-        WorkspaceFocus::Source => {
-            rows.selection
-                .toggle_records(source_records(sources, sessions, session_records, idx))
-        }
-        WorkspaceFocus::Sessions => {
-            if let Some(records) = session_records.get(idx) {
-                rows.selection.toggle_records(records.clone());
-            }
-        }
-        WorkspaceFocus::Dialogues => {
-            if let Some(record) = dialogues
-                .get(idx)
-                .and_then(|dialogue| dialogue.record.clone())
-            {
-                rows.selection.toggle_whole(record);
-            }
-        }
-        WorkspaceFocus::Content => {}
+    let target = match focus {
+        WorkspaceFocus::Source => sources.get(idx).map(|source| source.selection_target(None)),
+        WorkspaceFocus::Sessions => sessions
+            .get(idx)
+            .map(|session| session.source.selection_target(Some(&session.session_id))),
+        WorkspaceFocus::Dialogues => dialogues
+            .get(idx)
+            .and_then(|dialogue| dialogue.record.clone())
+            .map(WorkSelectionTarget::Whole),
+        WorkspaceFocus::Content => None,
+    };
+    if let Some(target) = target {
+        rows.selection.apply_target(
+            WorkSelectionAction::Toggle,
+            target,
+            session_records.iter().flatten().cloned(),
+        );
     }
 }
 
@@ -141,7 +123,11 @@ pub(super) fn toggle_block_selection(
     if let Some((_, record, parts)) =
         super::content::workspace_block_parts(dialogues, rows.dialogues.cursor(), block_id)
     {
-        rows.selection.toggle_parts(record, parts);
+        rows.selection.apply_target(
+            WorkSelectionAction::Toggle,
+            WorkSelectionTarget::Parts { record, parts },
+            [],
+        );
     }
 }
 
@@ -209,22 +195,45 @@ pub(super) fn apply_selection_action(
                         .get(rows.dialogues.cursor())
                         .and_then(|dialogue| dialogue.record.as_ref())
                     {
-                        rows.selection.toggle_whole(record.clone());
+                        rows.selection.apply_target(
+                            WorkSelectionAction::Toggle,
+                            WorkSelectionTarget::Whole(record.clone()),
+                            [],
+                        );
                     }
                 }
-                WorkspaceFocus::Dialogues => rows.selection.toggle_records(
-                    dialogues
-                        .iter()
-                        .filter_map(|dialogue| dialogue.record.clone())
-                        .collect(),
+                WorkspaceFocus::Dialogues => rows.selection.apply_target(
+                    WorkSelectionAction::Toggle,
+                    WorkSelectionTarget::Many(
+                        dialogues
+                            .iter()
+                            .filter_map(|dialogue| dialogue.record.clone())
+                            .map(WorkSelectionTarget::Whole)
+                            .collect(),
+                    ),
+                    session_records.iter().flatten().cloned(),
                 ),
-                WorkspaceFocus::Sessions => rows
-                    .selection
-                    .toggle_records(session_records.iter().flatten().cloned().collect()),
-                WorkspaceFocus::Source => rows.selection.toggle_records(
-                    (0..sources.len())
-                        .flat_map(|idx| source_records(sources, sessions, session_records, idx))
-                        .collect(),
+                WorkspaceFocus::Sessions => rows.selection.apply_target(
+                    WorkSelectionAction::Toggle,
+                    WorkSelectionTarget::Many(
+                        sessions
+                            .iter()
+                            .map(|session| {
+                                session.source.selection_target(Some(&session.session_id))
+                            })
+                            .collect(),
+                    ),
+                    session_records.iter().flatten().cloned(),
+                ),
+                WorkspaceFocus::Source => rows.selection.apply_target(
+                    WorkSelectionAction::Toggle,
+                    WorkSelectionTarget::Many(
+                        sources
+                            .iter()
+                            .map(|source| source.selection_target(None))
+                            .collect(),
+                    ),
+                    session_records.iter().flatten().cloned(),
                 ),
             }
             if matches!(focus, WorkspaceFocus::Source | WorkspaceFocus::Sessions) {
@@ -266,42 +275,59 @@ pub(super) fn apply_selection_action(
                         }
                     }
                     if let Some(record) = record {
-                        rows.selection.toggle_parts(record, parts);
+                        rows.selection.apply_target(
+                            WorkSelectionAction::Toggle,
+                            WorkSelectionTarget::Parts { record, parts },
+                            [],
+                        );
                     }
                 }
                 WorkspaceFocus::Dialogues => {
                     if let Some(span) = rows.range(focus, rows.dialogues.cursor()) {
-                        rows.selection.toggle_records(
-                            dialogues
-                                .iter()
-                                .enumerate()
-                                .filter(|(idx, _)| span.contains(idx))
-                                .filter_map(|(_, dialogue)| dialogue.record.clone())
-                                .collect(),
+                        rows.selection.apply_target(
+                            WorkSelectionAction::Toggle,
+                            WorkSelectionTarget::Many(
+                                dialogues
+                                    .iter()
+                                    .enumerate()
+                                    .filter(|(idx, _)| span.contains(idx))
+                                    .filter_map(|(_, dialogue)| dialogue.record.clone())
+                                    .map(WorkSelectionTarget::Whole)
+                                    .collect(),
+                            ),
+                            session_records.iter().flatten().cloned(),
                         );
                     }
                 }
                 WorkspaceFocus::Sessions => {
                     if let Some(span) = rows.range(focus, rows.sessions.cursor()) {
-                        rows.selection.toggle_records(
-                            session_records
-                                .iter()
-                                .enumerate()
-                                .filter(|(idx, _)| span.contains(idx))
-                                .flat_map(|(_, records)| records.iter().cloned())
-                                .collect(),
+                        let targets: Vec<_> = sessions
+                            .iter()
+                            .enumerate()
+                            .filter(|(idx, _)| span.contains(idx))
+                            .map(|(_, session)| {
+                                session.source.selection_target(Some(&session.session_id))
+                            })
+                            .collect();
+                        rows.selection.apply_target(
+                            WorkSelectionAction::Toggle,
+                            WorkSelectionTarget::Many(targets),
+                            session_records.iter().flatten().cloned(),
                         );
                     }
                 }
                 WorkspaceFocus::Source => {
                     if let Some(span) = rows.range(focus, rows.source.cursor()) {
-                        rows.selection.toggle_records(
-                            (0..sources.len())
-                                .filter(|idx| span.contains(idx))
-                                .flat_map(|idx| {
-                                    source_records(sources, sessions, session_records, idx)
-                                })
-                                .collect(),
+                        let targets: Vec<_> = sources
+                            .iter()
+                            .enumerate()
+                            .filter(|(idx, _)| span.contains(idx))
+                            .map(|(_, source)| source.selection_target(None))
+                            .collect();
+                        rows.selection.apply_target(
+                            WorkSelectionAction::Toggle,
+                            WorkSelectionTarget::Many(targets),
+                            session_records.iter().flatten().cloned(),
                         );
                     }
                 }
@@ -325,7 +351,16 @@ pub(super) fn resolve_loaded_scopes(
         let session_marked = rows.sessions.scope_mask()[session_idx];
         if source_marked || session_marked {
             if let Some(records) = sessions_pane.body_for(session) {
-                rows.selection.include_records(records.iter().cloned());
+                let target = if source_marked {
+                    session.source.selection_target(None)
+                } else {
+                    session.source.selection_target(Some(&session.session_id))
+                };
+                rows.selection.apply_target(
+                    WorkSelectionAction::Include,
+                    target,
+                    records.iter().cloned(),
+                );
             }
         }
     }

--- a/src/commands/memory/copy/export.rs
+++ b/src/commands/memory/copy/export.rs
@@ -22,6 +22,15 @@ pub fn export_picked(
     ansi: bool,
 ) -> Result<()> {
     let (units, label) = picked_units(picked)?;
+    // picked_units already applies the WorkSet's line_filter per unit;
+    // skip the merged-text filter here to avoid double-filtering.
+    let lines = match picked {
+        PickedContent::WorkSet {
+            line_filter: Some(_),
+            ..
+        } => None,
+        _ => lines,
+    };
     finish_units(
         &units,
         &CopyFilters {

--- a/src/commands/memory/copy/load.rs
+++ b/src/commands/memory/copy/load.rs
@@ -67,7 +67,7 @@ pub(crate) fn load_dialogues(
         return Ok(Vec::new());
     }
 
-    let mut records = set.records().to_vec();
+    let mut records = set.into_records();
     // Oldest → newest so relative select (from end) matches historical terminal semantics.
     records.sort_by_key(|r| (r.session.id.clone(), r.work_ref.index()));
     // Bare sources (e.g. `codex`, multi-session terminal) → newest session only.
@@ -118,7 +118,7 @@ fn load_pinned_ref(
     }
 
     let set = workset::query(expanded, Filter::none(), Some(cwd))?;
-    let record = workset::record_for_anchor(set.records(), work_ref)
+    let record = workset::find_record([set.records()], work_ref)
         .with_context(|| format!("No record found for ref `{expanded}`"))?
         .clone();
 

--- a/src/commands/memory/eval.rs
+++ b/src/commands/memory/eval.rs
@@ -59,7 +59,7 @@ fn create_snapshot(path: &Path) -> Result<()> {
     let mut records = Vec::new();
     for source in ["terminal", "agent"] {
         let set = workset::query(source, filter::Filter::none(), Some(&cwd))?;
-        records.extend(set.records().iter().cloned());
+        records.extend(set.into_records());
     }
     let snapshot = EvalSnapshot {
         queries: Vec::new(),

--- a/src/commands/memory/filter.rs
+++ b/src/commands/memory/filter.rs
@@ -163,9 +163,9 @@ pub fn execute(args: &FilterArgs) -> Result<()> {
 /// Load, filter, and optionally save a WorkSet without printing.
 pub fn run(args: &FilterArgs) -> Result<WorkSet> {
     let mut set = workset::query(&args.source, from_filter_args(args)?, args.cwd.as_deref())?;
-    set.save_last()?;
+    workset::save_last(&set)?;
     if let Some(name) = args.save.as_deref() {
-        set.save_as(name)?;
+        workset::save_as(&mut set, name)?;
     }
     Ok(set)
 }

--- a/src/commands/memory/nav.rs
+++ b/src/commands/memory/nav.rs
@@ -33,7 +33,7 @@ pub fn execute(args: &NavArgs) -> Result<()> {
     )?;
     let records = workset::records_for_anchors(&all_records, &anchors);
     let mut set = WorkSet::from_parts(source.cwd, records, anchors);
-    set.save_last()?;
+    workset::save_last(&set)?;
     show::print_workset(
         &mut set,
         show::resolve_output_format(args.format, false, args.refs, args.json),

--- a/src/commands/memory/nav.rs
+++ b/src/commands/memory/nav.rs
@@ -100,7 +100,8 @@ fn child(
     }
     match anchor.at {
         WorkAt::Whole => {
-            let record = workset::require_record([source_records, all_records], anchor)?;
+            let record = workset::require_record([source_records, all_records], anchor)
+                .with_context(|| format!("resolve child record for `{anchor}`"))?;
             let Some(part) = record.parts.get(index - 1) else {
                 return Ok(Vec::new());
             };
@@ -118,7 +119,8 @@ fn sibling(
 ) -> Result<Vec<WorkRef>> {
     match anchor.at {
         WorkAt::Whole => {
-            let record = workset::require_record([source_records, all_records], anchor)?;
+            let record = workset::require_record([source_records, all_records], anchor)
+                .with_context(|| format!("resolve sibling record for `{anchor}`"))?;
             let session_records = session_records_for(record, all_records);
             let Some(position) = session_records
                 .iter()
@@ -132,7 +134,8 @@ fn sibling(
             Ok(vec![session_records[target].work_ref.whole()])
         }
         WorkAt::Part(seq) => {
-            let record = workset::require_record([source_records, all_records], anchor)?;
+            let record = workset::require_record([source_records, all_records], anchor)
+                .with_context(|| format!("resolve sibling record for `{anchor}`"))?;
             let Some(position) = record.parts.iter().position(|part| part.seq == seq) else {
                 return Ok(Vec::new());
             };
@@ -156,7 +159,8 @@ fn window(
     }
     match anchor.at {
         WorkAt::Whole => {
-            let record = workset::require_record([source_records, all_records], anchor)?;
+            let record = workset::require_record([source_records, all_records], anchor)
+                .with_context(|| format!("resolve window record for `{anchor}`"))?;
             let session_records = session_records_for(record, all_records);
             let position = session_records
                 .iter()
@@ -170,7 +174,8 @@ fn window(
                 .collect())
         }
         WorkAt::Part(seq) => {
-            let record = workset::require_record([source_records, all_records], anchor)?;
+            let record = workset::require_record([source_records, all_records], anchor)
+                .with_context(|| format!("resolve window record for `{anchor}`"))?;
             let position = record
                 .parts
                 .iter()
@@ -191,7 +196,8 @@ fn session(
     source_records: &[WorkRecord],
     all_records: &[WorkRecord],
 ) -> Result<Vec<WorkRef>> {
-    let record = workset::require_record([source_records, all_records], anchor)?;
+    let record = workset::require_record([source_records, all_records], anchor)
+        .with_context(|| format!("resolve session record for `{anchor}`"))?;
     Ok(session_records_for(record, all_records)
         .into_iter()
         .map(|record| record.work_ref.whole())

--- a/src/commands/memory/search.rs
+++ b/src/commands/memory/search.rs
@@ -14,14 +14,14 @@ pub fn execute(args: &SearchArgs) -> Result<()> {
 
 /// Unified query for search: local and remote both run load+filter at the data owner.
 pub fn run(args: &SearchArgs) -> Result<WorkSet> {
-    let mut workset = workset::query(
+    let mut set = workset::query(
         &args.source,
         filter::from_search_args(args)?,
         args.cwd.as_deref(),
     )?;
-    workset.save_last()?;
+    workset::save_last(&set)?;
     if let Some(name) = args.save.as_deref() {
-        workset.save_as(name)?;
+        workset::save_as(&mut set, name)?;
     }
-    Ok(workset)
+    Ok(set)
 }

--- a/src/commands/memory/show.rs
+++ b/src/commands/memory/show.rs
@@ -123,7 +123,7 @@ fn anchor_items(set: &workset::WorkSet) -> Result<Vec<AnchorItem<'_>>> {
     set.anchors()
         .iter()
         .map(|anchor| {
-            let record = workset::record_for_anchor(set.records(), anchor)
+            let record = workset::find_record([set.records()], anchor)
                 .with_context(|| format!("No record found for anchor `{anchor}`"))?;
             Ok(AnchorItem {
                 anchor: anchor.clone(),

--- a/src/commands/memory/var.rs
+++ b/src/commands/memory/var.rs
@@ -35,7 +35,7 @@ fn set(name: &str, source: Option<&str>) -> Result<()> {
         None,
     )?;
     set = dedup(set);
-    set.save_as(name)?;
+    workset::save_as(&mut set, name)?;
     output::success(format!("saved @{name} ({} items)", set.anchors().len()));
     Ok(())
 }
@@ -127,30 +127,33 @@ fn merge_sets(base: WorkSet, addition: WorkSet) -> WorkSet {
     }
 
     anchors.extend(addition_anchors);
-    anchors = unique_anchors(anchors);
-    let records = records_for_unique_anchors(records_by_ref, &anchors);
-    WorkSet::from_parts(cwd, records, anchors)
+    rebuild(cwd, records_by_ref, anchors)
 }
 
 fn remove_anchors(base: WorkSet, remove: &HashSet<String>) -> WorkSet {
     let cwd = base.cwd.clone();
     let (base_records, anchors) = base.into_parts();
-    let records_by_ref = records_by_ref(base_records);
-    let anchors = unique_anchors(
-        anchors
-            .into_iter()
-            .filter(|anchor| !remove.contains(&anchor.to_string()))
-            .collect(),
-    );
-    let records = records_for_unique_anchors(records_by_ref, &anchors);
-    WorkSet::from_parts(cwd, records, anchors)
+    let anchors: Vec<_> = anchors
+        .into_iter()
+        .filter(|anchor| !remove.contains(&anchor.to_string()))
+        .collect();
+    rebuild(cwd, records_by_ref(base_records), anchors)
 }
 
 fn dedup(set: WorkSet) -> WorkSet {
     let cwd = set.cwd.clone();
     let (set_records, set_anchors) = set.into_parts();
-    let records_by_ref = records_by_ref(set_records);
-    let anchors = unique_anchors(set_anchors);
+    rebuild(cwd, records_by_ref(set_records), set_anchors)
+}
+
+/// Rebuild a WorkSet from its record map and anchors. `from_parts`
+/// normalizes the anchors (dedup + Whole canonical form), so no pre-dedup is
+/// needed here.
+fn rebuild(
+    cwd: String,
+    records_by_ref: HashMap<String, WorkRecord>,
+    anchors: Vec<WorkRef>,
+) -> WorkSet {
     let records = records_for_unique_anchors(records_by_ref, &anchors);
     WorkSet::from_parts(cwd, records, anchors)
 }

--- a/src/commands/memory/work.rs
+++ b/src/commands/memory/work.rs
@@ -56,7 +56,8 @@ fn execute_sessions(args: &WorkSessionsArgs) -> Result<()> {
     let cwd = resolve_cwd(args.cwd.as_deref())?;
     let (display_cwd, records) = if let Some(source) = args.source.as_deref() {
         let set = workset::query(source, filter::Filter::none(), Some(&cwd))?;
-        (set.cwd.clone(), set.records().to_vec())
+        let display_cwd = set.cwd.clone();
+        (display_cwd, set.into_records())
     } else {
         let providers = args.provider.providers();
         let records = current_work_record_index(&providers, &cwd, None)?;

--- a/src/commands/memory/work.rs
+++ b/src/commands/memory/work.rs
@@ -88,9 +88,9 @@ fn execute_sessions(args: &WorkSessionsArgs) -> Result<()> {
 fn execute_records(args: &WorkRecordsArgs) -> Result<()> {
     let cwd = resolve_cwd(args.cwd.as_deref())?;
     let mut set = workset::query(&args.source, filter::Filter::none(), Some(&cwd))?;
-    set.save_last()?;
+    workset::save_last(&set)?;
     if let Some(name) = args.save.as_deref() {
-        set.save_as(name)?;
+        workset::save_as(&mut set, name)?;
     }
     show::print_workset(
         &mut set,
@@ -105,9 +105,9 @@ fn execute_parts(args: &WorkPartsArgs) -> Result<()> {
         filter::from_work_parts_args(args)?,
         Some(&cwd),
     )?;
-    set.save_last()?;
+    workset::save_last(&set)?;
     if let Some(name) = args.save.as_deref() {
-        set.save_as(name)?;
+        workset::save_as(&mut set, name)?;
     }
     show::print_workset(
         &mut set,

--- a/src/commands/memory/workset/mod.rs
+++ b/src/commands/memory/workset/mod.rs
@@ -13,7 +13,8 @@ use std::collections::HashMap;
 use std::path::Path;
 
 pub use crate::workset::{
-    find_record, records_for_anchors, require_record, WorkSet, WORKSET_SCHEMA_VERSION,
+    find_record, records_for_anchors, require_record, WorkSelectionAction, WorkSelectionKind,
+    WorkSelectionTarget, WorkSet, WORKSET_SCHEMA_VERSION,
 };
 
 fn apply_selection(mut set: WorkSet, selection: WorkSetSelection) -> WorkSet {
@@ -341,9 +342,20 @@ mod tests {
     fn whole_anchor_covers_and_replaces_parts() {
         let first = record(1);
         let mut set = WorkSet::from_parts(".", vec![first.clone()], vec![]);
-        set.include_parts(first.clone(), [1]);
+        set.apply_target(
+            WorkSelectionAction::Include,
+            WorkSelectionTarget::Parts {
+                record: first.clone(),
+                parts: vec![1],
+            },
+            [],
+        );
         assert!(set.contains(&first.work_ref.with_part(1)));
-        set.include_whole(first.clone());
+        set.apply_target(
+            WorkSelectionAction::Include,
+            WorkSelectionTarget::Whole(first.clone()),
+            [],
+        );
         assert_eq!(set.anchors(), vec![first.work_ref.whole()]);
         assert!(set.contains(&first.work_ref.with_part(1)));
     }
@@ -352,7 +364,14 @@ mod tests {
     fn part_anchors_deduplicate_without_collapsing() {
         let first = record(1);
         let mut set = WorkSet::new(".", Vec::new());
-        set.include_parts(first.clone(), [1, 1]);
+        set.apply_target(
+            WorkSelectionAction::Include,
+            WorkSelectionTarget::Parts {
+                record: first.clone(),
+                parts: vec![1, 1],
+            },
+            [],
+        );
         assert_eq!(set.anchors(), vec![first.work_ref.with_part(1)]);
     }
 
@@ -360,7 +379,14 @@ mod tests {
     fn complete_part_selection_is_canonical_whole() {
         let first = record(1);
         let mut set = WorkSet::new(".", Vec::new());
-        set.include_parts(first.clone(), [1, 2, 1]);
+        set.apply_target(
+            WorkSelectionAction::Include,
+            WorkSelectionTarget::Parts {
+                record: first.clone(),
+                parts: vec![1, 2, 1],
+            },
+            [],
+        );
         assert_eq!(set.anchors(), vec![first.work_ref.whole()]);
         assert!(set.contains(&first.work_ref.with_part(2)));
     }
@@ -369,8 +395,16 @@ mod tests {
     fn incremental_part_selection_is_canonical_whole() {
         let first = record(1);
         let mut set = WorkSet::new(".", Vec::new());
-        set.include_parts(first.clone(), [1]);
-        set.include_parts(first.clone(), [2]);
+        for parts in [vec![1], vec![2]] {
+            set.apply_target(
+                WorkSelectionAction::Include,
+                WorkSelectionTarget::Parts {
+                    record: first.clone(),
+                    parts,
+                },
+                [],
+            );
+        }
         assert_eq!(set.anchors(), vec![first.work_ref.whole()]);
     }
 
@@ -389,10 +423,25 @@ mod tests {
     fn toggling_whole_replaces_narrow_selection() {
         let first = record(1);
         let mut set = WorkSet::new(".", Vec::new());
-        set.include_parts(first.clone(), [1]);
-        set.toggle_whole(first.clone());
+        set.apply_target(
+            WorkSelectionAction::Include,
+            WorkSelectionTarget::Parts {
+                record: first.clone(),
+                parts: vec![1],
+            },
+            [],
+        );
+        set.apply_target(
+            WorkSelectionAction::Toggle,
+            WorkSelectionTarget::Whole(first.clone()),
+            [],
+        );
         assert_eq!(set.anchors(), vec![first.work_ref.whole()]);
-        set.toggle_whole(first.clone());
+        set.apply_target(
+            WorkSelectionAction::Toggle,
+            WorkSelectionTarget::Whole(first.clone()),
+            [],
+        );
         assert!(set.anchors().is_empty());
     }
 
@@ -400,11 +449,41 @@ mod tests {
     fn toggling_part_from_whole_keeps_the_other_parts() {
         let first = record(1);
         let mut set = WorkSet::new(".", Vec::new());
-        set.include_whole(first.clone());
-        set.toggle_parts(first.clone(), [1]);
+        set.apply_target(
+            WorkSelectionAction::Include,
+            WorkSelectionTarget::Whole(first.clone()),
+            [],
+        );
+        set.apply_target(
+            WorkSelectionAction::Toggle,
+            WorkSelectionTarget::Parts {
+                record: first.clone(),
+                parts: vec![1],
+            },
+            [],
+        );
         assert_eq!(set.anchors(), vec![first.work_ref.with_part(2)]);
         assert!(!set.contains(&first.work_ref.with_part(1)));
         assert!(set.contains(&first.work_ref.with_part(2)));
+    }
+
+    #[test]
+    fn scope_target_selects_all_matching_records() {
+        let records = vec![record(1), record(2)];
+        let target = WorkSelectionTarget::Scope {
+            scope: sivtr_core::record::WorkScope::Local,
+            kind: WorkSelectionKind::Terminal,
+            session: Some("session_1".to_string()),
+        };
+        let mut set = WorkSet::new(".", Vec::new());
+        set.apply_target(WorkSelectionAction::Toggle, target, records.clone());
+        assert_eq!(
+            set.anchors(),
+            &records
+                .iter()
+                .map(|r| r.work_ref.clone())
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/src/commands/memory/workset/mod.rs
+++ b/src/commands/memory/workset/mod.rs
@@ -88,6 +88,7 @@ impl WorkSet {
     pub fn save_as(&mut self, name: &str) -> Result<()> {
         store::validate_name(name)?;
         self.materialize_parts()?;
+        self.validate()?;
         self.name = Some(name.to_string());
         save_named(name, self)
     }
@@ -95,6 +96,7 @@ impl WorkSet {
     pub fn save_last(&self) -> Result<()> {
         let mut set = self.clone();
         set.materialize_parts()?;
+        set.validate()?;
         save_named("last", &set)
     }
 }
@@ -316,6 +318,26 @@ mod tests {
     }
 
     #[test]
+    fn validation_rejects_anchor_without_backing_record() {
+        let first = record(1);
+        let mut value = serde_json::to_value(WorkSet::from_parts(".", vec![first.clone()], vec![]))
+            .expect("serialize WorkSet");
+        value["anchors"] = serde_json::json!([record(2).work_ref]);
+        let set: WorkSet = serde_json::from_value(value).expect("deserialize WorkSet");
+        assert!(set.validate().is_err());
+    }
+
+    #[test]
+    fn validation_rejects_part_anchor_without_matching_part() {
+        let first = record(1);
+        let mut value = serde_json::to_value(WorkSet::from_parts(".", vec![first.clone()], vec![]))
+            .expect("serialize WorkSet");
+        value["anchors"] = serde_json::json!([first.work_ref.with_part(99)]);
+        let set: WorkSet = serde_json::from_value(value).expect("deserialize WorkSet");
+        assert!(set.validate().is_err());
+    }
+
+    #[test]
     fn whole_anchor_covers_and_replaces_parts() {
         let first = record(1);
         let mut set = WorkSet::from_parts(".", vec![first.clone()], vec![]);
@@ -344,6 +366,26 @@ mod tests {
     }
 
     #[test]
+    fn incremental_part_selection_is_canonical_whole() {
+        let first = record(1);
+        let mut set = WorkSet::new(".", Vec::new());
+        set.include_parts(first.clone(), [1]);
+        set.include_parts(first.clone(), [2]);
+        assert_eq!(set.anchors(), vec![first.work_ref.whole()]);
+    }
+
+    #[test]
+    fn from_parts_collapses_complete_part_anchors() {
+        let first = record(1);
+        let set = WorkSet::from_parts(
+            ".",
+            vec![first.clone()],
+            vec![first.work_ref.with_part(1), first.work_ref.with_part(2)],
+        );
+        assert_eq!(set.anchors(), vec![first.work_ref.whole()]);
+    }
+
+    #[test]
     fn toggling_whole_replaces_narrow_selection() {
         let first = record(1);
         let mut set = WorkSet::new(".", Vec::new());
@@ -352,6 +394,17 @@ mod tests {
         assert_eq!(set.anchors(), vec![first.work_ref.whole()]);
         set.toggle_whole(first.clone());
         assert!(set.anchors().is_empty());
+    }
+
+    #[test]
+    fn toggling_part_from_whole_keeps_the_other_parts() {
+        let first = record(1);
+        let mut set = WorkSet::new(".", Vec::new());
+        set.include_whole(first.clone());
+        set.toggle_parts(first.clone(), [1]);
+        assert_eq!(set.anchors(), vec![first.work_ref.with_part(2)]);
+        assert!(!set.contains(&first.work_ref.with_part(1)));
+        assert!(set.contains(&first.work_ref.with_part(2)));
     }
 
     #[test]

--- a/src/commands/memory/workset/mod.rs
+++ b/src/commands/memory/workset/mod.rs
@@ -8,11 +8,13 @@ pub(crate) use store::{cleanup_saved, delete_saved, list_saved, load_saved, save
 
 use anyhow::{bail, Context, Result};
 use sivtr_core::query::{load_session_records, LoadMode};
-use sivtr_core::record::{WorkPath, WorkRecord, WorkRef};
+use sivtr_core::record::WorkPath;
 use std::collections::HashMap;
 use std::path::Path;
 
-pub use crate::workset::{records_for_anchors, WorkSet, WORKSET_SCHEMA_VERSION};
+pub use crate::workset::{
+    find_record, records_for_anchors, require_record, WorkSet, WORKSET_SCHEMA_VERSION,
+};
 
 fn apply_selection(mut set: WorkSet, selection: WorkSetSelection) -> WorkSet {
     let WorkSetSelection::Indices(indices) = selection else {
@@ -95,32 +97,6 @@ impl WorkSet {
         set.materialize_parts()?;
         save_named("last", &set)
     }
-}
-
-pub fn record_for_anchor<'a>(
-    records: &'a [WorkRecord],
-    anchor: &WorkRef,
-) -> Option<&'a WorkRecord> {
-    find_record([records], anchor)
-}
-
-pub fn find_record<'a, I>(record_sets: I, anchor: &WorkRef) -> Option<&'a WorkRecord>
-where
-    I: IntoIterator<Item = &'a [WorkRecord]>,
-{
-    let record_ref = anchor.whole();
-    record_sets
-        .into_iter()
-        .flat_map(|records| records.iter())
-        .find(|record| record.work_ref.whole() == record_ref)
-}
-
-pub fn require_record<'a, I>(record_sets: I, anchor: &WorkRef) -> Result<&'a WorkRecord>
-where
-    I: IntoIterator<Item = &'a [WorkRecord]>,
-{
-    find_record(record_sets, anchor)
-        .with_context(|| format!("No record found for ref `{}`", anchor.whole()))
 }
 
 pub fn load_reference(reference: &str) -> Result<WorkSet> {
@@ -321,6 +297,20 @@ mod tests {
         ))
         .expect("serialize WorkSet");
         value["anchors"] = serde_json::json!([first.work_ref.whole(), first.work_ref.with_part(1)]);
+        let set: WorkSet = serde_json::from_value(value).expect("deserialize WorkSet");
+        assert!(set.validate().is_err());
+    }
+
+    #[test]
+    fn validation_rejects_part_before_whole_loaded_from_json() {
+        let first = record(1);
+        let mut value = serde_json::to_value(WorkSet::from_parts(
+            ".",
+            vec![first.clone()],
+            vec![first.work_ref.whole()],
+        ))
+        .expect("serialize WorkSet");
+        value["anchors"] = serde_json::json!([first.work_ref.with_part(1), first.work_ref.whole()]);
         let set: WorkSet = serde_json::from_value(value).expect("deserialize WorkSet");
         assert!(set.validate().is_err());
     }

--- a/src/commands/memory/workset/mod.rs
+++ b/src/commands/memory/workset/mod.rs
@@ -7,12 +7,8 @@ pub(crate) use source::{
 pub(crate) use store::{cleanup_saved, delete_saved, list_saved, load_saved, save_named};
 
 use anyhow::{bail, Context, Result};
-use sivtr_core::query::{load_session_records, LoadMode};
-use sivtr_core::record::WorkPath;
-use std::collections::HashMap;
-use std::path::Path;
 
-pub use crate::workset::{
+pub use sivtr_core::workset::{
     find_record, records_for_anchors, require_record, WorkSelectionAction, WorkSelectionKind,
     WorkSelectionTarget, WorkSet, WORKSET_SCHEMA_VERSION,
 };
@@ -36,70 +32,23 @@ pub enum WorkSetSelection {
     Indices(Vec<usize>),
 }
 
-/// Cache namespace for a record's session file, used by [`materialize_parts`]
-/// to pick the right cache view when re-loading full records.
-fn session_namespace(path: &WorkPath) -> Option<&'static str> {
-    match path {
-        WorkPath::Agent { provider, .. } => Some(provider.command_name()),
-        WorkPath::Terminal { .. } => Some("terminal"),
-    }
+/// Persist a named WorkSet (`@name`). `materialize_parts` runs first so a
+/// light-loaded set saves complete records; [`WorkSet::validate`] rejects
+/// malformed sets before they hit disk.
+pub(crate) fn save_as(set: &mut WorkSet, name: &str) -> Result<()> {
+    store::validate_name(name)?;
+    set.materialize_parts()?;
+    set.validate()?;
+    set.name = Some(name.to_string());
+    save_named(name, set)
 }
 
-impl WorkSet {
-    /// Fill in `parts` for any light-loaded record (empty `parts`) whose
-    /// session file path is known.  Each session file is loaded once (full
-    /// view), then matching records are patched in place.  Records without a
-    /// session path (stdin sets) are already complete and stay untouched.
-    pub fn materialize_parts(&mut self) -> Result<()> {
-        // Group light records by their session file path, then load each
-        // session's full records once and patch matching parts back.
-        let mut needed: HashMap<String, Vec<usize>> = HashMap::new();
-        for (index, record) in self.records().iter().enumerate() {
-            if !record.parts.is_empty() {
-                continue;
-            }
-            let Some(path) = record.session.path.as_deref() else {
-                continue;
-            };
-            needed.entry(path.to_string()).or_default().push(index);
-        }
-
-        for (path, indices) in &needed {
-            // Any record in the group gives us the namespace; pick the first.
-            let namespace = session_namespace(&self.records()[indices[0]].work_ref.path);
-            let Some(namespace) = namespace else {
-                continue;
-            };
-            let full = load_session_records(namespace, Path::new(path), LoadMode::Full)
-                .with_context(|| format!("Failed to load full session {path} for {namespace}"))?;
-            for index in indices {
-                if let Some(record) = self.records_mut().get_mut(*index) {
-                    if let Some(full_record) = full
-                        .iter()
-                        .find(|r| r.work_ref.path.index() == record.work_ref.path.index())
-                    {
-                        record.parts = full_record.parts.clone();
-                    }
-                }
-            }
-        }
-        Ok(())
-    }
-
-    pub fn save_as(&mut self, name: &str) -> Result<()> {
-        store::validate_name(name)?;
-        self.materialize_parts()?;
-        self.validate()?;
-        self.name = Some(name.to_string());
-        save_named(name, self)
-    }
-
-    pub fn save_last(&self) -> Result<()> {
-        let mut set = self.clone();
-        set.materialize_parts()?;
-        set.validate()?;
-        save_named("last", &set)
-    }
+/// Persist the `@last` WorkSet.
+pub(crate) fn save_last(set: &WorkSet) -> Result<()> {
+    let mut set = set.clone();
+    set.materialize_parts()?;
+    set.validate()?;
+    save_named("last", &set)
 }
 
 pub fn load_reference(reference: &str) -> Result<WorkSet> {

--- a/src/commands/memory/workset/mod.rs
+++ b/src/commands/memory/workset/mod.rs
@@ -9,10 +9,10 @@ pub(crate) use store::{cleanup_saved, delete_saved, list_saved, load_saved, save
 use anyhow::{bail, Context, Result};
 use sivtr_core::query::{load_session_records, LoadMode};
 use sivtr_core::record::{WorkPath, WorkRecord, WorkRef};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::path::Path;
 
-pub use crate::workset::{WorkSet, WORKSET_SCHEMA_VERSION};
+pub use crate::workset::{records_for_anchors, WorkSet, WORKSET_SCHEMA_VERSION};
 
 fn apply_selection(mut set: WorkSet, selection: WorkSetSelection) -> WorkSet {
     let WorkSetSelection::Indices(indices) = selection else {
@@ -23,8 +23,7 @@ fn apply_selection(mut set: WorkSet, selection: WorkSetSelection) -> WorkSet {
         .into_iter()
         .map(|index| set.anchors()[index - 1].clone())
         .collect::<Vec<_>>();
-    let records = records_for_anchors(set.records(), &anchors);
-    set.replace_selection(records, anchors);
+    set.select_anchors(anchors);
     set
 }
 
@@ -96,24 +95,6 @@ impl WorkSet {
         set.materialize_parts()?;
         save_named("last", &set)
     }
-}
-
-pub fn records_for_anchors(records: &[WorkRecord], anchors: &[WorkRef]) -> Vec<WorkRecord> {
-    let mut selected = Vec::new();
-    let mut seen = HashSet::new();
-    for anchor in anchors {
-        let record_ref = anchor.whole();
-        if !seen.insert(record_ref.to_string()) {
-            continue;
-        }
-        if let Some(record) = records
-            .iter()
-            .find(|record| record.work_ref.whole() == record_ref)
-        {
-            selected.push(record.clone());
-        }
-    }
-    selected
 }
 
 pub fn record_for_anchor<'a>(
@@ -311,6 +292,37 @@ mod tests {
             refs,
             vec!["terminal/session_1/1/p1", "terminal/session_1/2/p1"]
         );
+    }
+
+    #[test]
+    fn from_parts_canonicalizes_duplicate_and_shadowed_anchors() {
+        let first = record(1);
+        let part = first.work_ref.with_part(1);
+        let set = WorkSet::from_parts(
+            ".",
+            vec![first.clone()],
+            vec![
+                part.clone(),
+                part,
+                first.work_ref.whole(),
+                first.work_ref.with_part(2),
+            ],
+        );
+        assert_eq!(set.anchors(), &[first.work_ref.whole()]);
+    }
+
+    #[test]
+    fn validation_rejects_shadowed_anchors_loaded_from_json() {
+        let first = record(1);
+        let mut value = serde_json::to_value(WorkSet::from_parts(
+            ".",
+            vec![first.clone()],
+            vec![first.work_ref.whole()],
+        ))
+        .expect("serialize WorkSet");
+        value["anchors"] = serde_json::json!([first.work_ref.whole(), first.work_ref.with_part(1)]);
+        let set: WorkSet = serde_json::from_value(value).expect("deserialize WorkSet");
+        assert!(set.validate().is_err());
     }
 
     #[test]

--- a/src/commands/memory/workset/source.rs
+++ b/src/commands/memory/workset/source.rs
@@ -405,12 +405,9 @@ pub fn run_on_share(
     match run_local(source, root, filter.for_remote_peer(), LoadMode::Full) {
         Ok(mut set) => {
             if redact {
-                let records = set
-                    .records()
-                    .iter()
-                    .map(crate::remote::redact::redact_record)
-                    .collect();
-                set.replace_records(records);
+                for record in set.records_mut() {
+                    *record = crate::remote::redact::redact_record(record);
+                }
             }
             Ok(set.into_parts())
         }
@@ -565,6 +562,7 @@ fn read_stdin() -> Result<WorkSet> {
         .context("Failed to read WorkSet from stdin")?;
     let set: WorkSet =
         serde_json::from_str(&input).context("Failed to parse WorkSet from stdin")?;
+    set.validate().context("Invalid WorkSet from stdin")?;
     Ok(set)
 }
 

--- a/src/commands/memory/workset/source.rs
+++ b/src/commands/memory/workset/source.rs
@@ -574,7 +574,7 @@ pub fn load_context_records(
     let mut sources = Vec::new();
     let mut seen_sources = HashSet::new();
     for anchor in source_anchors {
-        let record = super::record_for_anchor(source_records, anchor)
+        let record = super::find_record([source_records], anchor)
             .with_context(|| format!("No record found for ref `{anchor}`"))?;
         let path = match &record.work_ref.path {
             WorkPath::Terminal { session, .. } => format!("terminal/{session}"),

--- a/src/commands/memory/workset/source.rs
+++ b/src/commands/memory/workset/source.rs
@@ -237,12 +237,10 @@ fn merge_and_apply(results: Vec<QuerySourceResult>, cwd: &Path, filter: Filter) 
     for error in &errors {
         output::warning(format!("skipped an origin: {error}"));
     }
+    // `from_parts` normalizes the anchors (dedup + Whole canonical form), so
+    // the merged per-source anchors need no pre-dedup here.
     apply_loaded(
-        WorkSet::from_parts(
-            cwd.display().to_string(),
-            records,
-            crate::commands::memory::var::unique_anchors(anchors),
-        ),
+        WorkSet::from_parts(cwd.display().to_string(), records, anchors),
         filter,
     )
 }

--- a/src/commands/memory/workset/source.rs
+++ b/src/commands/memory/workset/source.rs
@@ -218,8 +218,9 @@ fn merge_and_apply(results: Vec<QuerySourceResult>, cwd: &Path, filter: Filter) 
         match result {
             QuerySourceResult::Ok(set) => {
                 any_ok = true;
-                anchors.extend(set.anchors().iter().cloned());
-                for record in set.into_records() {
+                let (set_records, set_anchors) = set.into_parts();
+                anchors.extend(set_anchors);
+                for record in set_records {
                     if seen.insert(record.work_ref.whole()) {
                         records.push(record);
                     }

--- a/src/commands/memory/workset/store.rs
+++ b/src/commands/memory/workset/store.rs
@@ -21,6 +21,8 @@ pub fn load_saved(name: &str) -> Result<WorkSet> {
         .with_context(|| format!("Failed to read WorkSet @{name} from {}", path.display()))?;
     let set: WorkSet = serde_json::from_str(&content)
         .with_context(|| format!("Failed to parse WorkSet @{name} from {}", path.display()))?;
+    set.validate()
+        .with_context(|| format!("Invalid WorkSet @{name}"))?;
     Ok(set)
 }
 

--- a/src/commands/memory/zoom.rs
+++ b/src/commands/memory/zoom.rs
@@ -37,12 +37,12 @@ pub fn run(args: &ZoomArgs) -> Result<WorkSet> {
         expand_around(source.records(), &anchors, &all_records, before, after)?
     };
 
-    let mut workset = WorkSet::new(source.cwd, expanded);
-    workset.save_last()?;
+    let mut set = WorkSet::new(source.cwd, expanded);
+    workset::save_last(&set)?;
     if let Some(name) = args.save.as_deref() {
-        workset.save_as(name)?;
+        workset::save_as(&mut set, name)?;
     }
-    Ok(workset)
+    Ok(set)
 }
 
 fn expand_around(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@ pub mod output;
 pub mod pane;
 pub mod remote;
 pub mod tui;
-pub mod workset;
 
 use anyhow::Result;
 use clap::Parser;

--- a/src/mcp/types.rs
+++ b/src/mcp/types.rs
@@ -10,7 +10,7 @@ use sivtr_core::search::{Field, PartKind};
 
 // MCP JSON schema exposes these as strings; serde still uses FromStr aliases.
 use crate::commands::memory::show::{self, WorkSetOutputFormat};
-use crate::commands::memory::workset::WorkSet;
+use sivtr_core::workset::WorkSet;
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct SearchParams {

--- a/src/remote/fanout.rs
+++ b/src/remote/fanout.rs
@@ -221,10 +221,11 @@ pub(crate) async fn group_fan_out(
     // share already applied; the shared code also ranks the merged corpus as
     // a whole when the sort is relevance.
     let merged = filter::apply(PathBuf::new(), records, anchors, full)?;
+    let (m_records, m_anchors) = merged.into_parts();
     Ok(GroupQueryResponse {
         query: QueryResponse {
-            records: merged.records().to_vec(),
-            anchors: merged.anchors().to_vec(),
+            records: m_records,
+            anchors: m_anchors,
         },
         skipped,
     })

--- a/src/tui/content/block.rs
+++ b/src/tui/content/block.rs
@@ -158,10 +158,10 @@ pub(crate) fn half_blocks(record: &WorkRecord, input: bool) -> Vec<Block> {
 
 /// Size of a dialogue's id space: every block of both halves, nested run
 /// members included, so a mask of this length holds a mark on any block —
-/// even one currently hidden by a fold.
-pub(crate) fn dialogue_block_count(record: &WorkRecord) -> usize {
-    let (input, output) = dialogue_blocks(record);
-    input.iter().chain(&output).map(Block::node_count).sum()
+/// even one currently hidden by a fold. Takes the already-built halves
+/// ([`dialogue_blocks`]) so callers build the tree once.
+pub(crate) fn dialogue_block_count(input: &[Block], output: &[Block]) -> usize {
+    input.iter().chain(output).map(Block::node_count).sum()
 }
 
 pub(crate) fn dialogue_block_id(record: &WorkRecord, seq: usize) -> Option<usize> {
@@ -718,8 +718,8 @@ mod tests {
             tool_part(2, "Bash", "ls"),
             tool_part(3, "Read", "file"),
         ]);
-        assert_eq!(dialogue_block_count(&rec), 4);
         let (input, output) = dialogue_blocks(&rec);
+        assert_eq!(dialogue_block_count(&input, &output), 4);
         assert_eq!(input.len(), 1);
         assert_eq!(output[0].children.len(), 2);
         assert_eq!(output[0].children[1].id, 3);

--- a/src/tui/workspace/model.rs
+++ b/src/tui/workspace/model.rs
@@ -349,9 +349,8 @@ pub(crate) struct WorkspaceView<'a> {
     /// Pending `v` block-range span `(anchor block, cursor block)`;
     /// its lines render with the same amber range style as the list panes.
     pub(crate) content_range: Option<(usize, usize)>,
-    /// Marked block mask (`mask[block_id]` = marked, dialogue-global ids),
-    /// owned by the content pane's native selection; consumed by the dot
-    /// gutter and copy.
+    /// WorkSet-derived block mask (`mask[block_id]` = marked, dialogue-global
+    /// ids), consumed by the dot gutter and copy.
     pub(crate) content_marked: &'a [bool],
     /// Dual IO layout + display texts, computed once per redraw by the picker
     /// and shared with the renderer (no per-frame duplicate layout).

--- a/src/tui/workspace/model.rs
+++ b/src/tui/workspace/model.rs
@@ -16,7 +16,7 @@ use crate::tui::content::view::{ContentSelection, ContentViewMode};
 use crate::tui::search::WorkspaceSearchScope;
 use crate::tui::theme;
 use crate::tui::workspace::rows::Rows;
-use crate::workset::{WorkSelectionKind, WorkSelectionTarget};
+use sivtr_core::workset::{WorkSelectionKind, WorkSelectionTarget};
 
 /// Indices of true entries in a selection mask, in order.
 pub(crate) fn selected_indices(mask: &[bool]) -> Vec<usize> {

--- a/src/tui/workspace/model.rs
+++ b/src/tui/workspace/model.rs
@@ -3,7 +3,7 @@
 use ratatui::prelude::Color;
 use ratatui::widgets::ListState;
 use sivtr_core::ai::AgentProvider;
-use sivtr_core::record::{WorkAt, WorkRecord, WorkRef};
+use sivtr_core::record::{WorkAt, WorkRecord, WorkRef, WorkScope};
 use std::collections::HashSet;
 use std::time::SystemTime;
 
@@ -16,6 +16,7 @@ use crate::tui::content::view::{ContentSelection, ContentViewMode};
 use crate::tui::search::WorkspaceSearchScope;
 use crate::tui::theme;
 use crate::tui::workspace::rows::Rows;
+use crate::workset::{WorkSelectionKind, WorkSelectionTarget};
 
 /// Indices of true entries in a selection mask, in order.
 pub(crate) fn selected_indices(mask: &[bool]) -> Vec<usize> {
@@ -142,6 +143,19 @@ impl WorkspaceSource {
 
     pub(crate) fn is_terminal(&self) -> bool {
         self.kind.is_terminal()
+    }
+
+    pub(crate) fn selection_target(&self, session: Option<&str>) -> WorkSelectionTarget {
+        WorkSelectionTarget::Scope {
+            scope: self.scope.as_deref().map_or(WorkScope::Local, |scope| {
+                WorkScope::Named(scope.to_string())
+            }),
+            kind: match self.kind {
+                WorkspaceSourceKind::Terminal => WorkSelectionKind::Terminal,
+                WorkspaceSourceKind::Agent(provider) => WorkSelectionKind::Agent(provider),
+            },
+            session: session.map(str::to_string),
+        }
     }
 }
 

--- a/src/tui/workspace/render.rs
+++ b/src/tui/workspace/render.rs
@@ -559,11 +559,8 @@ fn render_source_list(
         .iter()
         .enumerate()
         .map(|(idx, source)| {
-            let selected = pane.scope_mask().get(idx).copied().unwrap_or(false);
-            let load = source_markers
-                .get(idx)
-                .copied()
-                .unwrap_or(SourceLoadMarker::Idle);
+            let selected = pane.scope_mask()[idx];
+            let load = source_markers[idx];
             let marker = load.status_glyph(selected, loading_tick);
             let style = row_highlight(idx, cursor_idx, range_anchor)
                 .unwrap_or_else(|| Style::default().fg(source.color()));
@@ -603,12 +600,9 @@ fn render_source_strip(
         if idx > 0 {
             spans.push(Span::styled("  ", Style::default().fg(theme::dim())));
         }
-        let selected = pane.scope_mask().get(idx).copied().unwrap_or(false);
+        let selected = pane.scope_mask()[idx];
         let focused = idx == current && active;
-        let load = source_markers
-            .get(idx)
-            .copied()
-            .unwrap_or(SourceLoadMarker::Idle);
+        let load = source_markers[idx];
         let marker = load.status_glyph(selected, loading_tick);
         let marker_style = if focused {
             active_item_style()
@@ -660,7 +654,7 @@ fn render_session_list(
         .iter()
         .enumerate()
         .map(|(idx, choice)| {
-            let selected = pane.scope_mask().get(idx).copied().unwrap_or(false);
+            let selected = pane.scope_mask()[idx];
             let base_style = row_highlight(idx, cursor_idx, range_anchor).unwrap_or_default();
             let highlight = search
                 .filter(|search| search.scope == WorkspaceSearchScope::Session)
@@ -712,7 +706,7 @@ fn render_dialogue_list(
         .iter()
         .enumerate()
         .map(|(idx, title)| {
-            let selected = selected_dialogues.get(idx).copied().unwrap_or(false);
+            let selected = selected_dialogues[idx];
             // Selection is shown by the dot alone (● = selected, ○ = not),
             // always visible so it survives pane switches.
             let marker = format!("{} ", selection_dot(selected));

--- a/src/tui/workspace/rows.rs
+++ b/src/tui/workspace/rows.rs
@@ -13,7 +13,7 @@ use ratatui::widgets::ListState;
 
 use super::model::{selected_indices, WorkspaceFocus};
 use crate::pane::Selection;
-use crate::workset::WorkSet;
+use sivtr_core::workset::WorkSet;
 
 /// Rows a pane-wide action applies to: every marked row in row order, or the
 /// cursor row alone when nothing is marked. `len` is the row count, so a stale

--- a/src/workset.rs
+++ b/src/workset.rs
@@ -1,6 +1,6 @@
 //! Canonical record and part selection shared by the TUI, CLI, and MCP.
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use chrono::{SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
 use sivtr_core::record::{WorkAt, WorkRecord, WorkRef};
@@ -98,7 +98,6 @@ impl WorkSet {
                 && self
                     .anchors
                     .iter()
-                    .skip(index + 1)
                     .any(|other| other.at != WorkAt::Whole && other.whole() == anchor.whole())
             {
                 bail!("WorkSet contains Part anchors shadowed by Whole");
@@ -272,12 +271,28 @@ pub fn records_for_anchors(records: &[WorkRecord], anchors: &[WorkRef]) -> Vec<W
         if !seen.insert(record_ref.clone()) {
             continue;
         }
-        if let Some(record) = records
-            .iter()
-            .find(|record| record.work_ref.whole() == record_ref)
-        {
+        if let Some(record) = find_record([records], anchor) {
             selected.push(record.clone());
         }
     }
     selected
+}
+
+pub fn find_record<'a, I>(record_sets: I, anchor: &WorkRef) -> Option<&'a WorkRecord>
+where
+    I: IntoIterator<Item = &'a [WorkRecord]>,
+{
+    let record_ref = anchor.whole();
+    record_sets
+        .into_iter()
+        .flat_map(|records| records.iter())
+        .find(|record| record.work_ref.whole() == record_ref)
+}
+
+pub fn require_record<'a, I>(record_sets: I, anchor: &WorkRef) -> Result<&'a WorkRecord>
+where
+    I: IntoIterator<Item = &'a [WorkRecord]>,
+{
+    find_record(record_sets, anchor)
+        .with_context(|| format!("No record found for ref `{}`", anchor.whole()))
 }

--- a/src/workset.rs
+++ b/src/workset.rs
@@ -1,5 +1,6 @@
 //! Canonical record and part selection shared by the TUI, CLI, and MCP.
 
+use anyhow::{bail, Result};
 use chrono::{SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
 use sivtr_core::record::{WorkAt, WorkRecord, WorkRef};
@@ -34,13 +35,25 @@ impl WorkSet {
         records: Vec<WorkRecord>,
         anchors: Vec<WorkRef>,
     ) -> Self {
+        let mut canonical: Vec<WorkRef> = Vec::with_capacity(anchors.len());
+        for anchor in anchors {
+            let whole = anchor.whole();
+            if anchor.at == WorkAt::Whole {
+                canonical.retain(|existing| existing.whole() != whole);
+                canonical.push(anchor);
+            } else if !canonical.iter().any(|existing| {
+                existing == &anchor || (existing.at == WorkAt::Whole && existing.whole() == whole)
+            }) {
+                canonical.push(anchor);
+            }
+        }
         Self {
             schema_version: WORKSET_SCHEMA_VERSION,
             created_at: Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
             cwd: cwd.into(),
             name: None,
             records,
-            anchors,
+            anchors: canonical,
         }
     }
 
@@ -64,13 +77,34 @@ impl WorkSet {
         (self.records, self.anchors)
     }
 
-    pub(crate) fn replace_records(&mut self, records: Vec<WorkRecord>) {
-        self.records = records;
+    pub(crate) fn select_anchors(&mut self, anchors: Vec<WorkRef>) {
+        self.records = records_for_anchors(&self.records, &anchors);
+        self.anchors = anchors;
     }
 
-    pub(crate) fn replace_selection(&mut self, records: Vec<WorkRecord>, anchors: Vec<WorkRef>) {
-        self.records = records;
-        self.anchors = anchors;
+    pub(crate) fn validate(&self) -> Result<()> {
+        if self.schema_version != WORKSET_SCHEMA_VERSION {
+            bail!(
+                "unsupported WorkSet schema version {}; expected {}",
+                self.schema_version,
+                WORKSET_SCHEMA_VERSION
+            );
+        }
+        for (index, anchor) in self.anchors.iter().enumerate() {
+            if self.anchors[..index].contains(anchor) {
+                bail!("WorkSet contains duplicate anchor");
+            }
+            if anchor.at == WorkAt::Whole
+                && self
+                    .anchors
+                    .iter()
+                    .skip(index + 1)
+                    .any(|other| other.at != WorkAt::Whole && other.whole() == anchor.whole())
+            {
+                bail!("WorkSet contains Part anchors shadowed by Whole");
+            }
+        }
+        Ok(())
     }
 
     /// Whether this selection covers an address. A Whole anchor covers every
@@ -228,4 +262,22 @@ impl WorkSet {
             .retain(|record| record.work_ref.whole() != whole);
         self.anchors.retain(|anchor| anchor.whole() != whole);
     }
+}
+
+pub fn records_for_anchors(records: &[WorkRecord], anchors: &[WorkRef]) -> Vec<WorkRecord> {
+    let mut selected = Vec::new();
+    let mut seen = HashSet::new();
+    for anchor in anchors {
+        let record_ref = anchor.whole();
+        if !seen.insert(record_ref.clone()) {
+            continue;
+        }
+        if let Some(record) = records
+            .iter()
+            .find(|record| record.work_ref.whole() == record_ref)
+        {
+            selected.push(record.clone());
+        }
+    }
+    selected
 }

--- a/src/workset.rs
+++ b/src/workset.rs
@@ -3,10 +3,70 @@
 use anyhow::{bail, Context, Result};
 use chrono::{SecondsFormat, Utc};
 use serde::{Deserialize, Serialize};
-use sivtr_core::record::{WorkAt, WorkRecord, WorkRef};
+use sivtr_core::ai::AgentProvider;
+use sivtr_core::record::{WorkAt, WorkPath, WorkRecord, WorkRef, WorkScope};
 use std::collections::HashSet;
 
 pub const WORKSET_SCHEMA_VERSION: u32 = 2;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum WorkSelectionKind {
+    Terminal,
+    Agent(AgentProvider),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WorkSelectionTarget {
+    Scope {
+        scope: WorkScope,
+        kind: WorkSelectionKind,
+        session: Option<String>,
+    },
+    Whole(WorkRecord),
+    Parts {
+        record: WorkRecord,
+        parts: Vec<usize>,
+    },
+    Many(Vec<WorkSelectionTarget>),
+}
+
+impl WorkSelectionTarget {
+    fn matches(&self, record: &WorkRecord) -> bool {
+        match self {
+            Self::Many(targets) => targets.iter().any(|target| target.matches(record)),
+            Self::Scope {
+                scope,
+                kind,
+                session,
+            } => {
+                if &record.work_ref.scope != scope {
+                    return false;
+                }
+                let path_matches = match (kind, &record.work_ref.path) {
+                    (WorkSelectionKind::Terminal, WorkPath::Terminal { .. }) => true,
+                    (WorkSelectionKind::Agent(expected), WorkPath::Agent { provider, .. }) => {
+                        expected == provider
+                    }
+                    _ => false,
+                };
+                path_matches
+                    && session
+                        .as_deref()
+                        .is_none_or(|expected| record.work_ref.session() == expected)
+            }
+            Self::Whole(selected) => selected.work_ref.whole() == record.work_ref.whole(),
+            Self::Parts {
+                record: selected, ..
+            } => selected.work_ref.whole() == record.work_ref.whole(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WorkSelectionAction {
+    Include,
+    Toggle,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkSet {
@@ -151,7 +211,7 @@ impl WorkSet {
 
     /// Include a complete record. Whole is the canonical representation for a
     /// record-wide selection, so any narrower anchors for it are removed.
-    pub fn include_whole(&mut self, record: WorkRecord) {
+    fn include_whole(&mut self, record: WorkRecord) {
         let whole = record.work_ref.whole();
         self.records.retain(|item| item.work_ref.whole() != whole);
         self.records.push(record);
@@ -159,7 +219,7 @@ impl WorkSet {
         self.anchors.push(whole);
     }
 
-    pub fn include_records(&mut self, records: impl IntoIterator<Item = WorkRecord>) {
+    fn include_records(&mut self, records: impl IntoIterator<Item = WorkRecord>) {
         for record in records {
             let whole = record.work_ref.whole();
             if !self
@@ -172,9 +232,37 @@ impl WorkSet {
         }
     }
 
+    pub fn apply_target(
+        &mut self,
+        action: WorkSelectionAction,
+        target: WorkSelectionTarget,
+        records: impl IntoIterator<Item = WorkRecord>,
+    ) {
+        match target {
+            WorkSelectionTarget::Scope { .. } | WorkSelectionTarget::Many(_) => {
+                let selected = records
+                    .into_iter()
+                    .filter(|record| target.matches(record))
+                    .collect();
+                match action {
+                    WorkSelectionAction::Include => self.include_records(selected),
+                    WorkSelectionAction::Toggle => self.toggle_records(selected),
+                }
+            }
+            WorkSelectionTarget::Whole(record) => match action {
+                WorkSelectionAction::Include => self.include_whole(record),
+                WorkSelectionAction::Toggle => self.toggle_whole(record),
+            },
+            WorkSelectionTarget::Parts { record, parts } => match action {
+                WorkSelectionAction::Include => self.include_parts(record, parts),
+                WorkSelectionAction::Toggle => self.toggle_parts(record, parts),
+            },
+        }
+    }
+
     /// Include selected parts of a record. A Whole anchor already covers them
     /// and remains the only stored representation.
-    pub fn include_parts(&mut self, record: WorkRecord, parts: impl IntoIterator<Item = usize>) {
+    fn include_parts(&mut self, record: WorkRecord, parts: impl IntoIterator<Item = usize>) {
         let parts: Vec<_> = parts.into_iter().collect();
         if parts.is_empty() {
             return;
@@ -194,7 +282,7 @@ impl WorkSet {
     }
 
     /// Toggle a complete record selection.
-    pub fn toggle_whole(&mut self, record: WorkRecord) {
+    fn toggle_whole(&mut self, record: WorkRecord) {
         if self
             .anchors
             .iter()
@@ -208,7 +296,7 @@ impl WorkSet {
 
     /// Toggle a set of parts. A fully selected set is removed; otherwise the
     /// missing parts are added and a Whole selection remains authoritative.
-    pub fn toggle_parts(&mut self, record: WorkRecord, parts: impl IntoIterator<Item = usize>) {
+    fn toggle_parts(&mut self, record: WorkRecord, parts: impl IntoIterator<Item = usize>) {
         let parts: Vec<_> = parts.into_iter().collect();
         if parts.is_empty() {
             return;
@@ -254,7 +342,7 @@ impl WorkSet {
     }
 
     /// Toggle every record in a scope using the same Whole rule.
-    pub fn toggle_records(&mut self, records: Vec<WorkRecord>) {
+    fn toggle_records(&mut self, records: Vec<WorkRecord>) {
         if records.is_empty() {
             return;
         }

--- a/src/workset.rs
+++ b/src/workset.rs
@@ -35,11 +35,24 @@ impl WorkSet {
         records: Vec<WorkRecord>,
         anchors: Vec<WorkRef>,
     ) -> Self {
-        let mut canonical: Vec<WorkRef> = Vec::with_capacity(anchors.len());
-        for anchor in anchors {
+        let mut set = Self {
+            schema_version: WORKSET_SCHEMA_VERSION,
+            created_at: Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
+            cwd: cwd.into(),
+            name: None,
+            records,
+            anchors,
+        };
+        set.normalize_anchors();
+        set
+    }
+
+    fn normalize_anchors(&mut self) {
+        let mut canonical = Vec::with_capacity(self.anchors.len());
+        for anchor in self.anchors.drain(..) {
             let whole = anchor.whole();
             if anchor.at == WorkAt::Whole {
-                canonical.retain(|existing| existing.whole() != whole);
+                canonical.retain(|existing: &WorkRef| existing.whole() != whole);
                 canonical.push(anchor);
             } else if !canonical.iter().any(|existing| {
                 existing == &anchor || (existing.at == WorkAt::Whole && existing.whole() == whole)
@@ -47,14 +60,27 @@ impl WorkSet {
                 canonical.push(anchor);
             }
         }
-        Self {
-            schema_version: WORKSET_SCHEMA_VERSION,
-            created_at: Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true),
-            cwd: cwd.into(),
-            name: None,
-            records,
-            anchors: canonical,
+        for record in &self.records {
+            if record.parts.is_empty() {
+                continue;
+            }
+            let whole = record.work_ref.whole();
+            let complete = record.parts.iter().all(|part| {
+                canonical
+                    .iter()
+                    .any(|anchor| anchor.at == WorkAt::Part(part.seq) && anchor.whole() == whole)
+            });
+            if !complete || canonical.iter().any(|anchor| anchor == &whole) {
+                continue;
+            }
+            let first = canonical
+                .iter()
+                .position(|anchor| anchor.whole() == whole)
+                .expect("complete parts must have a matching anchor");
+            canonical.retain(|anchor| anchor.whole() != whole);
+            canonical.insert(first, whole);
         }
+        self.anchors = canonical;
     }
 
     pub fn anchors(&self) -> &[WorkRef] {
@@ -102,6 +128,14 @@ impl WorkSet {
             {
                 bail!("WorkSet contains Part anchors shadowed by Whole");
             }
+            let Some(record) = find_record([self.records.as_slice()], anchor) else {
+                bail!("WorkSet anchor has no backing record");
+            };
+            if let WorkAt::Part(seq) = anchor.at {
+                if !record.parts.iter().any(|part| part.seq == seq) {
+                    bail!("WorkSet Part anchor has no matching part");
+                }
+            }
         }
         Ok(())
     }
@@ -142,18 +176,10 @@ impl WorkSet {
     /// and remains the only stored representation.
     pub fn include_parts(&mut self, record: WorkRecord, parts: impl IntoIterator<Item = usize>) {
         let parts: Vec<_> = parts.into_iter().collect();
+        if parts.is_empty() {
+            return;
+        }
         let whole = record.work_ref.whole();
-        if !record.parts.is_empty() && record.parts.iter().all(|part| parts.contains(&part.seq)) {
-            self.include_whole(record);
-            return;
-        }
-        if self
-            .anchors
-            .iter()
-            .any(|anchor| anchor.at == WorkAt::Whole && anchor.whole() == whole)
-        {
-            return;
-        }
         if !self
             .records
             .iter()
@@ -162,11 +188,9 @@ impl WorkSet {
             self.records.push(record.clone());
         }
         for seq in parts {
-            let anchor = whole.with_part(seq);
-            if !self.anchors.contains(&anchor) {
-                self.anchors.push(anchor);
-            }
+            self.anchors.push(whole.with_part(seq));
         }
+        self.normalize_anchors();
     }
 
     /// Toggle a complete record selection.
@@ -199,7 +223,28 @@ impl WorkSet {
         {
             let whole = record.work_ref.whole();
             let remove: HashSet<_> = parts.into_iter().map(|seq| whole.with_part(seq)).collect();
-            self.anchors.retain(|anchor| !remove.contains(anchor));
+            let had_whole = self
+                .anchors
+                .iter()
+                .any(|anchor| anchor.at == WorkAt::Whole && anchor.whole() == whole);
+            let insert_at = self
+                .anchors
+                .iter()
+                .position(|anchor| anchor.whole() == whole);
+            self.anchors.retain(|anchor| {
+                anchor.whole() != whole || (!had_whole && !remove.contains(anchor))
+            });
+            if had_whole {
+                let remaining = record
+                    .parts
+                    .iter()
+                    .map(|part| whole.with_part(part.seq))
+                    .filter(|anchor| !remove.contains(anchor));
+                if let Some(index) = insert_at {
+                    self.anchors.splice(index..index, remaining);
+                }
+            }
+            self.normalize_anchors();
             if !self.anchors.iter().any(|anchor| anchor.whole() == whole) {
                 self.records.retain(|item| item.work_ref.whole() != whole);
             }


### PR DESCRIPTION
## Purpose
Finalize WorkSet persistence validation and hierarchical target routing.

## Changes
- Validate canonical anchors before persistence.
- Route hierarchical target expansion through WorkSet.
- Keep the TUI limited to row-to-target mapping and rendering.

## Validation
Validated on the stack tip with `cargo build --target-dir target/build-check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p sivtr --lib`.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared work set model for selecting complete records, individual parts, sessions, and content blocks.
  * Added support for toggling, excluding, validating, and materializing selections across workspace content.
  * Centralized work set handling across browsing, search, memory, and integrations.

* **Bug Fixes**
  * Saved work sets are now validated when loaded or persisted, with clearer errors for invalid data.
  * Improved selection consistency across sources, sessions, dialogues, and content blocks.

* **Documentation**
  * Documented the canonical work set model in the project guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->