### PR TITLE
feat(web): add local web UI and JSON API over the archive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2884,6 +2936,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2902,6 +2960,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -4418,6 +4492,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
+dependencies = [
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.118",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
+dependencies = [
+ "sha2 0.11.0",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4719,6 +4828,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4736,6 +4856,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -4900,6 +5032,7 @@ dependencies = [
  "aes-gcm 0.11.1",
  "anyhow",
  "arboard",
+ "axum",
  "base64 0.23.1",
  "chrono",
  "clap",
@@ -4914,12 +5047,14 @@ dependencies = [
  "getrandom 0.4.3",
  "iroh",
  "libc",
+ "mime_guess",
  "notify",
  "pulldown-cmark",
  "ratatui",
  "regex",
  "rmcp",
  "rusqlite",
+ "rust-embed",
  "schemars",
  "serde",
  "serde_json",
@@ -4930,6 +5065,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
+ "tower",
  "unicode-width",
  "ureq",
  "winapi",
@@ -5550,6 +5686,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,9 @@ zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
 flate2 = "1.1.9"
 tar = { version = "0.4.46", default-features = false }
 notify = "8.2"
+axum = "0.8.9"
+mime_guess = "2"
+rust-embed = "8.12.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -121,6 +124,7 @@ winapi = { version = "0.3", features = ["consoleapi", "fileapi", "handleapi", "n
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
 dhat = "0.3"
+tower = { version = "0.5", features = ["util"] }
 
 [features]
 # Benches only: `cargo bench -p sivtr --features perf-benches`

--- a/crates/sivtr-core/src/archive/store.rs
+++ b/crates/sivtr-core/src/archive/store.rs
@@ -395,6 +395,136 @@ pub fn provider_stamps(
     Ok(rows.into_iter().collect())
 }
 
+/// Session metadata for listings and API responses.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SessionMeta {
+    pub provider: String,
+    pub session_id: String,
+    pub title: Option<String>,
+    pub cwd: Option<String>,
+    pub started_at: Option<String>,
+    pub ended_at: Option<String>,
+    pub record_count: i64,
+}
+
+/// Per-provider archive totals.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ProviderCount {
+    pub provider: String,
+    pub sessions: i64,
+    pub records: i64,
+}
+
+/// List archived session metadata, newest-first, optionally filtered by
+/// provider and offset-paginated. Used by listings and the web API.
+pub fn list_sessions_meta(
+    conn: &Connection,
+    provider: Option<&str>,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<SessionMeta>> {
+    let sql = match provider {
+        Some(_) => {
+            "SELECT provider, session_id, title, cwd, started_at, ended_at, record_count
+             FROM sessions WHERE provider = ?1
+             ORDER BY COALESCE(ended_at, started_at, synced_at) DESC
+             LIMIT ?2 OFFSET ?3"
+        }
+        None => {
+            "SELECT provider, session_id, title, cwd, started_at, ended_at, record_count
+             FROM sessions
+             ORDER BY COALESCE(ended_at, started_at, synced_at) DESC
+             LIMIT ?2 OFFSET ?3"
+        }
+    };
+    let mut stmt = conn.prepare(sql)?;
+    let map_row = |row: &rusqlite::Row| {
+        Ok(SessionMeta {
+            provider: row.get(0)?,
+            session_id: row.get(1)?,
+            title: row.get(2)?,
+            cwd: row.get(3)?,
+            started_at: row.get(4)?,
+            ended_at: row.get(5)?,
+            record_count: row.get(6)?,
+        })
+    };
+    let rows = match provider {
+        Some(provider) => stmt
+            .query_map(params![provider, limit, offset], map_row)?
+            .collect::<std::result::Result<Vec<_>, _>>()?,
+        None => stmt
+            .query_map(params![limit, offset], map_row)?
+            .collect::<std::result::Result<Vec<_>, _>>()?,
+    };
+    Ok(rows)
+}
+
+/// Session and record totals per provider, alphabetical by provider name.
+pub fn provider_counts(conn: &Connection) -> Result<Vec<ProviderCount>> {
+    let mut stmt = conn.prepare(
+        "SELECT s.provider, COUNT(DISTINCT s.id), COALESCE(SUM(s.record_count), 0)
+         FROM sessions s GROUP BY s.provider ORDER BY s.provider ASC",
+    )?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok(ProviderCount {
+                provider: row.get(0)?,
+                sessions: row.get(1)?,
+                records: row.get(2)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
+/// One session's metadata by its archive key.
+pub fn session_meta_by_key(
+    conn: &Connection,
+    provider: &str,
+    session_id: &str,
+) -> Result<Option<SessionMeta>> {
+    conn.query_row(
+        "SELECT provider, session_id, title, cwd, started_at, ended_at, record_count
+         FROM sessions WHERE provider = ?1 AND session_id = ?2",
+        params![provider, session_id],
+        |row| {
+            Ok(SessionMeta {
+                provider: row.get(0)?,
+                session_id: row.get(1)?,
+                title: row.get(2)?,
+                cwd: row.get(3)?,
+                started_at: row.get(4)?,
+                ended_at: row.get(5)?,
+                record_count: row.get(6)?,
+            })
+        },
+    )
+    .optional()
+    .context("Failed to read archived session metadata")
+}
+
+/// Load one session's records by its archive key (provider + session id).
+pub fn load_records_by_key(
+    conn: &Connection,
+    provider: &str,
+    session_id: &str,
+    mode: BlobMode,
+) -> Result<Option<Vec<WorkRecord>>> {
+    let row: Option<i64> = conn
+        .query_row(
+            "SELECT id FROM sessions WHERE provider = ?1 AND session_id = ?2",
+            params![provider, session_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .context("Failed to look up archived session")?;
+    match row {
+        Some(row) => load_records_by_row(conn, row, mode).map(Some),
+        None => Ok(None),
+    }
+}
+
 /// Read/write the archive_meta key/value table (sync bookkeeping).
 pub fn meta_get(conn: &Connection, key: &str) -> Result<Option<String>> {
     conn.query_row(

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -73,6 +73,7 @@ export default defineConfig({
             'usage/compare-command-blocks',
             'usage/ai-sessions',
             'usage/search-and-show',
+            'usage/web-ui',
             'usage/skills',
             'usage/remote-access',
             'usage/history',

--- a/docs-site/src/content/docs/reference/cli.md
+++ b/docs-site/src/content/docs/reference/cli.md
@@ -890,6 +890,26 @@ sivtr hotkey status
 sivtr hotkey stop
 ```
 
+## web
+
+```bash
+sivtr web [--port <PORT>] [--host <HOST>]
+```
+
+Serves a local web UI and a read-only JSON API over the unified archive: a session browser (filter by provider, open a session, copy refs) and full-text search with BM25 relevance ranking.
+
+| Option | Meaning |
+| --- | --- |
+| `--port <PORT>` | TCP port to bind (default `8080`) |
+| `--host <HOST>` | Bind address (default `127.0.0.1`, loopback only) |
+
+The server validates the browser `Host` header to guard against DNS rebinding. It is read-only — no writes — and data never leaves the machine. See [Web UI](/usage/web-ui/).
+
+```bash
+sivtr web
+sivtr web --port 8081
+```
+
 ## sync
 
 ```bash

--- a/docs-site/src/content/docs/usage/web-ui.md
+++ b/docs-site/src/content/docs/usage/web-ui.md
@@ -1,0 +1,42 @@
+---
+title: Web UI
+description: Browse and search the unified local archive in a browser with `sivtr web`.
+---
+
+`sivtr web` serves a local web UI and a read-only JSON API over the unified archive (`archive.db`). Use it to browse terminal and agent sessions and to run full-text search ranked by BM25 relevance without opening the TUI.
+
+## Start the server
+
+```bash
+sivtr web
+```
+
+Then open <http://127.0.0.1:8080> in a browser.
+
+| Option | Meaning |
+| --- | --- |
+| `--port <PORT>` | TCP port to bind (default `8080`) |
+| `--host <HOST>` | Bind address (default `127.0.0.1`, loopback only) |
+
+## Using the UI
+
+- **Session browser** — filter sessions by provider, open a session, and copy its refs for use with `sivtr show`.
+- **Search** — press `/` anywhere to focus the search box; results are ranked by BM25 relevance.
+
+## JSON API
+
+The same surface is available as a read-only JSON API:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /api/v1/health` | Server health check |
+| `GET /api/v1/providers` | List registered providers |
+| `GET /api/v1/sessions?provider=&limit=&offset=` | List sessions with optional filters |
+| `GET /api/v1/sessions/{provider}/{session_id}` | One full session |
+| `GET /api/v1/search?q=&source=all|all:agent|all:terminal|<selector>&limit=` | Full-text search |
+
+## Privacy
+
+The server binds to loopback by default, so the UI is only reachable from this machine. It is strictly read-only — no writes — and data never leaves the machine. The server also validates the browser `Host` header to guard against DNS rebinding.
+
+Changing `--port` also changes the accepted `Host`, so requests must target the same `host:port` the server is bound to.

--- a/docs-site/src/content/docs/zh-cn/reference/cli.md
+++ b/docs-site/src/content/docs/zh-cn/reference/cli.md
@@ -888,6 +888,26 @@ sivtr hotkey status
 sivtr hotkey stop
 ```
 
+## web
+
+```bash
+sivtr web [--port <PORT>] [--host <HOST>]
+```
+
+在统一 archive 之上提供本地 web UI 和只读 JSON API：session 浏览器（按 provider 过滤、打开 session、复制 refs）和按 BM25 相关性排序的全文搜索。
+
+| 选项 | 含义 |
+| --- | --- |
+| `--port <PORT>` | 要绑定的 TCP 端口（默认 `8080`） |
+| `--host <HOST>` | 绑定地址（默认 `127.0.0.1`，仅 loopback） |
+
+server 会校验浏览器 `Host` header 以防范 DNS rebinding。它是只读的——不做任何写入——数据也不会离开本机。详见 [Web UI](/zh-cn/usage/web-ui/)。
+
+```bash
+sivtr web
+sivtr web --port 8081
+```
+
 ## sync
 
 ```bash

--- a/docs-site/src/content/docs/zh-cn/usage/web-ui.md
+++ b/docs-site/src/content/docs/zh-cn/usage/web-ui.md
@@ -1,0 +1,42 @@
+---
+title: Web UI
+description: 用 `sivtr web` 在浏览器中浏览和搜索统一的本地 archive。
+---
+
+`sivtr web` 在统一 archive（`archive.db`）之上提供本地 web UI 和只读 JSON API。用它浏览终端和 Agent session，或运行按 BM25 相关性排序的全文搜索，而不必打开 TUI。
+
+## 启动 server
+
+```bash
+sivtr web
+```
+
+然后在浏览器打开 <http://127.0.0.1:8080>。
+
+| 选项 | 含义 |
+| --- | --- |
+| `--port <PORT>` | 要绑定的 TCP 端口（默认 `8080`） |
+| `--host <HOST>` | 绑定地址（默认 `127.0.0.1`，仅 loopback） |
+
+## 使用 UI
+
+- **Session 浏览器** — 按 provider 过滤 session、打开一个 session、复制它的 refs，供 `sivtr show` 使用。
+- **搜索** — 在任意位置按 `/` 聚焦搜索框；结果按 BM25 相关性排序。
+
+## JSON API
+
+同样的表面也可以作为只读 JSON API 使用：
+
+| Endpoint | 用途 |
+| --- | --- |
+| `GET /api/v1/health` | Server 健康检查 |
+| `GET /api/v1/providers` | 列出已注册 provider |
+| `GET /api/v1/sessions?provider=&limit=&offset=` | 列出 session，支持可选过滤 |
+| `GET /api/v1/sessions/{provider}/{session_id}` | 单个完整 session |
+| `GET /api/v1/search?q=&source=all|all:agent|all:terminal|<selector>&limit=` | 全文搜索 |
+
+## 隐私
+
+server 默认只绑定 loopback，因此 UI 只能从本机访问。它是严格只读的——不做任何写入——数据也不会离开本机。server 还会校验浏览器的 `Host` header，以防范 DNS rebinding。
+
+修改 `--port` 也会改变接受的 `Host`，所以请求必须指向 server 实际绑定的同一个 `host:port`。

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -413,6 +413,9 @@ pub enum Commands {
     #[command(after_help = HOTKEY_AFTER_HELP)]
     Hotkey(HotkeyCommand),
 
+    /// Serve the local web UI and JSON API over the unified archive
+    Web(WebArgs),
+
     /// Sync terminal and agent sessions into the unified archive
     Sync(SyncArgs),
 
@@ -1163,6 +1166,17 @@ impl<'de> Deserialize<'de> for HotkeyProviderSelection {
         let value = String::deserialize(deserializer)?;
         Self::from_str(&value).map_err(serde::de::Error::custom)
     }
+}
+
+#[derive(Args, Debug)]
+pub struct WebArgs {
+    /// TCP port to bind
+    #[arg(long, value_name = "PORT", default_value_t = 8080)]
+    pub port: u16,
+
+    /// Bind address; loopback by default so the UI is never exposed
+    #[arg(long, value_name = "HOST", default_value = "127.0.0.1")]
+    pub host: String,
 }
 
 #[derive(Args, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod origins;
 pub mod output;
 pub mod pane;
 pub mod remote;
+pub mod server;
 pub mod tui;
 
 use anyhow::{Context, Result};
@@ -110,6 +111,9 @@ fn run() -> Result<()> {
         }
         Some(Commands::Hotkey(cmd)) => {
             commands::system::hotkey::execute(cmd)?;
+        }
+        Some(Commands::Web(args)) => {
+            server::execute(&args)?;
         }
         Some(Commands::Sync(args)) => {
             commands::system::sync::execute(&args)?;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,0 +1,303 @@
+//! Local web UI + JSON API over the unified archive.
+//!
+//! Binds loopback by default, validates the `Host` header against DNS
+//! rebinding, and serves the embedded single-page UI plus a read-only JSON
+//! surface (`/api/v1/...`) backed by the same archive functions the CLI
+//! uses. Nothing here writes to the archive: freshness comes from the same
+//! stamp-gated sync pass the CLI performs before queries.
+
+use anyhow::{Context, Result};
+use axum::extract::{Path as AxPath, Query as AxQuery};
+use axum::http::{header, HeaderValue, Request, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use rust_embed::RustEmbed;
+use serde::Deserialize;
+use serde_json::json;
+
+use sivtr_core::archive::store::{self, BlobMode};
+use sivtr_core::query::NO_RECORD_FOR_SELECTOR;
+use sivtr_core::search::{Filter, Sort};
+
+use crate::cli::WebArgs;
+use crate::commands::memory::workset;
+
+/// Embedded static assets for the UI (`web/` in the repository).
+#[derive(RustEmbed)]
+#[folder = "web"]
+struct Assets;
+
+/// Serve the web UI until interrupted.
+pub fn execute(args: &WebArgs) -> Result<()> {
+    let runtime = tokio::runtime::Runtime::new().context("Failed to start async runtime")?;
+    runtime.block_on(serve(args.host.clone(), args.port))
+}
+
+async fn serve(host: String, port: u16) -> Result<()> {
+    let app = router(port);
+    let addr = format!("{host}:{port}");
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .with_context(|| format!("Failed to bind web server on {addr}"))?;
+    crate::output::info(format!("sivtr web UI listening on http://{addr}"));
+    axum::serve(listener, app).await.context("web server error")
+}
+
+fn router(port: u16) -> Router {
+    Router::new()
+        .route("/api/v1/health", get(health))
+        .route("/api/v1/providers", get(providers))
+        .route("/api/v1/sessions", get(sessions))
+        .route(
+            "/api/v1/sessions/{provider}/{session_id}",
+            get(session_detail),
+        )
+        .route("/api/v1/search", get(search))
+        .route("/", get(index))
+        .fallback(static_asset)
+        .layer(middleware::from_fn(move |req, next| {
+            guard_host(req, next, port)
+        }))
+}
+
+/// Reject requests whose `Host` is not this server's loopback origin — the
+/// classic DNS-rebinding guard for a loopback-bound server.
+async fn guard_host(req: Request<axum::body::Body>, next: Next, port: u16) -> Response {
+    let host = req
+        .headers()
+        .get(header::HOST)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let allowed = [
+        format!("localhost:{port}"),
+        format!("127.0.0.1:{port}"),
+        format!("[::1]:{port}"),
+        "localhost".to_string(),
+        "127.0.0.1".to_string(),
+        "[::1]".to_string(),
+    ];
+    if allowed.iter().any(|candidate| candidate == &host) {
+        next.run(req).await
+    } else {
+        (StatusCode::FORBIDDEN, "unrecognized Host header").into_response()
+    }
+}
+
+fn with_archive<T: serde::Serialize>(
+    f: impl FnOnce(&rusqlite::Connection) -> anyhow::Result<T>,
+) -> Response {
+    match sivtr_core::archive::open().and_then(|conn| f(&conn)) {
+        Ok(value) => Json(value).into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({ "error": format!("{error:#}") })),
+        )
+            .into_response(),
+    }
+}
+
+async fn health() -> Response {
+    with_archive(|conn| {
+        let counts = store::provider_counts(conn)?;
+        Ok(json!({
+            "version": env!("CARGO_PKG_VERSION"),
+            "providers": counts,
+        }))
+    })
+}
+
+async fn providers() -> Response {
+    with_archive(|conn| Ok(json!(store::provider_counts(conn)?)))
+}
+
+#[derive(Deserialize)]
+struct SessionsQuery {
+    provider: Option<String>,
+    #[serde(default = "default_limit")]
+    limit: i64,
+    #[serde(default)]
+    offset: i64,
+}
+
+fn default_limit() -> i64 {
+    100
+}
+
+async fn sessions(AxQuery(query): AxQuery<SessionsQuery>) -> Response {
+    with_archive(|conn| {
+        Ok(json!(store::list_sessions_meta(
+            conn,
+            query.provider.as_deref(),
+            query.limit,
+            query.offset
+        )?))
+    })
+}
+
+async fn session_detail(AxPath((provider, session_id)): AxPath<(String, String)>) -> Response {
+    with_archive(|conn| {
+        let meta = store::session_meta_by_key(conn, &provider, &session_id)?
+            .ok_or_else(|| anyhow::anyhow!("no archived session `{provider}/{session_id}`"))?;
+        let records = store::load_records_by_key(conn, &provider, &session_id, BlobMode::Full)?
+            .unwrap_or_default();
+        Ok(json!({ "session": meta, "records": records }))
+    })
+}
+
+#[derive(Deserialize)]
+struct SearchQuery {
+    q: Option<String>,
+    /// Selector understood by the query layer (`all:agent`, `all:terminal`,
+    /// `codex`, `all`, …). `all` runs the agent and terminal corpora and
+    /// merges the hits.
+    source: Option<String>,
+    limit: Option<usize>,
+}
+
+async fn search(AxQuery(query): AxQuery<SearchQuery>) -> Response {
+    let limit = query.limit.unwrap_or(50);
+    let rank = query.q.clone().unwrap_or_default();
+    let sort = if query.q.is_some() {
+        Sort::Relevance
+    } else {
+        Sort::Newest
+    };
+    let make_filter = || Filter {
+        rank: Some(rank.clone()),
+        sort,
+        limit: Some(limit),
+        ..Filter::none()
+    };
+
+    let cwd = match std::env::current_dir() {
+        Ok(cwd) => cwd,
+        Err(error) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": format!("{error:#}") })),
+            )
+                .into_response();
+        }
+    };
+
+    let sources: Vec<String> = match query.source.as_deref().unwrap_or("all") {
+        "all" => vec!["all:agent".to_string(), "all:terminal".to_string()],
+        source => vec![source.to_string()],
+    };
+
+    let mut merged: Vec<sivtr_core::record::WorkRecord> = Vec::new();
+    for source in sources {
+        let set = match workset::query(&source, make_filter(), Some(&cwd)) {
+            Ok(set) => set,
+            Err(error) => {
+                let message = format!("{error:#}");
+                if message.starts_with(NO_RECORD_FOR_SELECTOR) {
+                    continue;
+                }
+                return (StatusCode::BAD_REQUEST, Json(json!({ "error": message })))
+                    .into_response();
+            }
+        };
+        merged.extend(set.into_records());
+    }
+    merged.sort_by(|a, b| b.time.primary_at().cmp(&a.time.primary_at()));
+    merged.truncate(limit);
+    Json(json!({ "records": merged })).into_response()
+}
+
+async fn index() -> Response {
+    serve_asset("index.html")
+}
+
+async fn static_asset(uri: axum::http::Uri) -> Response {
+    let path = uri.path().trim_start_matches('/');
+    serve_asset(path)
+}
+
+fn serve_asset(path: &str) -> Response {
+    match Assets::get(path) {
+        Some(asset) => {
+            let mime = mime_guess::from_path(path).first_or_octet_stream();
+            let mut response = (StatusCode::OK, asset.data).into_response();
+            response.headers_mut().insert(
+                header::CONTENT_TYPE,
+                HeaderValue::from_str(mime.as_ref())
+                    .unwrap_or(HeaderValue::from_static("text/plain")),
+            );
+            response
+        }
+        None => (StatusCode::NOT_FOUND, "not found").into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower::ServiceExt;
+
+    // `std::env` is process-global; serialize the env-touching tests the same
+    // way sivtr-core's tests do.
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn test_router() -> Router {
+        router(8080)
+    }
+
+    #[tokio::test]
+    async fn host_guard_rejects_foreign_hosts() {
+        let response = test_router()
+            .oneshot(
+                Request::builder()
+                    .header(header::HOST, "evil.example.com")
+                    .uri("/api/v1/health")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    // The env var must stay set while the handler runs, and this test has no
+    // concurrent sibling that could race the process-global value.
+    #[allow(clippy::await_holding_lock)]
+    async fn health_serves_json_on_loopback_host() {
+        let _guard = env_lock();
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("SIVTR_DATA_DIR", dir.path());
+        let response = test_router()
+            .oneshot(
+                Request::builder()
+                    .header(header::HOST, "localhost:8080")
+                    .uri("/api/v1/health")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        std::env::remove_var("SIVTR_DATA_DIR");
+    }
+
+    #[tokio::test]
+    async fn index_serves_embedded_page() {
+        let response = test_router()
+            .oneshot(
+                Request::builder()
+                    .header(header::HOST, "localhost:8080")
+                    .uri("/")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}

--- a/web/app.css
+++ b/web/app.css
@@ -1,0 +1,137 @@
+:root {
+  --bg: #0f1115;
+  --panel: #161a22;
+  --panel-2: #1c212c;
+  --border: #2a3140;
+  --text: #d6dae2;
+  --muted: #8a93a5;
+  --accent: #6ea8fe;
+  --user: #7ee2a8;
+  --assistant: #d6dae2;
+  --tool: #c9a6f5;
+  --error: #ff8f8f;
+}
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #f6f7f9;
+    --panel: #ffffff;
+    --panel-2: #eef1f5;
+    --border: #d8dde6;
+    --text: #23272f;
+    --muted: #6b7383;
+    --accent: #2f6fdb;
+    --user: #1c7c4c;
+    --assistant: #23272f;
+    --tool: #6b3fa0;
+    --error: #b3323a;
+  }
+}
+* { box-sizing: border-box; }
+html, body { height: 100%; }
+body {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+  color: var(--text);
+  font: 14px/1.5 ui-sans-serif, system-ui, "Segoe UI", sans-serif;
+}
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--panel);
+}
+.brand { font-weight: 700; letter-spacing: 0.04em; }
+.brand-sub { color: var(--muted); font-size: 12px; margin-right: 8px; }
+#search {
+  flex: 1;
+  padding: 7px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel-2);
+  color: var(--text);
+  font: inherit;
+}
+#search:focus { outline: 1px solid var(--accent); }
+select {
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel-2);
+  color: var(--text);
+  font: inherit;
+}
+.layout { flex: 1; display: grid; grid-template-columns: 360px 1fr; min-height: 0; }
+.pane { min-height: 0; overflow-y: auto; }
+#sessions-pane { border-right: 1px solid var(--border); background: var(--panel); }
+.pane-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  color: var(--muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  position: sticky;
+  top: 0;
+  background: inherit;
+  z-index: 1;
+}
+.hidden { display: none !important; }
+.list { list-style: none; margin: 0; padding: 0 8px 16px; }
+.item {
+  padding: 9px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  margin-bottom: 2px;
+}
+.item:hover { background: var(--panel-2); }
+.item.active { background: var(--panel-2); outline: 1px solid var(--accent); }
+.item .title { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.item .meta { color: var(--muted); font-size: 12px; }
+#detail { padding: 0 20px 40px; }
+.session-head { padding: 16px 0 8px; }
+.session-head h2 { margin: 0 0 4px; font-size: 17px; }
+.session-head .meta { color: var(--muted); font-size: 12px; }
+.record { border: 1px solid var(--border); border-radius: 10px; margin: 12px 0; overflow: hidden; }
+.record-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--panel-2);
+  font-size: 12px;
+  color: var(--muted);
+}
+.record-head .ref { font-family: ui-monospace, Consolas, monospace; cursor: pointer; }
+.record-head .ref:hover { color: var(--accent); }
+.part { padding: 8px 14px; border-top: 1px solid var(--border); }
+.part .kind {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  display: block;
+  margin-bottom: 2px;
+}
+.part pre { margin: 0; white-space: pre-wrap; word-break: break-word; font: 13px/1.55 ui-monospace, Consolas, monospace; }
+.kind-user .kind { color: var(--user); }
+.kind-assistant .kind { color: var(--accent); }
+.kind-tool_call .kind, .kind-tool_result .kind { color: var(--tool); }
+.kind-error .kind { color: var(--error); }
+button {
+  border: 1px solid var(--border);
+  background: var(--panel-2);
+  color: var(--text);
+  border-radius: 8px;
+  padding: 5px 10px;
+  font: inherit;
+  cursor: pointer;
+}
+button:hover { border-color: var(--accent); }
+.empty { color: var(--muted); padding: 24px; text-align: center; }

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,187 @@
+// sivtr web UI: session browser + search over the unified archive.
+// Plain ES module; the JSON API is documented in docs-site (web UI section).
+
+const $ = (id) => document.getElementById(id);
+
+async function api(path) {
+  const response = await fetch(path);
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    throw new Error(body.error || `${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
+function el(tag, attrs = {}, children = []) {
+  const node = document.createElement(tag);
+  for (const [key, value] of Object.entries(attrs)) {
+    if (key === "class") node.className = value;
+    else if (key === "text") node.textContent = value;
+    else if (key.startsWith("on")) node.addEventListener(key.slice(2), value);
+    else node.setAttribute(key, value);
+  }
+  for (const child of children) node.append(child);
+  return node;
+}
+
+function fmtTime(value) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+function shortText(value, max = 90) {
+  const text = (value || "").replace(/\s+/g, " ").trim();
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+async function loadProviders() {
+  const providers = await api("/api/v1/providers");
+  const select = $("provider");
+  for (const item of providers) {
+    select.append(
+      el("option", { value: item.provider, text: `${item.provider} (${item.sessions})` })
+    );
+  }
+}
+
+async function loadSessions() {
+  const provider = $("provider").value;
+  const params = new URLSearchParams({ limit: "200" });
+  if (provider) params.set("provider", provider);
+  const sessions = await api(`/api/v1/sessions?${params}`);
+  const list = $("sessions");
+  list.replaceChildren();
+  if (!sessions.length) {
+    list.append(el("li", { class: "empty", text: "No archived sessions yet. Run a command or use an agent, then wait for the next sync." }));
+    return;
+  }
+  for (const session of sessions) {
+    list.append(
+      el("li", {
+        class: "item",
+        onclick: () => openSession(session.provider, session.session_id),
+      }, [
+        el("span", { class: "title", text: session.title || session.session_id }),
+        el("span", {
+          class: "meta",
+          text: `${session.provider} · ${session.record_count} records · ${fmtTime(session.ended_at || session.started_at)}`,
+        }),
+      ])
+    );
+  }
+}
+
+async function openSession(provider, sessionId) {
+  const detail = $("detail");
+  detail.replaceChildren(el("p", { class: "empty", text: "Loading…" }));
+  let payload;
+  try {
+    payload = await api(`/api/v1/sessions/${encodeURIComponent(provider)}/${encodeURIComponent(sessionId)}`);
+  } catch (error) {
+    detail.replaceChildren(el("p", { class: "empty", text: `Failed to load: ${error.message}` }));
+    return;
+  }
+  const { session, records } = payload;
+  detail.replaceChildren();
+  detail.append(
+    el("div", { class: "session-head" }, [
+      el("h2", { text: session.title || session.session_id }),
+      el("span", {
+        class: "meta",
+        text: `${session.provider} · ${session.record_count} records · ${fmtTime(session.started_at)} → ${fmtTime(session.ended_at)}`,
+      }),
+    ])
+  );
+  for (const record of records) {
+    detail.append(renderRecord(record));
+  }
+}
+
+function renderRecord(record) {
+  const head = el("div", { class: "record-head" }, [
+    el("span", { class: "ref", text: record.work_ref, title: "Click to copy ref", onclick: () => navigator.clipboard?.writeText(record.work_ref) }),
+    el("span", { text: fmtTime(record.time && (record.time.ended_at || record.time.started_at)) }),
+  ]);
+  const body = el("div");
+  for (const part of record.parts || []) {
+    body.append(
+      el("div", { class: `part kind-${part.kind}` }, [
+        el("span", { class: "kind", text: part.label || part.kind }),
+        el("pre", { text: partText(part) }),
+      ])
+    );
+  }
+  return el("article", { class: "record" }, [head, body]);
+}
+
+function partText(part) {
+  switch (part.kind) {
+    case "tool_call": return JSON.stringify(part.input, null, 2) || "";
+    case "tool_result": return JSON.stringify(part.output, null, 2) || "";
+    default: return part.content || "";
+  }
+}
+
+async function runSearch() {
+  const q = $("search").value.trim();
+  const source = $("source").value;
+  $("results").classList.toggle("hidden", !q && source === "all");
+  $("results-head").classList.toggle("hidden", !q && source === "all");
+  if (!q) return;
+  const params = new URLSearchParams({ q, source, limit: "50" });
+  let payload;
+  try {
+    payload = await api(`/api/v1/search?${params}`);
+  } catch (error) {
+    $("results").replaceChildren(el("li", { class: "empty", text: `Search failed: ${error.message}` }));
+    return;
+  }
+  const list = $("results");
+  list.replaceChildren();
+  if (!payload.records.length) {
+    list.append(el("li", { class: "empty", text: "No hits." }));
+    return;
+  }
+  for (const record of payload.records) {
+    list.append(
+      el("li", {
+        class: "item",
+        onclick: () => openSession(record.source.provider || "terminal", record.session.canonical_id || record.session.id),
+      }, [
+        el("span", { class: "title", text: shortText(record.title) }),
+        el("span", { class: "meta", text: `${record.work_ref} · ${fmtTime(record.time && (record.time.ended_at || record.time.started_at))}` }),
+      ])
+    );
+  }
+}
+
+function showSessionsPane() {
+  $("results").classList.add("hidden");
+  $("results-head").classList.add("hidden");
+}
+
+$("search").addEventListener("keydown", (event) => {
+  if (event.key === "Enter") runSearch();
+});
+$("source").addEventListener("change", () => {
+  if ($("search").value.trim()) runSearch();
+});
+$("provider").addEventListener("change", () => {
+  showSessionsPane();
+  loadSessions();
+});
+$("clear-search").addEventListener("click", () => {
+  $("search").value = "";
+  showSessionsPane();
+});
+document.addEventListener("keydown", (event) => {
+  if (event.key === "/" && document.activeElement !== $("search")) {
+    event.preventDefault();
+    $("search").focus();
+  }
+});
+
+loadProviders();
+loadSessions();

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>sivtr</title>
+  <link rel="stylesheet" href="/app.css">
+</head>
+<body>
+  <header class="topbar">
+    <span class="brand">sivtr</span>
+    <span class="brand-sub">unified memory</span>
+    <input id="search" type="search" placeholder="Search memory  ( / )" autocomplete="off" spellcheck="false">
+    <select id="source">
+      <option value="all">all</option>
+      <option value="all:agent">agents</option>
+      <option value="all:terminal">terminal</option>
+    </select>
+  </header>
+  <main class="layout">
+    <aside id="sessions-pane" class="pane">
+      <div class="pane-head">
+        <span>Sessions</span>
+        <select id="provider"><option value="">all providers</option></select>
+      </div>
+      <ul id="sessions" class="list"></ul>
+    </aside>
+    <section id="content-pane" class="pane">
+      <div id="results-head" class="pane-head hidden"><span>Search results</span><button id="clear-search">clear</button></div>
+      <ul id="results" class="list hidden"></ul>
+      <div id="detail"></div>
+    </section>
+  </main>
+  <script type="module" src="/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Purpose

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `sivtr web`, a local web interface for browsing archived sessions and searching records.
  - Added provider filtering, session details, record viewing, source selection, and BM25-ranked full-text search.
  - Added read-only JSON API endpoints for health, providers, sessions, session details, and search.
  - Added loopback defaults and Host-header validation for local access protection.

- **Documentation**
  - Added English and Chinese documentation covering the web interface, API, options, and privacy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->