### PR TITLE
refactor!: replace WorkPartData with two-body WorkPart model

### DIFF
--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -1311,53 +1311,11 @@ mod tests {
         serde_json::from_str(&text).unwrap_or(serde_json::Value::String(text))
     }
 
-    use crate::test_fixtures::{message_part, shell_action_part};
-    use sivtr_core::record::{
-        MessageRole, WorkActionStatus, WorkActor, WorkContent, WorkContentBlock, WorkPartBody,
-        WorkTarget,
-    };
+    use crate::test_fixtures::{message_part, shell_action_part, tool_action_part};
+    use sivtr_core::record::{MessageRole, WorkContent, WorkPart, WorkPartBody};
 
     fn assistant_part(seq: usize, content: &str) -> WorkPart {
         message_part(seq, MessageRole::Assistant, content)
-    }
-
-    /// One agent tool action carrying input and result — the shape the core
-    /// reducer builds once a call's result event arrives.
-    fn tool_action_part(
-        seq: usize,
-        id: &str,
-        tool: Option<&str>,
-        input: Option<serde_json::Value>,
-        output: Option<serde_json::Value>,
-    ) -> WorkPart {
-        let has_output = output.is_some();
-        WorkPart {
-            seq,
-            occurred_at: None,
-            body: WorkPartBody::Action {
-                id: id.to_string(),
-                actor: WorkActor::Agent,
-                target: WorkTarget::Tool {
-                    name: tool.map(str::to_string),
-                },
-                title: None,
-                input: input.map(WorkContent::Json),
-                output: output
-                    .map(|value| {
-                        vec![WorkContentBlock {
-                            content: WorkContent::Json(value),
-                            start_line: None,
-                        }]
-                    })
-                    .unwrap_or_default(),
-                status: if has_output {
-                    WorkActionStatus::Completed
-                } else {
-                    WorkActionStatus::InProgress
-                },
-                exit_code: None,
-            },
-        }
     }
 
     use super::super::content::{
@@ -1384,7 +1342,7 @@ mod tests {
     use sivtr_core::agents::AgentProvider;
     use sivtr_core::record::{WorkAt, WorkRef};
     use sivtr_core::record::{
-        WorkChannel, WorkPart, WorkRecord, WorkRecordKind, WorkSessionRef, WorkSource, WorkTime,
+        WorkChannel, WorkRecord, WorkRecordKind, WorkSessionRef, WorkSource, WorkTime,
         RECORD_SCHEMA_VERSION,
     };
     use std::time::SystemTime;

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -54,6 +54,45 @@ pub fn shell_action_part(seq: usize, command: &str, output: Option<&str>) -> Wor
     }
 }
 
+/// One agent tool action carrying input and result — the shape the core
+/// reducer builds once a call's result event arrives.
+pub fn tool_action_part(
+    seq: usize,
+    id: &str,
+    tool: Option<&str>,
+    input: Option<serde_json::Value>,
+    output: Option<serde_json::Value>,
+) -> WorkPart {
+    let has_output = output.is_some();
+    WorkPart {
+        seq,
+        occurred_at: None,
+        body: WorkPartBody::Action {
+            id: id.to_string(),
+            actor: WorkActor::Agent,
+            target: WorkTarget::Tool {
+                name: tool.map(str::to_string),
+            },
+            title: None,
+            input: input.map(WorkContent::Json),
+            output: output
+                .map(|value| {
+                    vec![WorkContentBlock {
+                        content: WorkContent::Json(value),
+                        start_line: None,
+                    }]
+                })
+                .unwrap_or_default(),
+            status: if has_output {
+                WorkActionStatus::Completed
+            } else {
+                WorkActionStatus::InProgress
+            },
+            exit_code: None,
+        },
+    }
+}
+
 /// A chat-turn record whose parts the caller builds.
 pub fn chat_record(index: usize, parts: Vec<WorkPart>) -> WorkRecord {
     WorkRecord {

--- a/src/tui/content/block.rs
+++ b/src/tui/content/block.rs
@@ -409,8 +409,8 @@ mod tests {
     use crate::tui::content::io::ExpandedBlocks;
     use sivtr_core::agents::AgentProvider;
     use sivtr_core::record::{
-        WorkActor, WorkChannel, WorkContent, WorkContentBlock, WorkRecordKind, WorkRef,
-        WorkSessionRef, WorkSource, WorkTime, RECORD_SCHEMA_VERSION,
+        WorkChannel, WorkRecordKind, WorkRef, WorkSessionRef, WorkSource, WorkTime,
+        RECORD_SCHEMA_VERSION,
     };
 
     fn shell_action(seq: usize, command: &str, output: &str, exit: Option<i32>) -> WorkPart {
@@ -437,29 +437,13 @@ mod tests {
     }
 
     fn tool_action(seq: usize, tool: &str, path: &str, output: Option<&str>) -> WorkPart {
-        WorkPart {
+        crate::test_fixtures::tool_action_part(
             seq,
-            occurred_at: None,
-            body: WorkPartBody::Action {
-                id: format!("a{seq}"),
-                actor: WorkActor::Agent,
-                target: WorkTarget::Tool {
-                    name: Some(tool.to_string()),
-                },
-                title: None,
-                input: Some(WorkContent::Json(serde_json::json!({ "file_path": path }))),
-                output: output
-                    .map(|text| {
-                        vec![WorkContentBlock {
-                            content: WorkContent::Json(serde_json::json!({ "stdout": text })),
-                            start_line: None,
-                        }]
-                    })
-                    .unwrap_or_default(),
-                status: WorkActionStatus::Completed,
-                exit_code: None,
-            },
-        }
+            &format!("a{seq}"),
+            Some(tool),
+            Some(serde_json::json!({ "file_path": path })),
+            output.map(|text| serde_json::json!({ "stdout": text })),
+        )
     }
 
     fn user_message(seq: usize, content: &str) -> WorkPart {

--- a/src/tui/content/tool.rs
+++ b/src/tui/content/tool.rs
@@ -520,11 +520,10 @@ mod tests {
             input,
             output.map(|(value, _)| value),
         );
-        if let WorkPartBody::Action { output, status, .. } = &mut part.body {
+        if let WorkPartBody::Action { output, .. } = &mut part.body {
             if let Some(block) = output.first_mut() {
                 block.start_line = start_line;
             }
-            *status = WorkActionStatus::Completed;
         }
         part
     }

--- a/src/tui/content/tool.rs
+++ b/src/tui/content/tool.rs
@@ -512,34 +512,21 @@ mod tests {
         input: Option<Value>,
         output: Option<(Value, Option<u64>)>,
     ) -> WorkPart {
-        let has_output = output.is_some();
-        WorkPart {
+        let start_line = output.as_ref().and_then(|(_, line)| *line);
+        let mut part = crate::test_fixtures::tool_action_part(
             seq,
-            occurred_at: None,
-            body: WorkPartBody::Action {
-                id: format!("a{seq}"),
-                actor: WorkActor::Agent,
-                target: WorkTarget::Tool {
-                    name: Some(tool.to_string()),
-                },
-                title: None,
-                input: input.map(WorkContent::Json),
-                output: output
-                    .map(|(value, start_line)| {
-                        vec![WorkContentBlock {
-                            content: WorkContent::Json(value),
-                            start_line,
-                        }]
-                    })
-                    .unwrap_or_default(),
-                status: if has_output {
-                    WorkActionStatus::Completed
-                } else {
-                    WorkActionStatus::InProgress
-                },
-                exit_code: None,
-            },
+            &format!("a{seq}"),
+            Some(tool),
+            input,
+            output.map(|(value, _)| value),
+        );
+        if let WorkPartBody::Action { output, status, .. } = &mut part.body {
+            if let Some(block) = output.first_mut() {
+                block.start_line = start_line;
+            }
+            *status = WorkActionStatus::Completed;
         }
+        part
     }
 
     fn call(tool: &str, input: Value) -> WorkPart {


### PR DESCRIPTION
## What

`WorkPart` becomes a two-body model: dialogue parts carry `Message` bodies (user/assistant/system/reasoning), agent/terminal actions carry `Action` bodies (input/output/status). Replaces the catch-all `WorkPartData` across the full stack (35 files).

## Breaking

Part-shaped APIs change; consumers branch on part body, not part kind.

## Depends on

- #276 (archive memory)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized test setup for tool actions across browsing and interface components.
  * Tool action test scenarios now consistently represent in-progress and completed states based on available output.
  * Test fixtures now support optional tool names, inputs, outputs, and output metadata for more consistent validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->