### PR TITLE
refactor(record): derive kind from WorkRef, delete denormalized kind+source

### DIFF
--- a/crates/sivtr-core/src/archive/schema.rs
+++ b/crates/sivtr-core/src/archive/schema.rs
@@ -8,7 +8,7 @@ use rusqlite::Connection;
 /// Archive schema version. Bump when a release changes the table layout in a
 /// way older rows cannot serve; the store then rebuilds from native sources
 /// on the next sync (the archive is derived state, so a rebuild is safe).
-pub const SCHEMA_VERSION: i64 = 5;
+pub const SCHEMA_VERSION: i64 = 6;
 
 /// Path of the archive database (`<data_dir>/archive.db`).
 pub fn db_path() -> PathBuf {
@@ -166,11 +166,11 @@ CREATE INDEX IF NOT EXISTS idx_sessions_mtime
 -- MessagePack record; `blob_light` is the metadata view with part text
 -- stripped (the light-load view). Part text lives inside the blob, so a
 -- re-sync that produces identical refs simply replaces rows in place.
+-- The terminal/agent kind is not stored: it derives from the record ref.
 CREATE TABLE IF NOT EXISTS records (
     id          INTEGER PRIMARY KEY,
     session_row INTEGER NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
     idx         INTEGER NOT NULL,
-    kind        TEXT NOT NULL,
     title       TEXT NOT NULL,
     started_at  TEXT,
     ended_at    TEXT,

--- a/crates/sivtr-core/src/archive/store.rs
+++ b/crates/sivtr-core/src/archive/store.rs
@@ -234,13 +234,12 @@ fn replace_records(tx: &Transaction<'_>, session_row: i64, records: &[WorkRecord
             .map(|status| (Some(status.outcome), status.exit_code))
             .unwrap_or((None, None));
         tx.execute(
-            "INSERT INTO records (session_row, idx, kind, title, started_at, ended_at,
+            "INSERT INTO records (session_row, idx, title, started_at, ended_at,
              outcome, exit_code, blob, blob_light)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             params![
                 session_row,
                 record.work_ref.index() as i64,
-                record.kind_label(),
                 record.title,
                 record.time.started_at,
                 record.time.ended_at,
@@ -904,20 +903,13 @@ pub fn meta_set(conn: &Connection, key: &str, value: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::record::{
-        WorkChannel, WorkRecordKind, WorkSessionRef, WorkSource, WorkTime, RECORD_SCHEMA_VERSION,
-    };
+    use crate::record::{WorkSessionRef, WorkTime, RECORD_SCHEMA_VERSION};
     use crate::test_fixtures::shell_part;
 
     fn terminal_record(session: &str, index: usize, content: &str) -> WorkRecord {
         WorkRecord {
             schema_version: RECORD_SCHEMA_VERSION,
             work_ref: format!("terminal/{session}/{index}").parse().unwrap(),
-            kind: WorkRecordKind::TerminalCommand,
-            source: WorkSource {
-                channel: WorkChannel::Terminal,
-                provider: None,
-            },
             session: WorkSessionRef {
                 id: session.to_string(),
                 canonical_id: Some(session.to_string()),

--- a/crates/sivtr-core/src/archive/store.rs
+++ b/crates/sivtr-core/src/archive/store.rs
@@ -909,7 +909,9 @@ mod tests {
     fn terminal_record(session: &str, index: usize, content: &str) -> WorkRecord {
         WorkRecord {
             schema_version: RECORD_SCHEMA_VERSION,
-            work_ref: format!("terminal/{session}/{index}").parse().unwrap(),
+            work_ref: format!("terminal/{session}/{index}")
+                .parse()
+                .expect("parse terminal work ref"),
             session: WorkSessionRef {
                 id: session.to_string(),
                 canonical_id: Some(session.to_string()),

--- a/crates/sivtr-core/src/archive/sync.rs
+++ b/crates/sivtr-core/src/archive/sync.rs
@@ -584,10 +584,12 @@ mod tests {
     #[test]
     fn sync_session_derives_id_from_canonical_records() {
         use crate::record::WorkSessionRef;
-        let file = tempfile::NamedTempFile::new().unwrap();
+        let file = tempfile::NamedTempFile::new().expect("create temporary session file");
         let record = WorkRecord {
             schema_version: crate::record::RECORD_SCHEMA_VERSION,
-            work_ref: "codex/canonical-id/1".parse().unwrap(),
+            work_ref: "codex/canonical-id/1"
+                .parse()
+                .expect("parse codex work ref"),
             session: WorkSessionRef {
                 id: "canonical-id".into(),
                 canonical_id: Some("canonical-id".into()),

--- a/crates/sivtr-core/src/archive/sync.rs
+++ b/crates/sivtr-core/src/archive/sync.rs
@@ -583,16 +583,11 @@ mod tests {
 
     #[test]
     fn sync_session_derives_id_from_canonical_records() {
-        use crate::record::{WorkChannel, WorkRecordKind, WorkSessionRef, WorkSource};
+        use crate::record::WorkSessionRef;
         let file = tempfile::NamedTempFile::new().unwrap();
         let record = WorkRecord {
             schema_version: crate::record::RECORD_SCHEMA_VERSION,
             work_ref: "codex/canonical-id/1".parse().unwrap(),
-            kind: WorkRecordKind::ChatTurn,
-            source: WorkSource {
-                channel: WorkChannel::Chat,
-                provider: Some("codex".into()),
-            },
             session: WorkSessionRef {
                 id: "canonical-id".into(),
                 canonical_id: Some("canonical-id".into()),

--- a/crates/sivtr-core/src/publication.rs
+++ b/crates/sivtr-core/src/publication.rs
@@ -7,7 +7,7 @@ use sha2::{Digest, Sha256};
 
 use crate::privacy;
 use crate::record::{
-    output_blocks_text, MessageRole, WorkPart, WorkPartBody, WorkRecord, WorkRecordKind, WorkRef,
+    output_blocks_text, MessageRole, WorkPart, WorkPartBody, WorkRecord, WorkRef,
 };
 
 pub const PUBLICATION_SCHEMA_VERSION: u32 = 1;
@@ -353,7 +353,7 @@ fn create_record_publication_draft(
 
     let first = &records[order[0]];
     ensure!(
-        first.kind == WorkRecordKind::ChatTurn,
+        first.is_agent(),
         "publish v1 only supports agent conversations, not terminal records"
     );
     ensure!(
@@ -383,16 +383,8 @@ fn create_record_publication_draft(
             "publication anchors must match records in order"
         );
         ensure!(
-            record.kind == WorkRecordKind::ChatTurn,
+            record.is_agent(),
             "publish v1 only supports agent conversations"
-        );
-        ensure!(
-            record.source.channel == crate::record::WorkChannel::Chat,
-            "publication contains a non-chat record"
-        );
-        ensure!(
-            record.source.provider.as_deref() == Some(provider.command_name()),
-            "publication provider metadata does not match its WorkRef"
         );
         ensure!(
             record.work_ref.is_local(),
@@ -720,12 +712,8 @@ fn validate_granular_record(
     session: Option<&str>,
 ) -> Result<()> {
     ensure!(
-        record.kind == WorkRecordKind::ChatTurn,
+        record.is_agent(),
         "granular publication only supports agent conversations"
-    );
-    ensure!(
-        record.source.channel == crate::record::WorkChannel::Chat,
-        "publication contains a non-chat record"
     );
     ensure!(
         record.work_ref.is_local(),
@@ -735,10 +723,6 @@ fn validate_granular_record(
         .work_ref
         .provider()
         .ok_or_else(|| anyhow::anyhow!("publish requires an agent provider"))?;
-    ensure!(
-        record.source.provider.as_deref() == Some(record_provider.command_name()),
-        "publication provider metadata does not match its WorkRef"
-    );
     if let Some(provider) = provider {
         ensure!(
             record_provider == provider,
@@ -838,9 +822,9 @@ fn hex_sha256(bytes: &[u8]) -> String {
 mod tests {
     use super::*;
     use crate::record::{
-        MessageRole, WorkActionStatus, WorkActor, WorkChannel, WorkContent, WorkContentBlock,
-        WorkPart, WorkPartBody, WorkRecord, WorkRef, WorkSessionRef, WorkSource, WorkTarget,
-        WorkTime, RECORD_SCHEMA_VERSION,
+        MessageRole, WorkActionStatus, WorkActor, WorkContent, WorkContentBlock, WorkPart,
+        WorkPartBody, WorkRecord, WorkRef, WorkSessionRef, WorkTarget, WorkTime,
+        RECORD_SCHEMA_VERSION,
     };
     use crate::test_fixtures::message_part;
 
@@ -889,11 +873,6 @@ mod tests {
         WorkRecord {
             schema_version: RECORD_SCHEMA_VERSION,
             work_ref: WorkRef::agent(crate::agents::AgentProvider::Codex, "session", index),
-            kind: WorkRecordKind::ChatTurn,
-            source: WorkSource {
-                channel: WorkChannel::Chat,
-                provider: Some("codex".into()),
-            },
             session: WorkSessionRef {
                 id: "session".into(),
                 canonical_id: None,
@@ -1161,9 +1140,6 @@ mod tests {
 
         let mut terminal = local.clone();
         terminal.work_ref = WorkRef::terminal("session", 1);
-        terminal.kind = WorkRecordKind::TerminalCommand;
-        terminal.source.channel = WorkChannel::Terminal;
-        terminal.source.provider = None;
         assert!(create_publication_draft(
             std::slice::from_ref(&terminal),
             &[terminal.work_ref.with_part(1)],
@@ -1174,7 +1150,6 @@ mod tests {
         let mut other_provider = granular_record(2);
         other_provider.work_ref =
             WorkRef::agent(crate::agents::AgentProvider::Claude, "session", 2);
-        other_provider.source.provider = Some("claude".into());
         let cross = [
             local.work_ref.with_part(1),
             other_provider.work_ref.with_part(1),

--- a/crates/sivtr-core/src/publication.rs
+++ b/crates/sivtr-core/src/publication.rs
@@ -6,9 +6,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::privacy;
-use crate::record::{
-    output_blocks_text, MessageRole, WorkPart, WorkPartBody, WorkRecord, WorkRef,
-};
+use crate::record::{output_blocks_text, MessageRole, WorkPart, WorkPartBody, WorkRecord, WorkRef};
 
 pub const PUBLICATION_SCHEMA_VERSION: u32 = 1;
 pub const GRANULAR_PUBLICATION_SCHEMA_VERSION: u32 = 2;

--- a/crates/sivtr-core/src/query/mod.rs
+++ b/crates/sivtr-core/src/query/mod.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 
 use crate::agents::AgentProvider;
-use crate::record::{WorkPath, WorkRecord, WorkRecordIndex, WorkRef, WorkRefSelector};
+use crate::record::{WorkRecord, WorkRecordIndex, WorkRef, WorkRefSelector};
 use crate::session_source::{workspace_sources, SessionSource};
 
 /// Prefix of the error [`load_workspace_source`] raises when a selector
@@ -271,17 +271,13 @@ fn dedup_records(records: &mut Vec<WorkRecord>) {
 }
 
 fn record_identity_key(record: &WorkRecord) -> String {
-    match (&record.session.canonical_id, &record.work_ref.path) {
-        (Some(canonical_id), WorkPath::Terminal { index, .. }) => {
-            format!("terminal:{canonical_id}:{index}")
-        }
-        (
-            Some(canonical_id),
-            WorkPath::Agent {
-                provider, index, ..
-            },
-        ) => format!("{}:{canonical_id}:{index}", provider.command_name()),
-        (None, _) => record.work_ref.to_string(),
+    match &record.session.canonical_id {
+        Some(canonical_id) => format!(
+            "{}:{canonical_id}:{}",
+            record.work_ref.path.namespace(),
+            record.work_ref.path.index()
+        ),
+        None => record.work_ref.to_string(),
     }
 }
 
@@ -330,10 +326,7 @@ fn normalize_session_display_ids(records: &mut [WorkRecord]) {
 }
 
 fn session_source_key(reference: &WorkRef) -> String {
-    match &reference.path {
-        WorkPath::Terminal { .. } => "terminal".to_string(),
-        WorkPath::Agent { provider, .. } => format!("agent:{}", provider.command_name()),
-    }
+    reference.path.namespace().to_string()
 }
 
 fn compact_unique_session_id(canonical_id: &str, all_sessions: &[String]) -> String {
@@ -370,9 +363,8 @@ mod tests {
     use super::*;
     use crate::agents::{AgentBlock, AgentBlockKind, AgentSession};
     use crate::record::{
-        MessageRole, Projection, WorkActionStatus, WorkActor, WorkChannel, WorkContent,
-        WorkContentBlock, WorkPart, WorkPartBody, WorkRecordKind, WorkSessionRef, WorkSource,
-        WorkTarget, WorkTime,
+        MessageRole, Projection, WorkActionStatus, WorkActor, WorkContent, WorkContentBlock,
+        WorkPart, WorkPartBody, WorkSessionRef, WorkTarget, WorkTime,
     };
     use crate::session_source::SessionInfo;
     use crate::test_fixtures::message_part;
@@ -557,11 +549,6 @@ mod tests {
         WorkRecord {
             schema_version: 1,
             work_ref: work_ref.clone(),
-            kind: WorkRecordKind::ChatTurn,
-            source: WorkSource {
-                channel: WorkChannel::Chat,
-                provider: Some("codex".to_string()),
-            },
             session: WorkSessionRef {
                 id: display_id.to_string(),
                 canonical_id: canonical_id.map(str::to_string),

--- a/crates/sivtr-core/src/record/index.rs
+++ b/crates/sivtr-core/src/record/index.rs
@@ -1,4 +1,4 @@
-use super::model::{WorkRecord, WorkRecordKind};
+use super::model::WorkRecord;
 use super::refs::WorkRef;
 
 #[derive(Debug, Clone)]
@@ -27,15 +27,6 @@ impl WorkRecordIndex {
     }
 }
 
-impl WorkRecord {
-    pub fn kind_label(&self) -> &'static str {
-        match self.kind {
-            WorkRecordKind::TerminalCommand => "shell",
-            WorkRecordKind::ChatTurn => "ai",
-        }
-    }
-}
-
 fn find_part(record: &WorkRecord, seq: usize) -> Option<&super::model::WorkPart> {
     record.parts.iter().find(|part| part.seq == seq)
 }
@@ -44,9 +35,7 @@ fn find_part(record: &WorkRecord, seq: usize) -> Option<&super::model::WorkPart>
 mod tests {
     use super::*;
     use crate::agents::AgentProvider;
-    use crate::record::model::{
-        MessageRole, WorkChannel, WorkRecordKind, WorkSessionRef, WorkSource, WorkTime,
-    };
+    use crate::record::model::{MessageRole, WorkSessionRef, WorkTime};
     use crate::test_fixtures::message_part;
 
     #[test]
@@ -80,11 +69,6 @@ mod tests {
         WorkRecord {
             schema_version: 1,
             work_ref,
-            kind: WorkRecordKind::ChatTurn,
-            source: WorkSource {
-                channel: WorkChannel::Chat,
-                provider: Some("pi".to_string()),
-            },
             session: WorkSessionRef {
                 id: session_id.to_string(),
                 canonical_id: Some(session_id.to_string()),
@@ -108,11 +92,6 @@ mod tests {
         WorkRecord {
             schema_version: 1,
             work_ref,
-            kind: WorkRecordKind::TerminalCommand,
-            source: WorkSource {
-                channel: WorkChannel::Terminal,
-                provider: None,
-            },
             session: WorkSessionRef {
                 id: session_id.to_string(),
                 canonical_id: Some(session_id.to_string()),

--- a/crates/sivtr-core/src/record/mod.rs
+++ b/crates/sivtr-core/src/record/mod.rs
@@ -8,8 +8,8 @@ pub use index::WorkRecordIndex;
 pub use model::{
     agent_parts, chat_turn_ranges, format_shell_action, format_work_part, is_real_user_block,
     output_blocks_text, MessageRole, Projection, ProjectionSlice, RecordText, RecordTextMode,
-    WorkActionStatus, WorkActor, WorkChannel, WorkContent, WorkContentBlock, WorkOutcome, WorkPart,
-    WorkPartBody, WorkPartKind, WorkRecord, WorkRecordCopyParts, WorkRecordKind, WorkSessionRef,
-    WorkSource, WorkStatus, WorkTarget, WorkTime, RECORD_SCHEMA_VERSION,
+    WorkActionStatus, WorkActor, WorkContent, WorkContentBlock, WorkOutcome, WorkPart,
+    WorkPartBody, WorkPartKind, WorkRecord, WorkRecordCopyParts, WorkSessionRef, WorkStatus,
+    WorkTarget, WorkTime, RECORD_SCHEMA_VERSION,
 };
 pub use refs::{normalize_scope_name, WorkAt, WorkPath, WorkRef, WorkRefSelector, WorkScope};

--- a/crates/sivtr-core/src/record/model.rs
+++ b/crates/sivtr-core/src/record/model.rs
@@ -74,14 +74,7 @@ impl WorkRecordCopyParts {
     }
 }
 
-pub const RECORD_SCHEMA_VERSION: u32 = 4;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum WorkRecordKind {
-    TerminalCommand,
-    ChatTurn,
-}
+pub const RECORD_SCHEMA_VERSION: u32 = 5;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -125,20 +118,6 @@ impl std::fmt::Display for WorkOutcome {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str(self.as_status_arg())
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum WorkChannel {
-    Terminal,
-    Chat,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct WorkSource {
-    pub channel: WorkChannel,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub provider: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -458,8 +437,6 @@ impl WorkPart {
 pub struct WorkRecord {
     pub schema_version: u32,
     pub work_ref: WorkRef,
-    pub kind: WorkRecordKind,
-    pub source: WorkSource,
     pub session: WorkSessionRef,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cwd: Option<String>,
@@ -472,6 +449,30 @@ pub struct WorkRecord {
 }
 
 impl WorkRecord {
+    /// Stream discriminator derived from the ref: `None` = terminal, else
+    /// the agent provider. The single source of truth — everything else
+    /// (namespace, labels, cache keys) renders off this.
+    pub fn provider(&self) -> Option<AgentProvider> {
+        self.work_ref.provider()
+    }
+
+    pub fn is_terminal(&self) -> bool {
+        self.provider().is_none()
+    }
+
+    pub fn is_agent(&self) -> bool {
+        self.provider().is_some()
+    }
+
+    /// `"shell"` / `"ai"` — the kind label, derived from the ref.
+    pub fn kind_label(&self) -> &'static str {
+        if self.is_terminal() {
+            "shell"
+        } else {
+            "ai"
+        }
+    }
+
     pub fn terminal(entry: &SessionEntry, session_path: &Path, index: usize) -> Option<Self> {
         let command = entry.command.trim().to_string();
         let output = entry.output.trim().to_string();
@@ -499,11 +500,6 @@ impl WorkRecord {
         Some(Self {
             schema_version: RECORD_SCHEMA_VERSION,
             work_ref,
-            kind: WorkRecordKind::TerminalCommand,
-            source: WorkSource {
-                channel: WorkChannel::Terminal,
-                provider: None,
-            },
             session: WorkSessionRef {
                 id: session_id.clone(),
                 canonical_id: Some(session_id.clone()),
@@ -565,11 +561,6 @@ impl WorkRecord {
         Some(Self {
             schema_version: RECORD_SCHEMA_VERSION,
             work_ref,
-            kind: WorkRecordKind::ChatTurn,
-            source: WorkSource {
-                channel: WorkChannel::Chat,
-                provider: Some(provider.command_name().to_string()),
-            },
             session: WorkSessionRef {
                 id: session_ref_id,
                 canonical_id,
@@ -831,11 +822,6 @@ fn selected_block_record(
     WorkRecord {
         schema_version: RECORD_SCHEMA_VERSION,
         work_ref,
-        kind: WorkRecordKind::ChatTurn,
-        source: WorkSource {
-            channel: WorkChannel::Chat,
-            provider: Some(provider.command_name().to_string()),
-        },
         session: WorkSessionRef {
             id: session_ref_id,
             canonical_id,
@@ -868,11 +854,6 @@ fn selected_group_record(
     vec![WorkRecord {
         schema_version: RECORD_SCHEMA_VERSION,
         work_ref,
-        kind: WorkRecordKind::ChatTurn,
-        source: WorkSource {
-            channel: WorkChannel::Chat,
-            provider: Some(provider.command_name().to_string()),
-        },
         session: WorkSessionRef {
             id: session_ref_id,
             canonical_id,
@@ -1597,7 +1578,8 @@ mod tests {
 
         let record = WorkRecord::terminal(&entry, Path::new("session_123.log"), 0).unwrap();
 
-        assert_eq!(record.kind, WorkRecordKind::TerminalCommand);
+        assert!(record.is_terminal());
+        assert_eq!(record.kind_label(), "shell");
         assert_eq!(record.cwd.as_deref(), Some("D:\\sivtr"));
         assert_eq!(
             record.time.ended_at.as_deref().and_then(parse_timestamp),
@@ -1927,7 +1909,8 @@ mod tests {
         let records = WorkRecord::chat_turns(AgentProvider::Pi, &session);
 
         assert_eq!(records.len(), 1);
-        assert_eq!(records[0].kind, WorkRecordKind::ChatTurn);
+        assert!(records[0].is_agent());
+        assert_eq!(records[0].kind_label(), "ai");
         assert_eq!(records[0].work_ref.provider(), Some(AgentProvider::Pi));
         assert_eq!(records[0].input_text().as_deref(), Some("implement this"));
         assert_eq!(records[0].output_text().as_deref(), Some("done"));

--- a/crates/sivtr-core/src/record/refs.rs
+++ b/crates/sivtr-core/src/record/refs.rs
@@ -64,6 +64,32 @@ impl WorkPath {
         }
     }
 
+    /// Query namespace of a source discriminator: `terminal` for `None`
+    /// (terminal records carry no provider), else the provider's command
+    /// name. Terminal-vs-agent is `Option<AgentProvider>` everywhere; this
+    /// is the single string rendering of that choice.
+    pub fn namespace_for(provider: Option<AgentProvider>) -> &'static str {
+        provider.map_or("terminal", |provider| provider.command_name())
+    }
+
+    /// Query namespace: `terminal` or the provider's command name — the
+    /// cache namespace and selector head of this path.
+    pub fn namespace(&self) -> &'static str {
+        Self::namespace_for(self.provider())
+    }
+
+    /// Session-stream path: `terminal/<session>` or `<provider>/<session>`.
+    pub fn stream_path(&self) -> String {
+        format!("{}/{}", self.namespace(), self.session())
+    }
+
+    /// Whether two paths address the same session stream: same namespace
+    /// (terminal vs agent, or different providers are distinct) and same
+    /// session.
+    pub fn same_stream(&self, other: &Self) -> bool {
+        self.provider() == other.provider() && self.session() == other.session()
+    }
+
     pub fn with_session(&self, session: impl Into<String>) -> Self {
         match self {
             Self::Terminal { index, .. } => Self::Terminal {

--- a/crates/sivtr-core/src/search/bm25.rs
+++ b/crates/sivtr-core/src/search/bm25.rs
@@ -447,9 +447,9 @@ mod tests {
     use super::*;
     use crate::agents::{AgentBlock, AgentBlockKind};
     use crate::record::{
-        agent_parts, WorkActionStatus, WorkActor, WorkChannel, WorkContent, WorkContentBlock,
-        WorkOutcome, WorkPart, WorkPartBody, WorkRecord, WorkRecordKind, WorkSessionRef,
-        WorkSource, WorkStatus, WorkTarget, WorkTime, RECORD_SCHEMA_VERSION,
+        agent_parts, WorkActionStatus, WorkActor, WorkContent, WorkContentBlock, WorkOutcome,
+        WorkPart, WorkPartBody, WorkRecord, WorkSessionRef, WorkStatus, WorkTarget, WorkTime,
+        RECORD_SCHEMA_VERSION,
     };
 
     /// Rank a plain query string (test convenience over [`rank_terms_with`]).
@@ -506,11 +506,6 @@ mod tests {
         WorkRecord {
             schema_version: RECORD_SCHEMA_VERSION,
             work_ref: WorkRef::terminal(session, index),
-            kind: WorkRecordKind::TerminalCommand,
-            source: WorkSource {
-                channel: WorkChannel::Terminal,
-                provider: None,
-            },
             session: WorkSessionRef {
                 id: session.to_string(),
                 canonical_id: None,

--- a/crates/sivtr-core/src/search/filter.rs
+++ b/crates/sivtr-core/src/search/filter.rs
@@ -13,8 +13,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::agents::{AgentProvider, AgentSessionProvider};
 use crate::record::{
-    output_blocks_text, WorkAt, WorkOutcome, WorkPart, WorkPartBody, WorkRecord, WorkRecordKind,
-    WorkRef, WorkTarget,
+    output_blocks_text, WorkAt, WorkOutcome, WorkPart, WorkPartBody, WorkRecord, WorkRef,
+    WorkTarget,
 };
 use crate::time::parse_timestamp;
 
@@ -748,7 +748,7 @@ fn current_agent_session_id(provider: AgentProvider) -> Option<String> {
 }
 
 fn excluded_session_matches(record: &WorkRecord, excluded_sessions: &HashSet<PathBuf>) -> bool {
-    if excluded_sessions.is_empty() || record.kind != WorkRecordKind::ChatTurn {
+    if excluded_sessions.is_empty() || record.is_terminal() {
         return false;
     }
     record

--- a/crates/sivtr-core/src/test_fixtures.rs
+++ b/crates/sivtr-core/src/test_fixtures.rs
@@ -5,9 +5,9 @@ use std::fs;
 use std::path::Path;
 
 use crate::record::{
-    MessageRole, WorkActionStatus, WorkActor, WorkChannel, WorkContent, WorkContentBlock,
-    WorkOutcome, WorkPart, WorkPartBody, WorkRecord, WorkRecordKind, WorkRef, WorkSessionRef,
-    WorkSource, WorkStatus, WorkTarget, WorkTime, RECORD_SCHEMA_VERSION,
+    MessageRole, WorkActionStatus, WorkActor, WorkContent, WorkContentBlock, WorkOutcome, WorkPart,
+    WorkPartBody, WorkRecord, WorkRef, WorkSessionRef, WorkStatus, WorkTarget, WorkTime,
+    RECORD_SCHEMA_VERSION,
 };
 
 /// Create a normal repo (`root/.git` dir).
@@ -78,11 +78,6 @@ pub(crate) fn terminal_record(session: &str, index: usize, title: &str, text: &s
     WorkRecord {
         schema_version: RECORD_SCHEMA_VERSION,
         work_ref: WorkRef::terminal(session, index),
-        kind: WorkRecordKind::TerminalCommand,
-        source: WorkSource {
-            channel: WorkChannel::Terminal,
-            provider: None,
-        },
         session: WorkSessionRef {
             id: session.to_string(),
             canonical_id: None,

--- a/crates/sivtr-core/src/workset.rs
+++ b/crates/sivtr-core/src/workset.rs
@@ -6,17 +6,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::agents::AgentProvider;
 use crate::query::{load_session_records, LoadMode};
-use crate::record::{WorkAt, WorkPath, WorkRecord, WorkRef, WorkScope};
+use crate::record::{WorkAt, WorkRecord, WorkRef, WorkScope};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 pub const WORKSET_SCHEMA_VERSION: u32 = 2;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub enum WorkSelectionKind {
-    Terminal,
-    Agent(AgentProvider),
-}
+/// Stream discriminator for a selection scope: `None` = terminal, `Some` =
+/// the agent provider — same shape as `WorkPath::provider()`.
+pub type WorkSelectionKind = Option<AgentProvider>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum WorkSelectionTarget {
@@ -45,14 +43,7 @@ impl WorkSelectionTarget {
                 if &record.work_ref.scope != scope {
                     return false;
                 }
-                let path_matches = match (kind, &record.work_ref.path) {
-                    (WorkSelectionKind::Terminal, WorkPath::Terminal { .. }) => true,
-                    (WorkSelectionKind::Agent(expected), WorkPath::Agent { provider, .. }) => {
-                        expected == provider
-                    }
-                    _ => false,
-                };
-                path_matches
+                record.work_ref.path.provider() == *kind
                     && session
                         .as_deref()
                         .is_none_or(|expected| record.work_ref.session() == expected)
@@ -419,10 +410,7 @@ impl WorkSet {
 
         for (path, indices) in &needed {
             // Any record in the group gives us the namespace; pick the first.
-            let namespace = session_namespace(&self.records()[indices[0]].work_ref.path);
-            let Some(namespace) = namespace else {
-                continue;
-            };
+            let namespace = self.records()[indices[0]].work_ref.path.namespace();
             let full = load_session_records(namespace, Path::new(path), LoadMode::Full)
                 .with_context(|| format!("Failed to load full session {path} for {namespace}"))?;
             for index in indices {
@@ -437,16 +425,6 @@ impl WorkSet {
             }
         }
         Ok(())
-    }
-}
-
-/// Cache namespace for a record's session file, used by
-/// [`WorkSet::materialize_parts`] to pick the right cache view when
-/// re-loading full records.
-fn session_namespace(path: &WorkPath) -> Option<&'static str> {
-    match path {
-        WorkPath::Agent { provider, .. } => Some(provider.command_name()),
-        WorkPath::Terminal { .. } => Some("terminal"),
     }
 }
 

--- a/src/commands/browse/content.rs
+++ b/src/commands/browse/content.rs
@@ -333,8 +333,7 @@ mod tests {
     use crate::tui::workspace::WorkspaceSource;
     use sivtr_core::agents::AgentProvider;
     use sivtr_core::record::{
-        MessageRole, WorkActionStatus, WorkChannel, WorkPartBody, WorkRecord, WorkRecordKind,
-        WorkRef, WorkSessionRef, WorkSource, WorkTime,
+        MessageRole, WorkActionStatus, WorkPartBody, WorkRecord, WorkRef, WorkSessionRef, WorkTime,
     };
     use sivtr_core::workset::{WorkSelectionAction, WorkSelectionTarget, WorkSet};
 
@@ -342,11 +341,6 @@ mod tests {
         let mut record = WorkRecord {
             schema_version: 2,
             work_ref: WorkRef::agent(AgentProvider::Codex, "test", index + 1),
-            kind: WorkRecordKind::ChatTurn,
-            source: WorkSource {
-                channel: WorkChannel::Chat,
-                provider: Some("codex".to_string()),
-            },
             session: WorkSessionRef {
                 id: "test".to_string(),
                 canonical_id: Some("test-session-0123456789abcdef".to_string()),

--- a/src/commands/browse/load.rs
+++ b/src/commands/browse/load.rs
@@ -17,9 +17,7 @@ use crate::pane::{
     keep_keys, MetaNeed, Pane, PaneInput, SlidingPane, StorePhase, Viewport, WindowRow,
     FETCH_CEILING, FETCH_FLOOR,
 };
-use crate::tui::workspace::{
-    SourceLoadMarker, WorkspaceSession, WorkspaceSource, WorkspaceSourceKind,
-};
+use crate::tui::workspace::{SourceLoadMarker, WorkspaceSession, WorkspaceSource};
 use sivtr_core::agents::AgentProvider;
 use sivtr_core::origin::Reach;
 use sivtr_core::record::WorkRecord;
@@ -663,15 +661,9 @@ pub fn workspace_source_catalog(
             continue;
         }
         let origin = &entry.origin;
-        sources.push(WorkspaceSource::remote(
-            &origin.name,
-            WorkspaceSourceKind::Terminal,
-        ));
+        sources.push(WorkspaceSource::remote(&origin.name, None));
         for provider in providers {
-            sources.push(WorkspaceSource::remote(
-                &origin.name,
-                WorkspaceSourceKind::Agent(*provider),
-            ));
+            sources.push(WorkspaceSource::remote(&origin.name, Some(*provider)));
         }
     }
     Ok(sources)
@@ -769,9 +761,7 @@ fn record_modified(record: &WorkRecord) -> Option<SystemTime> {
 mod tests {
     use super::*;
     use sivtr_core::agents::AgentProvider;
-    use sivtr_core::record::{
-        WorkChannel, WorkRecord, WorkRecordKind, WorkRef, WorkSessionRef, WorkSource, WorkTime,
-    };
+    use sivtr_core::record::{WorkRecord, WorkRef, WorkSessionRef, WorkTime};
 
     #[test]
     fn sessions_from_records_groups_by_session() {
@@ -1147,11 +1137,6 @@ mod tests {
         WorkRecord {
             schema_version: 2,
             work_ref: WorkRef::agent(AgentProvider::Codex, session, index),
-            kind: WorkRecordKind::ChatTurn,
-            source: WorkSource {
-                channel: WorkChannel::Chat,
-                provider: Some("codex".to_string()),
-            },
             session: WorkSessionRef {
                 id: session.to_string(),
                 canonical_id: Some(session.to_string()),

--- a/src/commands/browse/panes.rs
+++ b/src/commands/browse/panes.rs
@@ -448,20 +448,13 @@ mod tests {
     use super::*;
     use crate::pane::Viewport;
     use sivtr_core::agents::AgentProvider;
-    use sivtr_core::record::{
-        WorkChannel, WorkRecord, WorkRecordKind, WorkSessionRef, WorkSource, WorkTime,
-    };
+    use sivtr_core::record::{WorkRecord, WorkSessionRef, WorkTime};
     use std::time::UNIX_EPOCH;
 
     fn test_record(session: &str, index: usize, title: &str) -> WorkRecord {
         WorkRecord {
             schema_version: 2,
             work_ref: WorkRef::agent(AgentProvider::Codex, session, index),
-            kind: WorkRecordKind::ChatTurn,
-            source: WorkSource {
-                channel: WorkChannel::Chat,
-                provider: Some("codex".to_string()),
-            },
             session: WorkSessionRef {
                 id: session.to_string(),
                 canonical_id: Some(session.to_string()),

--- a/src/commands/browse/perf.rs
+++ b/src/commands/browse/perf.rs
@@ -6,8 +6,7 @@ use crate::pane::{Pane, PaneInput, Viewport};
 use crate::tui::workspace::{WorkspaceDialogue, WorkspaceSession, WorkspaceSource};
 use sivtr_core::agents::AgentProvider;
 use sivtr_core::record::{
-    WorkChannel, WorkPart, WorkRecord, WorkRecordKind, WorkRef, WorkSessionRef, WorkSource,
-    WorkTime, RECORD_SCHEMA_VERSION,
+    WorkPart, WorkRecord, WorkRef, WorkSessionRef, WorkTime, RECORD_SCHEMA_VERSION,
 };
 use std::cell::RefCell;
 use std::time::UNIX_EPOCH;
@@ -19,11 +18,6 @@ fn fat_record(session: &str, index: usize, title: &str) -> WorkRecord {
     WorkRecord {
         schema_version: RECORD_SCHEMA_VERSION,
         work_ref: WorkRef::agent(AgentProvider::Codex, session, index),
-        kind: WorkRecordKind::ChatTurn,
-        source: WorkSource {
-            channel: WorkChannel::Chat,
-            provider: Some("codex".to_string()),
-        },
         session: WorkSessionRef {
             id: session.to_string(),
             canonical_id: Some(session.to_string()),

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -1336,15 +1336,12 @@ mod tests {
     };
     use crate::tui::workspace::{
         ContentIoFocus, ContentScrolls, ListPane, Rows, TextPair, WorkspaceDialogue,
-        WorkspaceFocus, WorkspaceSession, WorkspaceSource, WorkspaceSourceKind,
+        WorkspaceFocus, WorkspaceSession, WorkspaceSource,
     };
     use crossterm::event::{KeyCode, KeyModifiers};
     use sivtr_core::agents::AgentProvider;
     use sivtr_core::record::{WorkAt, WorkRef};
-    use sivtr_core::record::{
-        WorkChannel, WorkRecord, WorkRecordKind, WorkSessionRef, WorkSource, WorkTime,
-        RECORD_SCHEMA_VERSION,
-    };
+    use sivtr_core::record::{WorkRecord, WorkSessionRef, WorkTime, RECORD_SCHEMA_VERSION};
     use std::time::SystemTime;
 
     fn picked_units(picked: &PickedContent) -> Vec<TextPair> {
@@ -2611,30 +2608,18 @@ mod tests {
         plain: &str,
         index: usize,
     ) -> WorkRecord {
-        let (channel, provider, kind) = match source.kind {
-            WorkspaceSourceKind::Terminal => {
-                (WorkChannel::Terminal, None, WorkRecordKind::TerminalCommand)
-            }
-            WorkspaceSourceKind::Agent(provider) => (
-                WorkChannel::Chat,
-                Some(provider.command_name().to_string()),
-                WorkRecordKind::ChatTurn,
-            ),
-        };
         let work_ref = match source.kind {
-            WorkspaceSourceKind::Terminal => WorkRef::terminal("test", index + 1),
-            WorkspaceSourceKind::Agent(provider) => WorkRef::agent(provider, "test", index + 1),
+            None => WorkRef::terminal("test", index + 1),
+            Some(provider) => WorkRef::agent(provider, "test", index + 1),
         };
         WorkRecord {
             schema_version: RECORD_SCHEMA_VERSION,
             work_ref: work_ref.clone(),
-            source: WorkSource { channel, provider },
             session: WorkSessionRef {
                 id: "test".to_string(),
                 canonical_id: Some("test-session-0123456789abcdef".to_string()),
                 path: None,
             },
-            kind,
             cwd: None,
             time: WorkTime::default(),
             status: None,

--- a/src/commands/browse/publish_overlay.rs
+++ b/src/commands/browse/publish_overlay.rs
@@ -102,19 +102,13 @@ mod tests {
     use crate::test_fixtures::message_part;
     use sivtr_core::agents::AgentProvider;
     use sivtr_core::record::{
-        MessageRole, WorkChannel, WorkRecord, WorkRecordKind, WorkRef, WorkSessionRef, WorkSource,
-        WorkTime, RECORD_SCHEMA_VERSION,
+        MessageRole, WorkRecord, WorkRef, WorkSessionRef, WorkTime, RECORD_SCHEMA_VERSION,
     };
 
     fn record() -> WorkRecord {
         WorkRecord {
             schema_version: RECORD_SCHEMA_VERSION,
             work_ref: WorkRef::agent(AgentProvider::Codex, "session", 1),
-            kind: WorkRecordKind::ChatTurn,
-            source: WorkSource {
-                channel: WorkChannel::Chat,
-                provider: Some("codex".into()),
-            },
             session: WorkSessionRef {
                 id: "session".into(),
                 canonical_id: None,

--- a/src/commands/memory/copy/mod.rs
+++ b/src/commands/memory/copy/mod.rs
@@ -19,9 +19,7 @@ use sivtr_core::record::WorkRecord;
 
 use crate::commands::browse;
 use crate::output;
-use crate::tui::workspace::{
-    WorkspaceFocus, WorkspaceSession, WorkspaceSource, WorkspaceSourceKind,
-};
+use crate::tui::workspace::{WorkspaceFocus, WorkspaceSession, WorkspaceSource};
 
 use export::finish_units;
 use load::load_for_plan;
@@ -97,10 +95,7 @@ fn execute_pick(plan: &CopyPlan) -> Result<()> {
 
 fn session_source_from_records(records: &[WorkRecord]) -> Option<WorkspaceSource> {
     let record = records.first()?;
-    let kind = match record.work_ref.provider() {
-        Some(provider) => WorkspaceSourceKind::Agent(provider),
-        None => WorkspaceSourceKind::Terminal,
-    };
+    let kind = record.work_ref.provider();
     let Some(scope) = record.work_ref.scope_name() else {
         return Some(WorkspaceSource::local(kind));
     };

--- a/src/commands/memory/nav.rs
+++ b/src/commands/memory/nav.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Context, Result};
-use sivtr_core::record::{WorkAt, WorkPath, WorkRecord, WorkRef};
+use sivtr_core::record::{WorkAt, WorkRecord, WorkRef};
 use std::path::PathBuf;
 
 use crate::cli::NavArgs;
@@ -209,29 +209,10 @@ fn session_records_for<'a>(
 ) -> Vec<&'a WorkRecord> {
     let mut records = all_records
         .iter()
-        .filter(|candidate| same_stream(record, candidate))
+        .filter(|candidate| record.work_ref.path.same_stream(&candidate.work_ref.path))
         .collect::<Vec<_>>();
     records.sort_by_key(|record| record.work_ref.index());
     records
-}
-
-fn same_stream(left: &WorkRecord, right: &WorkRecord) -> bool {
-    match (&left.work_ref.path, &right.work_ref.path) {
-        (WorkPath::Terminal { .. }, WorkPath::Terminal { .. }) => {
-            left.work_ref.session() == right.work_ref.session()
-        }
-        (
-            WorkPath::Agent {
-                provider: left_provider,
-                ..
-            },
-            WorkPath::Agent {
-                provider: right_provider,
-                ..
-            },
-        ) => left_provider == right_provider && left.work_ref.session() == right.work_ref.session(),
-        _ => false,
-    }
 }
 
 fn offset_index(position: usize, offset: isize, len: usize) -> Option<usize> {
@@ -343,9 +324,7 @@ fn parse_signed_literal(value: &str, label: &str) -> Result<isize> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sivtr_core::record::{
-        MessageRole, WorkChannel, WorkRecordKind, WorkSessionRef, WorkSource, WorkTime,
-    };
+    use sivtr_core::record::{MessageRole, WorkSessionRef, WorkTime};
 
     #[test]
     fn parses_motion_steps() {
@@ -440,11 +419,6 @@ mod tests {
         WorkRecord {
             schema_version: sivtr_core::record::RECORD_SCHEMA_VERSION,
             work_ref: WorkRef::terminal("session_1", index),
-            kind: WorkRecordKind::TerminalCommand,
-            source: WorkSource {
-                channel: WorkChannel::Terminal,
-                provider: None,
-            },
             session: WorkSessionRef {
                 id: "session_1".to_string(),
                 canonical_id: Some("session_1".to_string()),

--- a/src/commands/memory/show.rs
+++ b/src/commands/memory/show.rs
@@ -322,14 +322,7 @@ fn short_time(record: &WorkRecord) -> String {
 }
 
 fn source_label(record: &WorkRecord) -> &'static str {
-    match record.kind {
-        sivtr_core::record::WorkRecordKind::TerminalCommand => "terminal",
-        sivtr_core::record::WorkRecordKind::ChatTurn => record
-            .work_ref
-            .provider()
-            .map(|provider| provider.command_name())
-            .unwrap_or("agent"),
-    }
+    record.work_ref.path.namespace()
 }
 
 fn escape_markdown_title(title: &str) -> String {

--- a/src/commands/memory/work.rs
+++ b/src/commands/memory/work.rs
@@ -13,16 +13,11 @@ use crate::commands::memory::show;
 use crate::commands::memory::work_json::{session_meta, WorkJsonSessionMeta};
 use crate::commands::memory::workset;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum WorkSessionSource {
-    Terminal,
-    Agent(AgentProvider),
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct WorkSessionMarker {
     scope: Option<String>,
-    source: WorkSessionSource,
+    /// `None` = terminal stream, `Some` = the agent provider.
+    provider: Option<AgentProvider>,
     session: String,
 }
 
@@ -130,7 +125,7 @@ fn build_session_items(records: &[WorkRecord]) -> Vec<WorkSessionListItem> {
         positions.insert(group_key, items.len());
         items.push(WorkSessionListItem {
             ref_: display_ref,
-            source: marker.source_name().to_string(),
+            source: WorkPath::namespace_for(marker.provider).to_string(),
             session: marker.session,
             session_meta: session_meta(record),
             timestamp: record.time.primary_at().map(str::to_string),
@@ -182,26 +177,10 @@ fn timestamp_tag(timestamp: Option<&str>) -> String {
 
 impl WorkSessionMarker {
     fn from_record(record: &WorkRecord) -> Self {
-        match &record.work_ref.path {
-            WorkPath::Terminal { session, .. } => Self {
-                scope: record.work_ref.scope_name().map(str::to_string),
-                source: WorkSessionSource::Terminal,
-                session: session.clone(),
-            },
-            WorkPath::Agent {
-                provider, session, ..
-            } => Self {
-                scope: record.work_ref.scope_name().map(str::to_string),
-                source: WorkSessionSource::Agent(*provider),
-                session: session.clone(),
-            },
-        }
-    }
-
-    fn source_name(&self) -> &'static str {
-        match self.source {
-            WorkSessionSource::Terminal => "terminal",
-            WorkSessionSource::Agent(provider) => provider.command_name(),
+        Self {
+            scope: record.work_ref.scope_name().map(str::to_string),
+            provider: record.work_ref.provider(),
+            session: record.work_ref.session().to_string(),
         }
     }
 }
@@ -211,16 +190,19 @@ impl fmt::Display for WorkSessionMarker {
         if let Some(scope) = self.scope.as_deref() {
             write!(formatter, "{scope}:")?;
         }
-        write!(formatter, "{}/{}", self.source_name(), self.session)
+        write!(
+            formatter,
+            "{}/{}",
+            WorkPath::namespace_for(self.provider),
+            self.session
+        )
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sivtr_core::record::{
-        MessageRole, WorkChannel, WorkRecordKind, WorkRef, WorkSessionRef, WorkSource, WorkTime,
-    };
+    use sivtr_core::record::{MessageRole, WorkRef, WorkSessionRef, WorkTime};
 
     #[test]
     fn session_markers_preserve_scope() {
@@ -279,21 +261,6 @@ mod tests {
         WorkRecord {
             schema_version: sivtr_core::record::RECORD_SCHEMA_VERSION,
             work_ref: work_ref.clone(),
-            kind: if matches!(work_ref.path, WorkPath::Terminal { .. }) {
-                WorkRecordKind::TerminalCommand
-            } else {
-                WorkRecordKind::ChatTurn
-            },
-            source: WorkSource {
-                channel: if matches!(work_ref.path, WorkPath::Terminal { .. }) {
-                    WorkChannel::Terminal
-                } else {
-                    WorkChannel::Chat
-                },
-                provider: work_ref
-                    .provider()
-                    .map(|provider| provider.command_name().to_string()),
-            },
             session: WorkSessionRef {
                 id: work_ref.session().to_string(),
                 canonical_id: Some(format!("{}-session-0123456789abcdef", work_ref.session())),

--- a/src/commands/memory/work_json.rs
+++ b/src/commands/memory/work_json.rs
@@ -1,11 +1,10 @@
 use serde::Serialize;
-use sivtr_core::record::{WorkChannel, WorkRecord};
+use sivtr_core::record::WorkRecord;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct WorkJsonSessionMeta {
     #[serde(rename = "ref")]
     pub ref_: String,
-    pub channel: WorkChannel,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
     pub display_id: String,
@@ -15,25 +14,10 @@ pub struct WorkJsonSessionMeta {
     pub path: Option<String>,
 }
 
-fn session_ref(record: &WorkRecord) -> String {
-    match &record.work_ref.path {
-        sivtr_core::record::WorkPath::Terminal { session, .. } => {
-            format!("terminal/{session}")
-        }
-        sivtr_core::record::WorkPath::Agent {
-            provider, session, ..
-        } => {
-            format!("{}/{session}", provider.command_name())
-        }
-    }
-}
-
 pub fn session_meta(record: &WorkRecord) -> WorkJsonSessionMeta {
     WorkJsonSessionMeta {
-        ref_: session_ref(record),
-        channel: record.source.channel,
+        ref_: record.work_ref.path.stream_path(),
         provider: record
-            .work_ref
             .provider()
             .map(|provider| provider.command_name().to_string()),
         display_id: record.session.id.clone(),
@@ -46,9 +30,7 @@ pub fn session_meta(record: &WorkRecord) -> WorkJsonSessionMeta {
 mod tests {
     use super::*;
     use sivtr_core::agents::AgentProvider;
-    use sivtr_core::record::{
-        MessageRole, WorkRecord, WorkRecordKind, WorkRef, WorkSessionRef, WorkSource, WorkTime,
-    };
+    use sivtr_core::record::{MessageRole, WorkRef, WorkSessionRef, WorkTime};
 
     #[test]
     fn builds_session_metadata_with_canonical_id() {
@@ -56,7 +38,6 @@ mod tests {
         let metadata = session_meta(&record);
 
         assert_eq!(metadata.ref_, "codex/shortid");
-        assert_eq!(metadata.channel, WorkChannel::Chat);
         assert_eq!(metadata.provider.as_deref(), Some("codex"));
         assert_eq!(metadata.display_id, "shortid");
         assert_eq!(
@@ -70,11 +51,6 @@ mod tests {
         WorkRecord {
             schema_version: sivtr_core::record::RECORD_SCHEMA_VERSION,
             work_ref: WorkRef::agent(AgentProvider::Codex, "shortid", 3),
-            kind: WorkRecordKind::ChatTurn,
-            source: WorkSource {
-                channel: WorkChannel::Chat,
-                provider: Some("codex".to_string()),
-            },
             session: WorkSessionRef {
                 id: "shortid".to_string(),
                 canonical_id: Some("session-0123456789abcdef".to_string()),

--- a/src/commands/memory/workset/mod.rs
+++ b/src/commands/memory/workset/mod.rs
@@ -156,9 +156,7 @@ fn validate_selection(reference: &str, set: &WorkSet, selection: &WorkSetSelecti
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sivtr_core::record::{
-        MessageRole, WorkChannel, WorkRecord, WorkRecordKind, WorkSessionRef, WorkSource, WorkTime,
-    };
+    use sivtr_core::record::{MessageRole, WorkRecord, WorkSessionRef, WorkTime};
 
     fn record(index: usize) -> WorkRecord {
         WorkRecord {
@@ -166,11 +164,6 @@ mod tests {
             work_ref: format!("terminal/session_1/{index}")
                 .parse()
                 .expect("valid work ref"),
-            kind: WorkRecordKind::TerminalCommand,
-            source: WorkSource {
-                channel: WorkChannel::Terminal,
-                provider: None,
-            },
             session: WorkSessionRef {
                 id: "session_1".to_string(),
                 canonical_id: Some("session_1".to_string()),
@@ -438,7 +431,7 @@ mod tests {
         let records = vec![record(1), record(2)];
         let target = WorkSelectionTarget::Scope {
             scope: sivtr_core::record::WorkScope::Local,
-            kind: WorkSelectionKind::Terminal,
+            kind: None,
             session: Some("session_1".to_string()),
         };
         let mut set = WorkSet::new(".", Vec::new());

--- a/src/commands/memory/workset/source.rs
+++ b/src/commands/memory/workset/source.rs
@@ -612,9 +612,7 @@ pub fn load_context_records(
 mod tests {
     use super::{merge_and_apply, resolve_source, split_group_scope, QueryTransport};
     use crate::commands::memory::workset::{QuerySourceResult, WorkSet};
-    use sivtr_core::record::{
-        MessageRole, WorkChannel, WorkRecord, WorkRecordKind, WorkSessionRef, WorkSource, WorkTime,
-    };
+    use sivtr_core::record::{MessageRole, WorkRecord, WorkSessionRef, WorkTime};
     use sivtr_core::search::Filter;
 
     fn record(index: usize) -> WorkRecord {
@@ -623,11 +621,6 @@ mod tests {
             work_ref: format!("terminal/session_1/{index}")
                 .parse()
                 .expect("valid work ref"),
-            kind: WorkRecordKind::TerminalCommand,
-            source: WorkSource {
-                channel: WorkChannel::Terminal,
-                provider: None,
-            },
             session: WorkSessionRef {
                 id: "session_1".to_string(),
                 canonical_id: Some("session_1".to_string()),

--- a/src/commands/memory/zoom.rs
+++ b/src/commands/memory/zoom.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use anyhow::{Context, Result};
-use sivtr_core::record::{WorkPath, WorkRecord, WorkRef};
+use sivtr_core::record::{WorkRecord, WorkRef};
 
 use crate::cli::ZoomArgs;
 use crate::commands::memory::show;
@@ -60,7 +60,7 @@ fn expand_around(
             .with_context(|| format!("No record found for ref `{source_ref}`"))?;
         let mut session_records = all_records
             .iter()
-            .filter(|record| same_stream(source, record))
+            .filter(|record| source.work_ref.path.same_stream(&record.work_ref.path))
             .collect::<Vec<_>>();
         session_records.sort_by_key(|record| record.work_ref.index());
 
@@ -82,31 +82,10 @@ fn expand_around(
     Ok(expanded)
 }
 
-fn same_stream(left: &WorkRecord, right: &WorkRecord) -> bool {
-    match (&left.work_ref.path, &right.work_ref.path) {
-        (WorkPath::Terminal { .. }, WorkPath::Terminal { .. }) => {
-            left.work_ref.session() == right.work_ref.session()
-        }
-        (
-            WorkPath::Agent {
-                provider: left_provider,
-                ..
-            },
-            WorkPath::Agent {
-                provider: right_provider,
-                ..
-            },
-        ) => left_provider == right_provider && left.work_ref.session() == right.work_ref.session(),
-        _ => false,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sivtr_core::record::{
-        WorkChannel, WorkOutcome, WorkRecordKind, WorkSessionRef, WorkSource, WorkStatus, WorkTime,
-    };
+    use sivtr_core::record::{WorkOutcome, WorkSessionRef, WorkStatus, WorkTime};
 
     #[test]
     fn expand_around_expands_each_record_and_dedups_overlaps() {
@@ -156,11 +135,6 @@ mod tests {
         WorkRecord {
             schema_version: 1,
             work_ref: WorkRef::terminal("session_1", index),
-            kind: WorkRecordKind::TerminalCommand,
-            source: WorkSource {
-                channel: WorkChannel::Terminal,
-                provider: None,
-            },
             session: WorkSessionRef {
                 id: "session_1".to_string(),
                 canonical_id: Some("session_1".to_string()),

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -778,11 +778,6 @@ mod tests {
         WorkRecord {
             schema_version: RECORD_SCHEMA_VERSION,
             work_ref: WorkRef::agent(sivtr_core::agents::AgentProvider::Codex, session, index),
-            kind: sivtr_core::record::WorkRecordKind::ChatTurn,
-            source: sivtr_core::record::WorkSource {
-                channel: sivtr_core::record::WorkChannel::Chat,
-                provider: Some("codex".into()),
-            },
             session: sivtr_core::record::WorkSessionRef {
                 id: session.into(),
                 canonical_id: None,

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -2,9 +2,8 @@
 //! `pub` so sibling module trees (commands, tui) can reach it in tests.
 
 use sivtr_core::record::{
-    MessageRole, WorkActionStatus, WorkActor, WorkChannel, WorkContent, WorkContentBlock, WorkPart,
-    WorkPartBody, WorkRecord, WorkRecordKind, WorkRef, WorkSessionRef, WorkSource, WorkTarget,
-    WorkTime, RECORD_SCHEMA_VERSION,
+    MessageRole, WorkActionStatus, WorkActor, WorkContent, WorkContentBlock, WorkPart,
+    WorkPartBody, WorkRecord, WorkRef, WorkSessionRef, WorkTarget, WorkTime, RECORD_SCHEMA_VERSION,
 };
 
 /// A message part of the given role — the shape every record test speaks in.
@@ -98,11 +97,6 @@ pub fn chat_record(index: usize, parts: Vec<WorkPart>) -> WorkRecord {
     WorkRecord {
         schema_version: RECORD_SCHEMA_VERSION,
         work_ref: WorkRef::agent(sivtr_core::agents::AgentProvider::Codex, "test", index),
-        kind: WorkRecordKind::ChatTurn,
-        source: WorkSource {
-            channel: WorkChannel::Chat,
-            provider: Some("codex".to_string()),
-        },
         session: WorkSessionRef {
             id: "test".to_string(),
             canonical_id: None,

--- a/src/tui/content/block.rs
+++ b/src/tui/content/block.rs
@@ -408,10 +408,7 @@ mod tests {
     use super::*;
     use crate::tui::content::io::ExpandedBlocks;
     use sivtr_core::agents::AgentProvider;
-    use sivtr_core::record::{
-        WorkChannel, WorkRecordKind, WorkRef, WorkSessionRef, WorkSource, WorkTime,
-        RECORD_SCHEMA_VERSION,
-    };
+    use sivtr_core::record::{WorkRef, WorkSessionRef, WorkTime, RECORD_SCHEMA_VERSION};
 
     fn shell_action(seq: usize, command: &str, output: &str, exit: Option<i32>) -> WorkPart {
         let mut part = crate::test_fixtures::shell_action_part(
@@ -462,11 +459,6 @@ mod tests {
         WorkRecord {
             schema_version: RECORD_SCHEMA_VERSION,
             work_ref: WorkRef::agent(AgentProvider::Codex, "session", 1),
-            kind: WorkRecordKind::ChatTurn,
-            source: WorkSource {
-                channel: WorkChannel::Chat,
-                provider: Some("codex".to_string()),
-            },
             session: WorkSessionRef {
                 id: "session".to_string(),
                 canonical_id: None,

--- a/src/tui/content/text.rs
+++ b/src/tui/content/text.rs
@@ -90,9 +90,8 @@ mod tests {
     use crate::tui::content::io::ExpandedBlocks;
     use sivtr_core::agents::AgentProvider;
     use sivtr_core::record::{
-        MessageRole, WorkActionStatus, WorkActor, WorkChannel, WorkContent, WorkContentBlock,
-        WorkPart, WorkPartBody, WorkRecord, WorkRecordKind, WorkRef, WorkSessionRef, WorkSource,
-        WorkTarget, WorkTime,
+        MessageRole, WorkActionStatus, WorkActor, WorkContent, WorkContentBlock, WorkPart,
+        WorkPartBody, WorkRecord, WorkRef, WorkSessionRef, WorkTarget, WorkTime,
     };
 
     fn shell_action(seq: usize, command: &str, output: Option<&str>) -> WorkPart {
@@ -126,11 +125,6 @@ mod tests {
         WorkRecord {
             schema_version: 2,
             work_ref: WorkRef::agent(AgentProvider::Codex, "session", 1),
-            kind: WorkRecordKind::ChatTurn,
-            source: WorkSource {
-                channel: WorkChannel::Chat,
-                provider: Some("codex".to_string()),
-            },
             session: WorkSessionRef {
                 id: "session".to_string(),
                 canonical_id: None,

--- a/src/tui/workspace/model.rs
+++ b/src/tui/workspace/model.rs
@@ -16,7 +16,7 @@ use crate::tui::content::view::{ContentSelection, ContentViewMode};
 use crate::tui::search::WorkspaceSearchScope;
 use crate::tui::theme;
 use crate::tui::workspace::rows::Rows;
-use sivtr_core::workset::{WorkSelectionKind, WorkSelectionTarget};
+use sivtr_core::workset::WorkSelectionTarget;
 
 /// Indices of true entries in a selection mask, in order.
 pub(crate) fn selected_indices(mask: &[bool]) -> Vec<usize> {
@@ -26,56 +26,55 @@ pub(crate) fn selected_indices(mask: &[bool]) -> Vec<usize> {
         .collect()
 }
 
-/// Kind of memory source (local path body before any `scope:` prefix).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub(crate) enum WorkspaceSourceKind {
-    Terminal,
-    Agent(AgentProvider),
+/// Kind of memory source: `None` = terminal, `Some` = the agent provider —
+/// the same discriminator as `WorkPath::provider()`.
+pub(crate) type WorkspaceSourceKind = Option<AgentProvider>;
+
+/// Rendering metadata for the stream discriminator (badges, colors).
+pub(crate) trait SourceKindDisplay: Copy {
+    fn path(self) -> &'static str;
+    fn badge(self) -> String;
+    fn color(self) -> Color;
 }
 
-impl WorkspaceSourceKind {
-    pub(crate) fn path(self) -> &'static str {
+impl SourceKindDisplay for WorkspaceSourceKind {
+    fn path(self) -> &'static str {
+        sivtr_core::record::WorkPath::namespace_for(self)
+    }
+
+    fn badge(self) -> String {
+        const BADGES: &[(AgentProvider, &str)] = &[
+            (AgentProvider::Codex, "cdx"),
+            (AgentProvider::Claude, "cld"),
+            (AgentProvider::Cursor, "cur"),
+            (AgentProvider::Dsh, "dsh"),
+            (AgentProvider::OpenCode, "opc"),
+            (AgentProvider::OpenClaw, "ocw"),
+            (AgentProvider::Hermes, "hrm"),
+            (AgentProvider::Grok, "grk"),
+            (AgentProvider::Pi, "pi"),
+            (AgentProvider::Qoder, "qdr"),
+            (AgentProvider::QoderCn, "qcn"),
+            (AgentProvider::Gemini, "gmi"),
+            (AgentProvider::Goose, "gse"),
+            (AgentProvider::Qwen, "qwn"),
+            (AgentProvider::Zcode, "zcd"),
+        ];
         match self {
-            Self::Terminal => "terminal",
-            Self::Agent(provider) => provider.command_name(),
+            None => "term".to_string(),
+            Some(provider) => BADGES
+                .iter()
+                .find(|(known, _)| *known == provider)
+                .map(|(_, badge)| badge.to_string())
+                .unwrap_or_else(|| provider.command_name().chars().take(3).collect()),
         }
     }
 
-    pub(crate) fn badge(self) -> String {
+    fn color(self) -> Color {
         match self {
-            Self::Terminal => "term".to_string(),
-            Self::Agent(AgentProvider::Codex) => "cdx".to_string(),
-            Self::Agent(AgentProvider::Claude) => "cld".to_string(),
-            Self::Agent(AgentProvider::Cursor) => "cur".to_string(),
-            Self::Agent(AgentProvider::Dsh) => "dsh".to_string(),
-            Self::Agent(AgentProvider::OpenCode) => "opc".to_string(),
-            Self::Agent(AgentProvider::OpenClaw) => "ocw".to_string(),
-            Self::Agent(AgentProvider::Hermes) => "hrm".to_string(),
-            Self::Agent(AgentProvider::Grok) => "grk".to_string(),
-            Self::Agent(AgentProvider::Pi) => "pi".to_string(),
-            Self::Agent(AgentProvider::Qoder) => "qdr".to_string(),
-            Self::Agent(AgentProvider::QoderCn) => "qcn".to_string(),
-            Self::Agent(AgentProvider::Gemini) => "gmi".to_string(),
-            Self::Agent(AgentProvider::Goose) => "gse".to_string(),
-            Self::Agent(AgentProvider::Qwen) => "qwn".to_string(),
-            Self::Agent(AgentProvider::Zcode) => "zcd".to_string(),
-            Self::Agent(provider) => provider.command_name().chars().take(3).collect(),
+            None => theme::terminal_color(),
+            Some(provider) => theme::provider_color(provider),
         }
-    }
-
-    pub(crate) fn color(self) -> Color {
-        match self {
-            Self::Terminal => theme::terminal_color(),
-            Self::Agent(provider) => theme::provider_color(provider),
-        }
-    }
-
-    pub(crate) fn is_agent(self) -> bool {
-        matches!(self, Self::Agent(_))
-    }
-
-    pub(crate) fn is_terminal(self) -> bool {
-        matches!(self, Self::Terminal)
     }
 }
 
@@ -94,11 +93,11 @@ impl WorkspaceSource {
     }
 
     pub(crate) fn terminal() -> Self {
-        Self::local(WorkspaceSourceKind::Terminal)
+        Self::local(None)
     }
 
     pub(crate) fn agent(provider: AgentProvider) -> Self {
-        Self::local(WorkspaceSourceKind::Agent(provider))
+        Self::local(Some(provider))
     }
 
     /// A source on another device, addressed by its mount alias.
@@ -139,11 +138,11 @@ impl WorkspaceSource {
     }
 
     pub(crate) fn is_agent(&self) -> bool {
-        self.kind.is_agent()
+        self.kind.is_some()
     }
 
     pub(crate) fn is_terminal(&self) -> bool {
-        self.kind.is_terminal()
+        self.kind.is_none()
     }
 
     pub(crate) fn selection_target(&self, session: Option<&str>) -> WorkSelectionTarget {
@@ -151,10 +150,7 @@ impl WorkspaceSource {
             scope: self.scope.as_deref().map_or(WorkScope::Local, |scope| {
                 WorkScope::Named(scope.to_string())
             }),
-            kind: match self.kind {
-                WorkspaceSourceKind::Terminal => WorkSelectionKind::Terminal,
-                WorkspaceSourceKind::Agent(provider) => WorkSelectionKind::Agent(provider),
-            },
+            kind: self.kind,
             session: session.map(str::to_string),
         }
     }

--- a/web/app.js
+++ b/web/app.js
@@ -216,11 +216,24 @@ function renderRecord(record) {
 }
 
 function partText(part) {
-  switch (part.kind) {
-    case "tool_call": return JSON.stringify(part.input, null, 2) || "";
-    case "tool_result": return JSON.stringify(part.output, null, 2) || "";
-    default: return part.content || "";
+  if (part.kind === "action") {
+    const blocks = (part.output || []).map((block) => contentText(block.content));
+    if (blocks.length) return blocks.join("\n\n");
+    return contentText(part.input);
   }
+  return contentText(part.content);
+}
+
+function contentText(content) {
+  if (!content) return "";
+  // `WorkContent` serializes externally tagged: {"Text": {...}} | {"Json": ...}.
+  if (content.Json !== undefined) return JSON.stringify(content.Json, null, 2);
+  return content.Text?.content || "";
+}
+
+// "codex/abc/1" → "codex"; "terminal/s/1" → "terminal".
+function recordNamespace(record) {
+  return String(record.work_ref || "").split("/")[0] || "terminal";
 }
 
 async function runSearch() {
@@ -251,7 +264,7 @@ async function runSearch() {
     return;
   }
   for (const record of payload.records) {
-    const open = () => openSession(record.source.provider || "terminal", record.session.canonical_id || record.session.id);
+    const open = () => openSession(recordNamespace(record), record.session.canonical_id || record.session.id);
     const item = el("li", {
       class: "item",
       role: "button",

--- a/web/app.js
+++ b/web/app.js
@@ -231,9 +231,12 @@ function contentText(content) {
   return content.Text?.content || "";
 }
 
-// "codex/abc/1" → "codex"; "terminal/s/1" → "terminal".
+// "codex/abc/1" → "codex"; "desk:codex/abc/1" → "codex"; "terminal/s/1" → "terminal".
 function recordNamespace(record) {
-  return String(record.work_ref || "").split("/")[0] || "terminal";
+  const ref = String(record.work_ref || "");
+  const colon = ref.indexOf(":");
+  const path = colon >= 0 ? ref.slice(colon + 1) : ref;
+  return path.split("/")[0] || "terminal";
 }
 
 async function runSearch() {


### PR DESCRIPTION
## What

Drops the denormalized `kind` + `source` fields on records; consumers derive them from the existing `WorkRef`. Includes the tool-action test fixture convergence into shared `test_fixtures` (fixture commit landed between model commits).

## Why

Two sources of truth for the same fact drift; WorkRef already encodes it.

## Depends on

- #278 (WorkPart model)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Record identity and provider namespaces are derived consistently from work references across grouping, filtering, navigation, and publication validation.
  - Search indexing distinguishes messages, commands, outputs, errors, and tool results.
  - Records support structured messages and actions, including stable action matching and normalized shell content.
  - Session paths and source labels use standardized namespaces.

- **Web App**
  - Structured action and content parts render more reliably.
  - Search-result navigation preserves provider namespaces.

- **Compatibility**
  - Archive and record schema versions have been updated for the revised record format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->