### PR TITLE
feat(diagnostics): unified warning sink with TUI `!` overlay

### DIFF
--- a/crates/sivtr-core/src/agents/codex.rs
+++ b/crates/sivtr-core/src/agents/codex.rs
@@ -28,10 +28,10 @@ impl AgentSessionProvider for CodexProvider {
             match list_recent_jsonl_sessions(PROVIDER_NAME, &root, cwd, parse_session_meta) {
                 Ok(mut root_sessions) => sessions.append(&mut root_sessions),
                 Err(error) => {
-                    eprintln!(
-                        "sivtr: warning: failed to read Codex session dir {}: {error:#}",
+                    crate::diagnostics::warn(format!(
+                        "failed to read Codex session dir {}: {error:#}",
                         root.display()
-                    );
+                    ));
                 }
             }
         }

--- a/crates/sivtr-core/src/agents/generic.rs
+++ b/crates/sivtr-core/src/agents/generic.rs
@@ -89,7 +89,19 @@ impl AgentSessionProvider for GenericProvider {
                 sessions.extend(list_sqlite_sessions(self.provider, &path)?);
                 continue;
             }
-            let parsed = self.parse_session_file(&path)?;
+            // One unreadable file must not drop the provider's whole listing;
+            // warn and keep going (same policy as the jsonl meta reader).
+            let parsed = match self.parse_session_file(&path) {
+                Ok(parsed) => parsed,
+                Err(error) => {
+                    crate::diagnostics::warn(format!(
+                        "failed to parse {} session {}: {error:#}",
+                        self.provider.command_name(),
+                        path.display()
+                    ));
+                    continue;
+                }
+            };
             if parsed.blocks.is_empty() {
                 continue;
             }

--- a/crates/sivtr-core/src/agents/goose.rs
+++ b/crates/sivtr-core/src/agents/goose.rs
@@ -220,10 +220,9 @@ fn apply_message_rows(
         let content = match serde_json::from_str::<Value>(&content_json) {
             Ok(content) => content,
             Err(error) => {
-                eprintln!(
-                    "warning: failed to parse Goose message content for session {}: {error}",
-                    session_id
-                );
+                crate::diagnostics::warn(format!(
+                    "failed to parse Goose message content for session {session_id}: {error}"
+                ));
                 continue;
             }
         };

--- a/crates/sivtr-core/src/agents/jsonl.rs
+++ b/crates/sivtr-core/src/agents/jsonl.rs
@@ -201,10 +201,10 @@ fn collect_recent_sessions(
                     meta,
                     wanted.as_ref(),
                 ),
-                Err(error) => eprintln!(
-                    "warning: failed to parse agent session metadata {}: {error:#}",
+                Err(error) => crate::diagnostics::warn(format!(
+                    "failed to parse agent session metadata {}: {error:#}",
                     path.display()
-                ),
+                )),
             }
             continue;
         };
@@ -233,10 +233,10 @@ fn collect_recent_sessions(
                         meta
                     }
                     Err(error) => {
-                        eprintln!(
-                            "warning: failed to parse agent session metadata {}: {error:#}",
+                        crate::diagnostics::warn(format!(
+                            "failed to parse agent session metadata {}: {error:#}",
                             path.display()
-                        );
+                        ));
                         continue;
                     }
                 }

--- a/crates/sivtr-core/src/diagnostics.rs
+++ b/crates/sivtr-core/src/diagnostics.rs
@@ -12,32 +12,40 @@ static LOG: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
 const LOG_CAP: usize = 200;
 
 /// Listeners mirror each warning to additional destinations (stderr).
-type Listener = Box<dyn Fn(&str) + Send + Sync>;
+/// Arc-shared so `warn` can clone the list and invoke outside the lock.
+type Listener = std::sync::Arc<dyn Fn(&str) + Send + Sync>;
 static LISTENERS: OnceLock<Mutex<Vec<Listener>>> = OnceLock::new();
 
 /// Report a warning: appended to the diagnostics log and mirrored to every
-/// registered listener. Thread-safe; never blocks on lock poisoning.
+/// registered listener. Thread-safe; listeners run outside the lock so they
+/// may warn or subscribe re-entrantly. Never blocks on lock poisoning.
 pub fn warn(message: impl Display) {
     let message = message.to_string();
-    if let Some(mut log) = LOG.get().and_then(|log| log.lock().ok()) {
-        if log.len() == LOG_CAP {
-            log.remove(0);
-        }
-        log.push(message.clone());
+    let mut log = LOG
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if log.len() == LOG_CAP {
+        log.remove(0);
     }
-    if let Some(listeners) = LISTENERS.get().and_then(|listeners| listeners.lock().ok()) {
-        for listener in listeners.iter() {
-            listener(&message);
-        }
+    log.push(message.clone());
+    drop(log);
+    let listeners = LISTENERS
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+    for listener in listeners.iter() {
+        listener(&message);
     }
 }
 
 /// Snapshot of the diagnostics log, oldest first.
 pub fn log() -> Vec<String> {
-    LOG.get()
-        .and_then(|log| log.lock().ok())
-        .map(|log| log.clone())
-        .unwrap_or_default()
+    LOG.get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
 }
 
 /// Register a warning destination (stderr for CLI runs). Only listeners
@@ -61,7 +69,7 @@ mod tests {
         // which is the same `warn` pipeline the ring mirrors.
         let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let sink = seen.clone();
-        subscribe(Box::new(move |message| {
+        subscribe(std::sync::Arc::new(move |message: &str| {
             sink.lock().unwrap().push(message.to_string());
         }));
         warn("ordered first");
@@ -81,7 +89,7 @@ mod tests {
     fn subscribers_see_every_warning() {
         let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let sink = seen.clone();
-        subscribe(Box::new(move |message| {
+        subscribe(std::sync::Arc::new(move |message: &str| {
             sink.lock().unwrap().push(message.to_string());
         }));
         warn("for the listener");

--- a/crates/sivtr-core/src/diagnostics.rs
+++ b/crates/sivtr-core/src/diagnostics.rs
@@ -1,0 +1,93 @@
+//! One process-wide diagnostic sink: warnings from every source (native
+//! listing, archive sync, index cache) land here. CLI runs report to stderr
+//! via the subscriber installed at startup; the TUI reads the log for the
+//! `!` diagnostics overlay. Nothing forks: there is exactly one warning
+//! path, and the listener list decides where it shows up.
+
+use std::fmt::Display;
+use std::sync::{Mutex, OnceLock};
+
+/// Newest-last ring of captured warnings (TUI diagnostics overlay).
+static LOG: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+const LOG_CAP: usize = 200;
+
+/// Listeners mirror each warning to additional destinations (stderr).
+type Listener = Box<dyn Fn(&str) + Send + Sync>;
+static LISTENERS: OnceLock<Mutex<Vec<Listener>>> = OnceLock::new();
+
+/// Report a warning: appended to the diagnostics log and mirrored to every
+/// registered listener. Thread-safe; never blocks on lock poisoning.
+pub fn warn(message: impl Display) {
+    let message = message.to_string();
+    if let Some(mut log) = LOG.get().and_then(|log| log.lock().ok()) {
+        if log.len() == LOG_CAP {
+            log.remove(0);
+        }
+        log.push(message.clone());
+    }
+    if let Some(listeners) = LISTENERS.get().and_then(|listeners| listeners.lock().ok()) {
+        for listener in listeners.iter() {
+            listener(&message);
+        }
+    }
+}
+
+/// Snapshot of the diagnostics log, oldest first.
+pub fn log() -> Vec<String> {
+    LOG.get()
+        .and_then(|log| log.lock().ok())
+        .map(|log| log.clone())
+        .unwrap_or_default()
+}
+
+/// Register a warning destination (stderr for CLI runs). Only listeners
+/// registered before the first warning fire — callers install at startup.
+pub fn subscribe(listener: Listener) {
+    LISTENERS
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .push(listener);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn warnings_are_delivered_in_order() {
+        // The ring is process-global (parallel tests warn into it and can
+        // evict entries), so order is verified through the subscriber path,
+        // which is the same `warn` pipeline the ring mirrors.
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        subscribe(Box::new(move |message| {
+            sink.lock().unwrap().push(message.to_string());
+        }));
+        warn("ordered first");
+        warn("ordered second");
+        // Parallel tests warn too and every listener sees every warning, so
+        // filter to this test's marker and assert the relative order.
+        let captured = seen.lock().unwrap();
+        let mine: Vec<String> = captured
+            .iter()
+            .filter(|entry| entry.starts_with("ordered"))
+            .cloned()
+            .collect();
+        assert_eq!(mine, vec!["ordered first", "ordered second"]);
+    }
+
+    #[test]
+    fn subscribers_see_every_warning() {
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        subscribe(Box::new(move |message| {
+            sink.lock().unwrap().push(message.to_string());
+        }));
+        warn("for the listener");
+        assert!(seen
+            .lock()
+            .unwrap()
+            .contains(&"for the listener".to_string()));
+    }
+}

--- a/crates/sivtr-core/src/lib.rs
+++ b/crates/sivtr-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod archive;
 pub mod cache;
 pub mod capture;
 pub mod config;
+pub mod diagnostics;
 pub mod export;
 pub mod origin;
 pub mod privacy;

--- a/crates/sivtr-core/src/search/index_cache.rs
+++ b/crates/sivtr-core/src/search/index_cache.rs
@@ -45,20 +45,20 @@ pub fn load_index(records: &[crate::record::WorkRecord]) -> Option<Bm25Index> {
     let bytes = match std::fs::read(&path) {
         Ok(bytes) => bytes,
         Err(error) => {
-            eprintln!(
-                "sivtr: failed to read cached BM25 index {}: {error}",
+            crate::diagnostics::warn(format!(
+                "failed to read cached BM25 index {}: {error}",
                 path.display()
-            );
+            ));
             return None;
         }
     };
     let cached: CachedIndex = match rmp_serde::from_slice(&bytes) {
         Ok(cached) => cached,
         Err(error) => {
-            eprintln!(
-                "sivtr: cached BM25 index {} is corrupt: {error}",
+            crate::diagnostics::warn(format!(
+                "cached BM25 index {} is corrupt: {error}",
                 path.display()
-            );
+            ));
             return None;
         }
     };
@@ -80,13 +80,16 @@ pub fn store_index(records: &[crate::record::WorkRecord], index: &Bm25Index) {
     let bytes = match rmp_serde::to_vec(&cached) {
         Ok(bytes) => bytes,
         Err(error) => {
-            eprintln!("sivtr: failed to serialize BM25 index cache: {error}");
+            crate::diagnostics::warn(format!("failed to serialize BM25 index cache: {error}"));
             return;
         }
     };
     let path = index_cache_path(cached.fingerprint);
     if !write_cache_atomic(&path, &bytes) {
-        eprintln!("sivtr: failed to write BM25 index cache {}", path.display());
+        crate::diagnostics::warn(format!(
+            "failed to write BM25 index cache {}",
+            path.display()
+        ));
     }
 }
 

--- a/src/commands/browse/help.rs
+++ b/src/commands/browse/help.rs
@@ -52,6 +52,7 @@ pub(super) fn apply_workspace_help_action(
     content_pane: &mut ContentPane,
     content_blocks: (&[BlockText], &[BlockText]),
     show_help: &mut bool,
+    show_diagnostics: &mut bool,
     show_search: &mut bool,
     search_query: &mut String,
     search_dirty: &mut bool,
@@ -292,8 +293,12 @@ pub(super) fn apply_workspace_help_action(
         WorkspaceHelpAction::ToggleHelp => {
             *show_help = !*show_help;
         }
+        WorkspaceHelpAction::ToggleDiagnostics => {
+            *show_diagnostics = !*show_diagnostics;
+        }
         WorkspaceHelpAction::OpenSearch => {
             *show_help = false;
+            *show_diagnostics = false;
             *show_search = true;
             search_query.clear();
             *search_dirty = true;

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -115,6 +115,8 @@ pub(crate) fn run(
     // the first drag, so a pure click never shows a selection flash.
     let mut mouse_down_select: Option<MouseSelectionStart> = None;
     let mut show_help = false;
+    let mut show_diagnostics = false;
+    let mut diagnostics_state = ListState::default();
     let mut publish_overlay: Option<PublishOverlay> = None;
     let mut publish_error: Option<String> = None;
     let mut show_search = false;
@@ -430,6 +432,9 @@ pub(crate) fn run(
                 })
                 .collect();
             terminal.draw(|frame| {
+                // Snapshot at paint: the overlay shows warnings that landed
+                // while it was open (loads run in background threads).
+                let diagnostics_log = show_diagnostics.then(sivtr_core::diagnostics::log);
                 render_workspace(
                     frame,
                     WorkspaceView {
@@ -449,6 +454,9 @@ pub(crate) fn run(
                         content_at: active_content_at,
                         show_help,
                         help_state: &help_state,
+                        diagnostics: diagnostics_log
+                            .as_deref()
+                            .map(|log| (&diagnostics_state, log)),
                         search: (show_search || search_has_query).then_some(WorkspaceSearchView {
                             query: &search_query,
                             scope: workspace_search_query(&search_query).0,
@@ -754,6 +762,26 @@ pub(crate) fn run(
                         }
                         _ => continue,
                     }
+                } else if show_diagnostics {
+                    match key.code {
+                        KeyCode::Char('!') | KeyCode::Esc => {
+                            show_diagnostics = false;
+                            continue;
+                        }
+                        KeyCode::Up | KeyCode::Char('k') => {
+                            let next = selected_index(&diagnostics_state).saturating_sub(1);
+                            diagnostics_state.select(Some(next));
+                            continue;
+                        }
+                        KeyCode::Down | KeyCode::Char('j') => {
+                            let log_len = sivtr_core::diagnostics::log().len();
+                            let current = selected_index(&diagnostics_state);
+                            let next = (current + 1).min(log_len.saturating_sub(1));
+                            diagnostics_state.select(Some(next));
+                            continue;
+                        }
+                        _ => continue,
+                    }
                 } else {
                     if handle_line_filter_key(
                         key.code,
@@ -857,6 +885,7 @@ pub(crate) fn run(
                         &mut content_pane,
                         content_frame.texts.block_slices(),
                         &mut show_help,
+                        &mut show_diagnostics,
                         &mut show_search,
                         &mut search_query,
                         &mut search_dirty,
@@ -937,6 +966,23 @@ pub(crate) fn run(
                     for _ in 0..MOUSE_SCROLL_LINES {
                         let next = (selected_index(&help_state) + 1).min(len.saturating_sub(1));
                         help_state.select((len > 0).then_some(next));
+                    }
+                }
+                _ => {}
+            },
+            Event::Mouse(mouse) if show_diagnostics && !show_search => match mouse.kind {
+                MouseEventKind::ScrollUp => {
+                    for _ in 0..MOUSE_SCROLL_LINES {
+                        diagnostics_state
+                            .select(Some(selected_index(&diagnostics_state).saturating_sub(1)));
+                    }
+                }
+                MouseEventKind::ScrollDown => {
+                    let len = sivtr_core::diagnostics::log().len();
+                    for _ in 0..MOUSE_SCROLL_LINES {
+                        let next =
+                            (selected_index(&diagnostics_state) + 1).min(len.saturating_sub(1));
+                        diagnostics_state.select((len > 0).then_some(next));
                     }
                 }
                 _ => {}

--- a/src/commands/browse/picker.rs
+++ b/src/commands/browse/picker.rs
@@ -116,7 +116,9 @@ pub(crate) fn run(
     let mut mouse_down_select: Option<MouseSelectionStart> = None;
     let mut show_help = false;
     let mut show_diagnostics = false;
-    let mut diagnostics_state = ListState::default();
+    // First entry selected so the initial Down/j moves to the second line
+    // instead of silently skipping the oldest warning.
+    let mut diagnostics_state = ListState::default().with_selected(Some(0));
     let mut publish_overlay: Option<PublishOverlay> = None;
     let mut publish_error: Option<String> = None;
     let mut show_search = false;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ use std::process::ExitCode;
 
 /// Binary entry — keeps `main.rs` a one-liner so benches can depend on the lib.
 pub fn cli_main() -> ExitCode {
+    output::install_diagnostics_listener();
     tui::panic::install();
     match run() {
         Ok(()) => ExitCode::SUCCESS,

--- a/src/output.rs
+++ b/src/output.rs
@@ -14,6 +14,26 @@ const COLOR_ALWAYS: u8 = 1;
 const COLOR_NEVER: u8 = 2;
 
 static COLOR_CHOICE: AtomicU8 = AtomicU8::new(COLOR_AUTO);
+static TUI_OWNS_SCREEN: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// While a TUI owns the screen, stderr mirroring of diagnostics is suppressed:
+/// the messages stay in the diagnostics ring buffer for the `!` overlay
+/// instead of corrupting the alternate-screen UI.
+pub fn set_tui_owns_screen(active: bool) {
+    TUI_OWNS_SCREEN.store(active, Ordering::Release);
+}
+
+/// Install the one process-wide diagnostics destination for CLI runs: every
+/// warning mirrors to stderr unless the TUI owns the screen (the TUI shows
+/// the same messages through the `!` overlay). Call once at binary startup,
+/// before any command can warn.
+pub fn install_diagnostics_listener() {
+    sivtr_core::diagnostics::subscribe(Box::new(|message| {
+        if !TUI_OWNS_SCREEN.load(Ordering::Acquire) {
+            labeled("warning", Style::YellowBold, message);
+        }
+    }));
+}
 
 pub fn set_color_choice(choice: ColorChoice) {
     COLOR_CHOICE.store(

--- a/src/output.rs
+++ b/src/output.rs
@@ -28,7 +28,7 @@ pub fn set_tui_owns_screen(active: bool) {
 /// the same messages through the `!` overlay). Call once at binary startup,
 /// before any command can warn.
 pub fn install_diagnostics_listener() {
-    sivtr_core::diagnostics::subscribe(Box::new(|message| {
+    sivtr_core::diagnostics::subscribe(std::sync::Arc::new(|message| {
         if !TUI_OWNS_SCREEN.load(Ordering::Acquire) {
             labeled("warning", Style::YellowBold, message);
         }

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -78,9 +78,14 @@ impl Drop for Tui {
             let _ = restore_terminal_state(&mut state);
         }
         self.drawing_active = false;
+        // Claim "back on the normal screen" only when every cleanup step
+        // disarmed: a failed restore may leave the alternate screen up, and
+        // stderr diagnostics would paint over it.
+        let cleaned = !state.has_pending_cleanup();
         drop(state);
-        // Back on the normal screen: diagnostics may mirror to stderr again.
-        crate::output::set_tui_owns_screen(false);
+        if cleaned {
+            crate::output::set_tui_owns_screen(false);
+        }
     }
 }
 
@@ -330,7 +335,15 @@ fn apply_full_redraw_policy(buffer: &mut Buffer) {
 pub fn restore(terminal: &mut Tui) -> Result<()> {
     terminal.drawing_active = false;
     let mut state = terminal.state.borrow_mut();
-    restore_terminal_state(&mut state)
+    let result = restore_terminal_state(&mut state);
+    // The terminal is genuinely back on the normal screen (suspend() will
+    // hand it to an external program): resume stderr diagnostics only once
+    // every cleanup step disarmed. `Tui::drop` re-checks on the way out, so
+    // leaving the flag set here is safe.
+    if result.is_ok() && !state.has_pending_cleanup() {
+        crate::output::set_tui_owns_screen(false);
+    }
+    result
 }
 
 /// Restore a terminal and preserve both the operation error and a cleanup error, if both occur.

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -91,9 +91,6 @@ pub fn init() -> Result<Tui> {
     // here too. `install` is idempotent, and `register_panic_restore` below arms the closure.
     panic::install();
     ensure_tui_stdout()?;
-    // Warnings stay in the diagnostics ring while the UI is up (the `!`
-    // overlay shows them); stderr mirroring resumes on teardown.
-    crate::output::set_tui_owns_screen(true);
 
     // Pick the palette before the first frame draws: honor the config
     // override, otherwise detect light/dark and truecolor from the
@@ -204,6 +201,11 @@ pub fn init() -> Result<Tui> {
         #[cfg(windows)]
         synchronized_updates_supported,
     };
+    // Set only once the TUI is fully constructed: every failure path above
+    // now exits through `setup.fail` or `?` without leaving the flag latched.
+    // Warnings stay in the diagnostics ring while the UI is up (the `!`
+    // overlay shows them); stderr mirroring resumes on teardown.
+    crate::output::set_tui_owns_screen(true);
     Ok(tui)
 }
 /// Draw one TUI frame.

--- a/src/tui/terminal.rs
+++ b/src/tui/terminal.rs
@@ -78,6 +78,9 @@ impl Drop for Tui {
             let _ = restore_terminal_state(&mut state);
         }
         self.drawing_active = false;
+        drop(state);
+        // Back on the normal screen: diagnostics may mirror to stderr again.
+        crate::output::set_tui_owns_screen(false);
     }
 }
 
@@ -88,6 +91,9 @@ pub fn init() -> Result<Tui> {
     // here too. `install` is idempotent, and `register_panic_restore` below arms the closure.
     panic::install();
     ensure_tui_stdout()?;
+    // Warnings stay in the diagnostics ring while the UI is up (the `!`
+    // overlay shows them); stderr mirroring resumes on teardown.
+    crate::output::set_tui_owns_screen(true);
 
     // Pick the palette before the first frame draws: honor the config
     // override, otherwise detect light/dark and truecolor from the

--- a/src/tui/workspace/help.rs
+++ b/src/tui/workspace/help.rs
@@ -33,6 +33,8 @@ pub(crate) enum WorkspaceHelpAction {
     ToggleFullscreen,
     /// Toggle the help overlay.
     ToggleHelp,
+    /// Toggle the diagnostics overlay (full warning history).
+    ToggleDiagnostics,
     OpenSearch,
     /// Esc in the main UI: cancel from Source/Sessions, else step focus left.
     BackOrCancel,
@@ -293,6 +295,13 @@ pub(crate) fn workspace_help_entries() -> &'static [WorkspaceHelpEntry] {
             description: "toggle help",
             action: WorkspaceHelpAction::ToggleHelp,
             footer_label: Some("help"),
+            footer_panes: NAV,
+        },
+        WorkspaceHelpEntry {
+            key: "!",
+            description: "diagnostics log",
+            action: WorkspaceHelpAction::ToggleDiagnostics,
+            footer_label: Some("diag"),
             footer_panes: NAV,
         },
         WorkspaceHelpEntry {

--- a/src/tui/workspace/model.rs
+++ b/src/tui/workspace/model.rs
@@ -348,6 +348,8 @@ pub(crate) struct WorkspaceView<'a> {
     pub(crate) content_at: Option<WorkAt>,
     pub(crate) show_help: bool,
     pub(crate) help_state: &'a ListState,
+    /// `!` diagnostics overlay (Option = closed), newest-last log snapshot.
+    pub(crate) diagnostics: Option<(&'a ListState, &'a [String])>,
     pub(crate) search: Option<WorkspaceSearchView<'a>>,
     pub(crate) line_filter_input_open: bool,
     pub(crate) line_filter: Option<&'a str>,

--- a/src/tui/workspace/render.rs
+++ b/src/tui/workspace/render.rs
@@ -194,6 +194,8 @@ pub(crate) fn render_workspace(frame: &mut Frame, view: WorkspaceView<'_>) {
         );
     } else if view.show_help {
         render_help_panel(frame, chunks[0], view.help_state);
+    } else if let Some((state, log)) = view.diagnostics {
+        render_diagnostics_panel(frame, chunks[0], state, log);
     }
 }
 
@@ -610,6 +612,35 @@ fn render_help_panel(frame: &mut Frame, area: Rect, state: &ListState) {
         workspace_help_entries().len(),
         true,
     );
+}
+
+/// Full diagnostics history (`!`), newest last. Snapshot comes from the
+/// picker at paint, so warnings arriving while open appear live.
+fn render_diagnostics_panel(frame: &mut Frame, area: Rect, state: &ListState, log: &[String]) {
+    frame.render_widget(Clear, area);
+    let items = if log.is_empty() {
+        vec![ListItem::new(Line::styled(
+            "no warnings",
+            Style::default().fg(theme::muted()),
+        ))]
+    } else {
+        log.iter()
+            .map(|entry| {
+                ListItem::new(Line::styled(
+                    entry.clone(),
+                    Style::default().fg(theme::help_text()),
+                ))
+            })
+            .collect()
+    };
+    render_list_panel(
+        frame,
+        area,
+        Panel::new("!", "Diagnostics", true),
+        items,
+        state,
+    );
+    render_list_scrollbar(frame, area, selected_index(state), log.len(), true);
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
## What

One warning sink for parse/sync failures (replaces ad-hoc eprintln), surfaced in the TUI as a `!` overlay.

## Depends on

- #280 (archive sync)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a diagnostics system that collects warnings and displays them in a scrollable workspace overlay.
  * Added keyboard and mouse navigation for reviewing diagnostic history.
  * Added a help shortcut for toggling the diagnostics overlay.
  * Warnings are shown in the terminal when the interface is not active.

* **Bug Fixes**
  * Standardized warning handling across session discovery, parsing, and cache operations.
  * Preserved warnings during TUI sessions without interfering with terminal rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->