### PR TITLE
refactor(tui): unify content colors by part kind

### DIFF
--- a/src/tui/content/markdown.rs
+++ b/src/tui/content/markdown.rs
@@ -319,7 +319,7 @@ fn markdown_line_parts(line: &str) -> MarkdownLineParts<'_> {
     let trimmed = &line[leading_width..];
 
     if let Some((level, rest)) = markdown_heading(trimmed) {
-        let style = agent_heading_style(rest).unwrap_or_else(|| heading_style(level));
+        let style = heading_style(level);
         return MarkdownLineParts {
             prefix: format!("{leading}{} ", "#".repeat(level)),
             prefix_style: structure_prefix_style(),
@@ -870,23 +870,6 @@ fn current_style(styles: &[Style]) -> Style {
     styles.last().copied().unwrap_or_default()
 }
 
-fn agent_heading_style(text: &str) -> Option<Style> {
-    let color = if text.starts_with("Assistant") {
-        crate::tui::theme::success()
-    } else if text.starts_with("User") {
-        crate::tui::theme::user()
-    } else if text.starts_with("Command") {
-        crate::tui::theme::structure_color(false)
-    } else if text.starts_with("Error") {
-        crate::tui::theme::failure()
-    } else if text.starts_with("Output") {
-        crate::tui::theme::output()
-    } else {
-        return None;
-    };
-    Some(Style::default().fg(color).add_modifier(Modifier::BOLD))
-}
-
 /// Style for `<:channel:…:>` structure markers (tools/skills/thinking/mcp):
 /// structural content renders in a subdued gray, distinct from the
 /// default-foreground body.
@@ -959,22 +942,20 @@ mod tests {
     use ratatui::prelude::Modifier;
 
     #[test]
-    fn renders_agent_headings_with_provider_roles() {
+    fn renders_headings_by_level_not_text() {
         let lines = render_markdown_window(&["## User", "## Assistant"], 0, 2, 80);
         let user = &lines[0].line;
         let assistant = &lines[1].line;
 
         assert_eq!(user.spans[0].content.as_ref(), "## ");
         assert_eq!(user.spans[1].content.as_ref(), "User");
-        assert_eq!(user.spans[1].style.fg, Some(crate::tui::theme::user()));
-        assert_eq!(
-            assistant.spans[1].style.fg,
-            Some(crate::tui::theme::success())
-        );
+        // Heading color depends on the heading level alone — never on the
+        // text content.
+        assert_eq!(user.spans[1].style, assistant.spans[1].style);
     }
 
     #[test]
-    fn renders_work_part_headings_with_distinct_styles() {
+    fn renders_structure_markers_in_muted_gray() {
         let lines = render_markdown_window(
             &[
                 "## Command",
@@ -989,10 +970,6 @@ mod tests {
             80,
         );
 
-        assert_eq!(
-            lines[0].line.spans[1].style.fg,
-            Some(crate::tui::theme::structure_color(false))
-        ); // Command heading stays amber
         for marker in [1, 2, 3, 4] {
             assert_eq!(
                 lines[marker].line.spans[0].style.fg,
@@ -1000,10 +977,6 @@ mod tests {
                 "structure marker line {marker} must render gray"
             );
         }
-        assert_eq!(
-            lines[5].line.spans[1].style.fg,
-            Some(crate::tui::theme::failure())
-        ); // Error
     }
 
     #[test]

--- a/src/tui/content/view.rs
+++ b/src/tui/content/view.rs
@@ -1177,18 +1177,20 @@ fn block_dot_lines(
     Text::from(lines)
 }
 
-/// Dot color by block role: the same palette the pane uses for roles, so a
-/// conversation's dots read like chat bubbles (user, tool, thinking, ...).
+/// Dot color by part kind: dialogue parts (user/assistant) carry the default
+/// text color; structure parts (thinking/system/shell/tool/agent) share one
+/// muted light color; failure is status, not decoration.
 fn block_dot_color(role: Option<BlockRole>) -> Color {
     match role {
-        Some(BlockRole::User) => crate::tui::theme::user(),
-        Some(BlockRole::Assistant) => Color::Reset,
-        Some(BlockRole::Reasoning | BlockRole::System) => crate::tui::theme::muted(),
         Some(BlockRole::Failed) => crate::tui::theme::failure(),
-        Some(BlockRole::Shell | BlockRole::Tool | BlockRole::Agent) => {
-            crate::tui::theme::structure_color(false)
-        }
-        None => crate::tui::theme::muted(),
+        Some(
+            BlockRole::Reasoning
+            | BlockRole::System
+            | BlockRole::Shell
+            | BlockRole::Tool
+            | BlockRole::Agent,
+        ) => crate::tui::theme::muted(),
+        Some(BlockRole::User | BlockRole::Assistant) | None => Color::Reset,
     }
 }
 
@@ -1479,10 +1481,9 @@ mod tests {
         assert_eq!(rendered.lines.len(), 2);
         assert_eq!(rendered.lines[0].spans[0].content.as_ref(), "## ");
         assert_eq!(rendered.lines[0].spans[1].content.as_ref(), "User");
-        assert_eq!(
-            rendered.lines[0].spans[1].style.fg,
-            Some(crate::tui::theme::user())
-        );
+        // Heading color depends on the level alone, not the text: an h2
+        // renders in the default foreground.
+        assert_eq!(rendered.lines[0].spans[1].style.fg, None);
         assert!(rendered.lines[1].spans[0]
             .style
             .add_modifier

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -54,10 +54,6 @@ pub(crate) struct Theme {
     pub(crate) link: Color,
     pub(crate) quote: Color,
     pub(crate) success: Color,
-    pub(crate) user: Color,
-    pub(crate) output: Color,
-    pub(crate) structure: Color,
-    pub(crate) structure_result: Color,
 }
 
 /// The four agent-label colors for one provider, one per palette. Chosen by
@@ -179,28 +175,24 @@ impl Theme {
     pub(crate) const fn dark() -> Self {
         Self {
             mode: PaletteMode::Dark,
-            accent: Color::Rgb(56, 189, 248),           // sky-400
-            muted: Color::Rgb(100, 116, 139),           // slate-500
-            dim: Color::Rgb(71, 85, 105),               // slate-600
-            local_origin: Color::Rgb(52, 211, 153),     // emerald-400
-            remote_origin: Color::Rgb(244, 114, 182),   // pink-400
-            focus_bg: Color::Rgb(15, 23, 42),           // slate-900 (veil tint)
-            selected_bg: Color::Rgb(51, 65, 85),        // slate-700
-            selected_fg: Color::Rgb(226, 232, 240),     // slate-200
-            range_fg: Color::Rgb(251, 191, 36),         // amber-400
-            title_active: Color::Rgb(224, 242, 254),    // sky-100
-            muted_text: Color::Rgb(203, 213, 225),      // slate-300
-            key_hint: Color::Rgb(125, 211, 252),        // sky-300
-            footer: Color::Rgb(148, 163, 184),          // slate-400
-            failure: Color::Rgb(248, 113, 113),         // red-400
-            code: Color::Rgb(148, 163, 184),            // slate-400
-            link: Color::Rgb(125, 211, 252),            // sky-300
-            quote: Color::Rgb(52, 211, 153),            // emerald-400
-            success: Color::Rgb(74, 222, 128),          // green-400
-            user: Color::Rgb(34, 211, 238),             // cyan-400
-            output: Color::Rgb(96, 165, 250),           // blue-400
-            structure: Color::Rgb(251, 191, 36),        // amber-400
-            structure_result: Color::Rgb(56, 189, 248), // sky-400
+            accent: Color::Rgb(56, 189, 248),         // sky-400
+            muted: Color::Rgb(100, 116, 139),         // slate-500
+            dim: Color::Rgb(71, 85, 105),             // slate-600
+            local_origin: Color::Rgb(52, 211, 153),   // emerald-400
+            remote_origin: Color::Rgb(244, 114, 182), // pink-400
+            focus_bg: Color::Rgb(15, 23, 42),         // slate-900 (veil tint)
+            selected_bg: Color::Rgb(51, 65, 85),      // slate-700
+            selected_fg: Color::Rgb(226, 232, 240),   // slate-200
+            range_fg: Color::Rgb(251, 191, 36),       // amber-400
+            title_active: Color::Rgb(224, 242, 254),  // sky-100
+            muted_text: Color::Rgb(203, 213, 225),    // slate-300
+            key_hint: Color::Rgb(125, 211, 252),      // sky-300
+            footer: Color::Rgb(148, 163, 184),        // slate-400
+            failure: Color::Rgb(248, 113, 113),       // red-400
+            code: Color::Rgb(148, 163, 184),          // slate-400
+            link: Color::Rgb(125, 211, 252),          // sky-300
+            quote: Color::Rgb(52, 211, 153),          // emerald-400
+            success: Color::Rgb(74, 222, 128),        // green-400
         }
     }
 
@@ -208,28 +200,24 @@ impl Theme {
     pub(crate) const fn light() -> Self {
         Self {
             mode: PaletteMode::Light,
-            accent: Color::Rgb(2, 132, 199),           // sky-600
-            muted: Color::Rgb(100, 116, 139),          // slate-500
-            dim: Color::Rgb(148, 163, 184),            // slate-400
-            local_origin: Color::Rgb(5, 150, 105),     // emerald-600
-            remote_origin: Color::Rgb(219, 39, 119),   // pink-600
-            focus_bg: Color::Rgb(241, 245, 249),       // slate-100 (faint gray tint)
-            selected_bg: Color::Rgb(226, 232, 240),    // slate-200
-            selected_fg: Color::Rgb(51, 65, 85),       // slate-700
-            range_fg: Color::Rgb(217, 119, 6),         // amber-600
-            title_active: Color::Rgb(15, 23, 42),      // slate-900
-            muted_text: Color::Rgb(100, 116, 139),     // slate-500
-            key_hint: Color::Rgb(3, 105, 161),         // sky-700
-            footer: Color::Rgb(71, 85, 105),           // slate-600
-            failure: Color::Rgb(220, 38, 38),          // red-600
-            code: Color::Rgb(71, 85, 105),             // slate-600
-            link: Color::Rgb(3, 105, 161),             // sky-700
-            quote: Color::Rgb(5, 150, 105),            // emerald-600
-            success: Color::Rgb(22, 163, 74),          // green-600
-            user: Color::Rgb(8, 145, 178),             // cyan-600
-            output: Color::Rgb(37, 99, 235),           // blue-600
-            structure: Color::Rgb(217, 119, 6),        // amber-600
-            structure_result: Color::Rgb(2, 132, 199), // sky-600
+            accent: Color::Rgb(2, 132, 199),         // sky-600
+            muted: Color::Rgb(100, 116, 139),        // slate-500
+            dim: Color::Rgb(148, 163, 184),          // slate-400
+            local_origin: Color::Rgb(5, 150, 105),   // emerald-600
+            remote_origin: Color::Rgb(219, 39, 119), // pink-600
+            focus_bg: Color::Rgb(241, 245, 249),     // slate-100 (faint gray tint)
+            selected_bg: Color::Rgb(226, 232, 240),  // slate-200
+            selected_fg: Color::Rgb(51, 65, 85),     // slate-700
+            range_fg: Color::Rgb(217, 119, 6),       // amber-600
+            title_active: Color::Rgb(15, 23, 42),    // slate-900
+            muted_text: Color::Rgb(100, 116, 139),   // slate-500
+            key_hint: Color::Rgb(3, 105, 161),       // sky-700
+            footer: Color::Rgb(71, 85, 105),         // slate-600
+            failure: Color::Rgb(220, 38, 38),        // red-600
+            code: Color::Rgb(71, 85, 105),           // slate-600
+            link: Color::Rgb(3, 105, 161),           // sky-700
+            quote: Color::Rgb(5, 150, 105),          // emerald-600
+            success: Color::Rgb(22, 163, 74),        // green-600
         }
     }
 
@@ -257,10 +245,6 @@ impl Theme {
             link: Color::Blue,
             quote: Color::Green,
             success: Color::Green,
-            user: Color::Cyan,
-            output: Color::Blue,
-            structure: Color::Yellow,
-            structure_result: Color::Blue,
         }
     }
 
@@ -289,10 +273,6 @@ impl Theme {
             link: Color::Blue,
             quote: Color::DarkGray,
             success: Color::Blue,
-            user: Color::Magenta,
-            output: Color::Blue,
-            structure: Color::Red,
-            structure_result: Color::Blue,
         }
     }
 }
@@ -493,27 +473,6 @@ pub(crate) fn success() -> Color {
     ACTIVE.get().success
 }
 
-/// User role headings.
-pub(crate) fn user() -> Color {
-    ACTIVE.get().user
-}
-
-/// Output role headings.
-pub(crate) fn output() -> Color {
-    ACTIVE.get().output
-}
-
-/// Color for the `## Command` dialogue heading and structural roles. Result
-/// channels (`… result:>`) lean blue, everything else yellow.
-pub(crate) fn structure_color(is_result: bool) -> Color {
-    let theme = ACTIVE.get();
-    if is_result {
-        theme.structure_result
-    } else {
-        theme.structure
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -600,10 +559,6 @@ mod tests {
             ("link", light.link),
             ("quote", light.quote),
             ("success", light.success),
-            ("user", light.user),
-            ("output", light.output),
-            ("structure", light.structure),
-            ("structure result", light.structure_result),
         ] {
             assert_dark_foreground(name, color);
         }


### PR DESCRIPTION
## What

Content-pane colors come from the part kind alone: dialogue parts (user/assistant) render in the default text color, structure parts (thinking/system/shell/tool/agent) share one muted light color, failure is red. Deletes the per-role dot palette and the heading text-matching special cases (net −71 lines).

## Depends on

- #281 (diagnostics)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Standardized heading appearance so colors no longer vary based on heading text or role.
  - Updated block markers to use consistent default and muted colors, while preserving a distinct color for failed blocks.
  - Simplified the color theme by removing role-specific colors for user, output, and structural content, resulting in a more consistent interface across themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->