### PR TITLE
fix(agents): filter injected user envelopes at the shared block funnel

### DIFF
--- a/crates/sivtr-core/src/agents/claude.rs
+++ b/crates/sivtr-core/src/agents/claude.rs
@@ -634,7 +634,7 @@ mod tests {
     fn skips_injected_user_envelopes_without_meta_flag() {
         // Background-task notifications arrive as plain user messages with no
         // isMeta flag; only the text identifies them as machine injections.
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().expect("test tempdir");
         let path = dir.path().join("session.jsonl");
         std::fs::write(
             &path,
@@ -645,9 +645,11 @@ mod tests {
 {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}
 "#,
         )
-        .unwrap();
+        .expect("write test session log");
 
-        let session = ClaudeProvider.parse_session_file(&path).unwrap();
+        let session = ClaudeProvider
+            .parse_session_file(&path)
+            .expect("parse test session");
 
         assert_eq!(session.blocks.len(), 2);
         assert_eq!(session.blocks[0].text, "real follow-up");

--- a/crates/sivtr-core/src/agents/claude.rs
+++ b/crates/sivtr-core/src/agents/claude.rs
@@ -631,6 +631,30 @@ mod tests {
     }
 
     #[test]
+    fn skips_injected_user_envelopes_without_meta_flag() {
+        // Background-task notifications arrive as plain user messages with no
+        // isMeta flag; only the text identifies them as machine injections.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"type":"user","message":{"role":"user","content":"<task-notification>\n<task-id>aa05</task-id>\n<output-file>C:\\tmp\\out</output-file>\n</task-notification>"}}
+{"type":"user","message":{"role":"user","content":"<bash-input>cargo test</bash-input>\n<bash-stdout>ok</bash-stdout>"}}
+{"type":"user","message":{"role":"user","content":"<command-name>/review</command-name>\n<command-message>review</command-message>"}}
+{"type":"user","message":{"role":"user","content":"real follow-up"}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}
+"#,
+        )
+        .unwrap();
+
+        let session = ClaudeProvider.parse_session_file(&path).unwrap();
+
+        assert_eq!(session.blocks.len(), 2);
+        assert_eq!(session.blocks[0].text, "real follow-up");
+        assert_eq!(session.blocks[1].text, "done");
+    }
+
+    #[test]
     fn selects_last_claude_turn() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("session.jsonl");

--- a/crates/sivtr-core/src/agents/codex.rs
+++ b/crates/sivtr-core/src/agents/codex.rs
@@ -396,7 +396,7 @@ mod tests {
 
     #[test]
     fn filters_injected_user_envelopes_and_keeps_skill_wrapper() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().expect("test tempdir");
         let path = dir.path().join("rollout.jsonl");
         std::fs::write(
             &path,
@@ -412,9 +412,11 @@ mod tests {
 {"timestamp":"2026-04-27T00:00:09Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"answer"}]}}
 "#,
         )
-        .unwrap();
+        .expect("write test session log");
 
-        let session = CodexProvider.parse_session_file(&path).unwrap();
+        let session = CodexProvider
+            .parse_session_file(&path)
+            .expect("parse test session");
 
         // Injected envelopes never become dialogue; the bare `<skill>` wrapper
         // becomes a labeled skill block.
@@ -433,7 +435,7 @@ mod tests {
 
     #[test]
     fn unclosed_skill_wrapper_stays_user_dialogue() {
-        let dir = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().expect("test tempdir");
         let path = dir.path().join("rollout.jsonl");
         std::fs::write(
             &path,
@@ -444,9 +446,11 @@ mod tests {
                 "\n",
             ),
         )
-        .unwrap();
+        .expect("write test session log");
 
-        let session = CodexProvider.parse_session_file(&path).unwrap();
+        let session = CodexProvider
+            .parse_session_file(&path)
+            .expect("parse test session");
 
         // A truncated wrapper is user text, not a Codex skill expansion:
         // reclassifying it would swallow real dialogue into a Skill block.

--- a/crates/sivtr-core/src/agents/codex.rs
+++ b/crates/sivtr-core/src/agents/codex.rs
@@ -331,7 +331,9 @@ fn find_current_thread_session() -> Result<Option<PathBuf>> {
 #[cfg(test)]
 mod tests {
     use super::CodexProvider;
-    use crate::agents::{select_blocks, AgentBlockKind, AgentSelection, AgentSessionProvider};
+    use crate::agents::{
+        select_blocks, AgentBlockKind, AgentProvider, AgentSelection, AgentSessionProvider,
+    };
     use serde_json::json;
     use std::{env, time::Duration};
 
@@ -390,6 +392,43 @@ mod tests {
         assert_eq!(session.blocks[2].kind, AgentBlockKind::ToolOutput);
         assert_eq!(session.blocks[2].call_id.as_deref(), Some("call_1"));
         assert_eq!(session.blocks[2].text, "Patch applied");
+    }
+
+    #[test]
+    fn filters_injected_user_envelopes_and_keeps_skill_wrapper() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"timestamp":"2026-04-27T00:00:00Z","type":"session_meta","payload":{"id":"abc","cwd":"C:\\repo"}}
+{"timestamp":"2026-04-27T00:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<codex_internal_context source=\"goal\">\n<objective>ship it</objective>\n</codex_internal_context>"}]}}
+{"timestamp":"2026-04-27T00:00:02Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<turn_aborted/>"}]}}
+{"timestamp":"2026-04-27T00:00:03Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<image>"}]}}
+{"timestamp":"2026-04-27T00:00:04Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<image name=\"[Image #1]\">"}]}}
+{"timestamp":"2026-04-27T00:00:05Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<subagent_notification>\n<task-id>1</task-id>\n</subagent_notification>"}]}}
+{"timestamp":"2026-04-27T00:00:06Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<user_action>scrolled</user_action>"}]}}
+{"timestamp":"2026-04-27T00:00:07Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<skill>\n<name>skill-installer</name>\n<path>C:\\skills\\SKILL.md</path>\n---\nbody text\n</skill>"}]}}
+{"timestamp":"2026-04-27T00:00:08Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"real question"}]}}
+{"timestamp":"2026-04-27T00:00:09Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"answer"}]}}
+"#,
+        )
+        .unwrap();
+
+        let session = CodexProvider.parse_session_file(&path).unwrap();
+
+        // Injected envelopes never become dialogue; the bare `<skill>` wrapper
+        // becomes a labeled skill block.
+        assert_eq!(session.blocks.len(), 3);
+        assert_eq!(session.blocks[0].kind, AgentBlockKind::Skill);
+        assert_eq!(session.blocks[0].label.as_deref(), Some("skill-installer"));
+        assert!(session.blocks[0].text.starts_with("---\nbody text"));
+        assert!(!session.blocks[0].text.contains("SKILL.md"));
+        assert_eq!(session.blocks[1].text, "real question");
+        assert_eq!(session.blocks[2].text, "answer");
+
+        let records = crate::record::WorkRecord::chat_turns(AgentProvider::Codex, &session);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].input_text().as_deref(), Some("real question"));
     }
 
     #[test]

--- a/crates/sivtr-core/src/agents/codex.rs
+++ b/crates/sivtr-core/src/agents/codex.rs
@@ -432,6 +432,30 @@ mod tests {
     }
 
     #[test]
+    fn unclosed_skill_wrapper_stays_user_dialogue() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rollout.jsonl");
+        std::fs::write(
+            &path,
+            concat!(
+                r#"{"timestamp":"2026-04-27T00:00:00Z","type":"session_meta","payload":{"id":"abc","cwd":"C:\\repo"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-04-27T00:00:01Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<skill>\n<name>half</name>\nstarted reading the skill doc but never"}]}}"#,
+                "\n",
+            ),
+        )
+        .unwrap();
+
+        let session = CodexProvider.parse_session_file(&path).unwrap();
+
+        // A truncated wrapper is user text, not a Codex skill expansion:
+        // reclassifying it would swallow real dialogue into a Skill block.
+        assert_eq!(session.blocks.len(), 1);
+        assert_eq!(session.blocks[0].kind, AgentBlockKind::User);
+        assert!(session.blocks[0].text.starts_with("<skill>"));
+    }
+
+    #[test]
     fn selects_last_turn_without_tool_noise() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("rollout.jsonl");

--- a/crates/sivtr-core/src/agents/grok.rs
+++ b/crates/sivtr-core/src/agents/grok.rs
@@ -230,7 +230,7 @@ fn apply_user(session: &mut AgentSession, value: &Value) {
     }
 
     let text = extract_user_text(value.get("content").unwrap_or(&Value::Null));
-    if text.trim().is_empty() || is_scaffolding_user_text(&text) {
+    if text.trim().is_empty() {
         return;
     }
     push_block(session, AgentBlockKind::User, None, None, text);
@@ -706,14 +706,6 @@ fn extract_user_query(text: &str) -> Option<String> {
     } else {
         Some(query.to_string())
     }
-}
-
-fn is_scaffolding_user_text(text: &str) -> bool {
-    let trimmed = text.trim_start();
-    trimmed.starts_with("<user_info>")
-        || trimmed.starts_with("<system-reminder>")
-        || trimmed.starts_with("<image_files>")
-        || trimmed.starts_with("<environment_context>")
 }
 
 fn parse_rfc3339(value: Option<&str>) -> Option<SystemTime> {

--- a/crates/sivtr-core/src/agents/model.rs
+++ b/crates/sivtr-core/src/agents/model.rs
@@ -332,7 +332,9 @@ fn bare_skill_wrapper(text: &str) -> Option<(String, String)> {
         return None;
     }
     let body = text.strip_prefix(OPEN)?;
-    let body = body.strip_suffix(CLOSE).unwrap_or(body);
+    // An unclosed wrapper is not a Codex skill expansion — treating it as
+    // one would swallow user text into a Skill block, so keep it dialogue.
+    let body = body.strip_suffix(CLOSE)?;
     let name_start = body.find("<name>")? + "<name>".len();
     let name_end = body[name_start..].find("</name>")? + name_start;
     let name = body[name_start..name_end].trim();

--- a/crates/sivtr-core/src/agents/model.rs
+++ b/crates/sivtr-core/src/agents/model.rs
@@ -260,17 +260,94 @@ pub fn push_block(
     label: Option<String>,
     text: impl Into<String>,
 ) {
-    let text = text.into().trim().to_string();
-    if !text.is_empty() {
-        session.blocks.push(AgentBlock {
-            kind,
-            timestamp,
-            label,
-            call_id: None,
-            start_line: None,
-            text,
-        });
+    let mut text = text.into().trim().to_string();
+    if text.is_empty() {
+        return;
     }
+    let mut kind = kind;
+    let mut label = label;
+    if kind == AgentBlockKind::User {
+        // Machine-injected user-role text is never dialogue. Bare `<skill>`
+        // wrappers (Codex skill expansion) still carry the skill body.
+        if let Some((name, body)) = bare_skill_wrapper(&text) {
+            kind = AgentBlockKind::Skill;
+            label = Some(name);
+            text = body;
+        } else if is_scaffolding_user_text(&text) {
+            return;
+        }
+    }
+    session.blocks.push(AgentBlock {
+        kind,
+        timestamp,
+        label,
+        call_id: None,
+        start_line: None,
+        text,
+    });
+}
+
+/// User-role text injected by the agent runtime rather than typed by a human:
+/// reminders, context snapshots, goal continuations, machine notifications,
+/// command transcripts. One predicate at the shared block funnel keeps every
+/// provider's parser from leaking scaffolding into dialogue.
+fn is_scaffolding_user_text(text: &str) -> bool {
+    const PREFIXES: &[&str] = &[
+        // Claude Code runtime injections and slash-command/bash transcripts.
+        "<system-reminder",
+        "<system_reminder",
+        "<local-command-caveat",
+        "<local-command-stdout",
+        "<command-message",
+        "<command-name",
+        "<command-args",
+        "<ide_opened_file",
+        "<ide_selection",
+        "<bash-input",
+        "<bash-stdout",
+        "<task-notification",
+        "[Request interrupted by user",
+        "# AGENTS.md instructions for",
+        // Codex injected context and machine notifications. Tag prefixes omit
+        // the closing `>`: injected envelopes also arrive self-closing or with
+        // attributes (`<turn_aborted/>`, `<codex_internal_context source=…>`).
+        "<environment_context",
+        "<turn_aborted",
+        "<codex_internal_context",
+        "<subagent_notification",
+        "<user_action",
+        "<user_info",
+        "<image",
+    ];
+    PREFIXES.iter().any(|prefix| text.starts_with(prefix))
+}
+
+/// Codex wraps expanded skill documents as `<skill>\n<name>x</name>…</skill>`
+/// (no `name=` attribute). Returns the skill name and inner body so the block
+/// renders as a labeled skill.
+fn bare_skill_wrapper(text: &str) -> Option<(String, String)> {
+    const OPEN: &str = "<skill>";
+    const CLOSE: &str = "</skill>";
+    if !text.starts_with(OPEN) {
+        return None;
+    }
+    let body = text.strip_prefix(OPEN)?;
+    let body = body.strip_suffix(CLOSE).unwrap_or(body);
+    let name_start = body.find("<name>")? + "<name>".len();
+    let name_end = body[name_start..].find("</name>")? + name_start;
+    let name = body[name_start..name_end].trim();
+    if name.is_empty() {
+        return None;
+    }
+    // Drop the `<name>`/`<path>` envelope lines from the displayed body.
+    let mut body = body[name_end + "</name>".len()..].trim();
+    for (open, close) in [("<name>", "</name>"), ("<path>", "</path>")] {
+        if body.starts_with(open) {
+            let Some(end) = body.find(close) else { break };
+            body = body[end + close.len()..].trim();
+        }
+    }
+    Some((name.to_string(), body.to_string()))
 }
 
 pub fn push_tool_block(

--- a/crates/sivtr-core/src/archive/schema.rs
+++ b/crates/sivtr-core/src/archive/schema.rs
@@ -8,7 +8,7 @@ use rusqlite::Connection;
 /// Archive schema version. Bump when a release changes the table layout in a
 /// way older rows cannot serve; the store then rebuilds from native sources
 /// on the next sync (the archive is derived state, so a rebuild is safe).
-pub const SCHEMA_VERSION: i64 = 6;
+pub const SCHEMA_VERSION: i64 = 7;
 
 /// Path of the archive database (`<data_dir>/archive.db`).
 pub fn db_path() -> PathBuf {

--- a/crates/sivtr-core/src/record/mod.rs
+++ b/crates/sivtr-core/src/record/mod.rs
@@ -6,10 +6,10 @@ pub mod refs;
 pub use expand::{expand_source, resolve_scope_token};
 pub use index::WorkRecordIndex;
 pub use model::{
-    agent_parts, chat_turn_ranges, format_shell_action, format_work_part, is_real_user_block,
-    output_blocks_text, MessageRole, Projection, ProjectionSlice, RecordText, RecordTextMode,
-    WorkActionStatus, WorkActor, WorkContent, WorkContentBlock, WorkOutcome, WorkPart,
-    WorkPartBody, WorkPartKind, WorkRecord, WorkRecordCopyParts, WorkSessionRef, WorkStatus,
-    WorkTarget, WorkTime, RECORD_SCHEMA_VERSION,
+    agent_parts, chat_turn_ranges, format_shell_action, format_work_part, output_blocks_text,
+    MessageRole, Projection, ProjectionSlice, RecordText, RecordTextMode, WorkActionStatus,
+    WorkActor, WorkContent, WorkContentBlock, WorkOutcome, WorkPart, WorkPartBody, WorkPartKind,
+    WorkRecord, WorkRecordCopyParts, WorkSessionRef, WorkStatus, WorkTarget, WorkTime,
+    RECORD_SCHEMA_VERSION,
 };
 pub use refs::{normalize_scope_name, WorkAt, WorkPath, WorkRef, WorkRefSelector, WorkScope};

--- a/crates/sivtr-core/src/record/model.rs
+++ b/crates/sivtr-core/src/record/model.rs
@@ -74,7 +74,7 @@ impl WorkRecordCopyParts {
     }
 }
 
-pub const RECORD_SCHEMA_VERSION: u32 = 5;
+pub const RECORD_SCHEMA_VERSION: u32 = 6;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -873,7 +873,7 @@ pub fn chat_turn_ranges(blocks: &[AgentBlock]) -> Vec<(usize, usize)> {
     let mut has_assistant = false;
 
     for (idx, block) in blocks.iter().enumerate() {
-        if block.kind == AgentBlockKind::User && is_real_user_block(block) {
+        if block.kind == AgentBlockKind::User {
             if let Some(start) = start {
                 if has_assistant {
                     ranges.push((start, idx));
@@ -908,33 +908,6 @@ fn user_only_turn_before_trailing_tools(
         .iter()
         .all(|block| block.kind.is_structure())
         .then_some((start, blocks.len()))
-}
-
-pub fn is_real_user_block(block: &AgentBlock) -> bool {
-    if block.kind != AgentBlockKind::User {
-        return false;
-    }
-
-    let text = block.text.trim_start();
-    !is_agent_startup_user_text(text)
-}
-
-fn is_agent_startup_user_text(text: &str) -> bool {
-    let text = text.trim_start();
-    text.starts_with("# AGENTS.md instructions for")
-        || text.starts_with("<environment_context>")
-        || text.starts_with("<turn_aborted>")
-        || text.starts_with("<local-command-caveat>")
-        || text.starts_with("<local-command-stdout>")
-        || text.starts_with("<command-message>")
-        || text.starts_with("<command-name>")
-        || text.starts_with("<command-args>")
-        || text.starts_with("<ide_opened_file>")
-        || text.starts_with("<ide_selection>")
-        || text.starts_with("<system-reminder>")
-        || text.starts_with("<system_reminder>")
-        // Covers plain interrupt and "…for tool use" variants.
-        || text.starts_with("[Request interrupted by user")
 }
 
 fn agent_session_ref_id(id: Option<&str>, path: &Path) -> String {
@@ -1564,6 +1537,7 @@ pub fn format_shell_action(part: &WorkPart, slice: ProjectionSlice) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agents::push_block;
     use crate::time::parse_timestamp;
     use std::path::PathBuf;
 
@@ -1983,46 +1957,31 @@ mod tests {
 
     #[test]
     fn chat_turn_records_ignore_interrupted_tool_use_noise() {
-        let session = AgentSession {
+        // The interrupted-turn noise is dropped at parse time (push_block
+        // filters scaffolding), so post-parse this is a plain two-turn
+        // session: an empty-scaffold start and a normal continuation.
+        let mut session = AgentSession {
             path: PathBuf::from("claude-session.jsonl"),
             id: Some("abcdef123456".to_string()),
             cwd: Some("D:\\sivtr".to_string()),
             title: None,
-            blocks: vec![
-                AgentBlock {
-                    kind: AgentBlockKind::User,
-                    timestamp: Some("2026-05-23T12:00:00Z".to_string()),
-                    label: None,
-                    call_id: None,
-                    text: "[Request interrupted by user for tool use]".to_string(),
-                    start_line: None,
-                },
-                AgentBlock {
-                    kind: AgentBlockKind::Assistant,
-                    timestamp: Some("2026-05-23T12:00:01Z".to_string()),
-                    label: None,
-                    call_id: None,
-                    text: "partial".to_string(),
-                    start_line: None,
-                },
-                AgentBlock {
-                    kind: AgentBlockKind::User,
-                    timestamp: Some("2026-05-23T12:01:00Z".to_string()),
-                    label: None,
-                    call_id: None,
-                    text: "continue".to_string(),
-                    start_line: None,
-                },
-                AgentBlock {
-                    kind: AgentBlockKind::Assistant,
-                    timestamp: Some("2026-05-23T12:02:00Z".to_string()),
-                    label: None,
-                    call_id: None,
-                    text: "done".to_string(),
-                    start_line: None,
-                },
-            ],
+            blocks: Vec::new(),
         };
+        for (kind, at, text) in [
+            (
+                AgentBlockKind::User,
+                "2026-05-23T12:00:00Z",
+                "[Request interrupted by user for tool use]",
+            ),
+            (AgentBlockKind::Assistant, "2026-05-23T12:00:01Z", "partial"),
+            (AgentBlockKind::User, "2026-05-23T12:01:00Z", "continue"),
+            (AgentBlockKind::Assistant, "2026-05-23T12:02:00Z", "done"),
+        ] {
+            push_block(&mut session, kind, Some(at.to_string()), None, text);
+        }
+
+        // Scaffolding never reaches the block list.
+        assert_eq!(session.blocks.len(), 3);
 
         let records = WorkRecord::chat_turns(AgentProvider::Claude, &session);
         assert_eq!(records.len(), 1);
@@ -2036,54 +1995,41 @@ mod tests {
 
     #[test]
     fn chat_turn_records_ignore_system_and_command_noise() {
-        let session = AgentSession {
+        let mut session = AgentSession {
             path: PathBuf::from("claude-session.jsonl"),
             id: Some("abcdef123456".to_string()),
             cwd: Some("D:\\sivtr".to_string()),
             title: None,
-            blocks: vec![
-                AgentBlock {
-                    kind: AgentBlockKind::User,
-                    timestamp: Some("2026-05-23T12:00:00Z".to_string()),
-                    label: None,
-                    call_id: None,
-                    text: "  <system-reminder>\nhidden\n</system-reminder>".to_string(),
-                    start_line: None,
-                },
-                AgentBlock {
-                    kind: AgentBlockKind::User,
-                    timestamp: Some("2026-05-23T12:00:01Z".to_string()),
-                    label: None,
-                    call_id: None,
-                    text: "<command-args>--foo</command-args>".to_string(),
-                    start_line: None,
-                },
-                AgentBlock {
-                    kind: AgentBlockKind::User,
-                    timestamp: Some("2026-05-23T12:00:02Z".to_string()),
-                    label: None,
-                    call_id: None,
-                    text: "<ide_selection>main.rs</ide_selection>".to_string(),
-                    start_line: None,
-                },
-                AgentBlock {
-                    kind: AgentBlockKind::User,
-                    timestamp: Some("2026-05-23T12:01:00Z".to_string()),
-                    label: None,
-                    call_id: None,
-                    text: "real question".to_string(),
-                    start_line: None,
-                },
-                AgentBlock {
-                    kind: AgentBlockKind::Assistant,
-                    timestamp: Some("2026-05-23T12:02:00Z".to_string()),
-                    label: None,
-                    call_id: None,
-                    text: "answer".to_string(),
-                    start_line: None,
-                },
-            ],
+            blocks: Vec::new(),
         };
+        for (kind, at, text) in [
+            (
+                AgentBlockKind::User,
+                "2026-05-23T12:00:00Z",
+                "  <system-reminder>\nhidden\n</system-reminder>",
+            ),
+            (
+                AgentBlockKind::User,
+                "2026-05-23T12:00:01Z",
+                "<command-args>--foo</command-args>",
+            ),
+            (
+                AgentBlockKind::User,
+                "2026-05-23T12:00:02Z",
+                "<ide_selection>main.rs</ide_selection>",
+            ),
+            (
+                AgentBlockKind::User,
+                "2026-05-23T12:01:00Z",
+                "real question",
+            ),
+            (AgentBlockKind::Assistant, "2026-05-23T12:02:00Z", "answer"),
+        ] {
+            push_block(&mut session, kind, Some(at.to_string()), None, text);
+        }
+
+        // Scaffolding never reaches the block list.
+        assert_eq!(session.blocks.len(), 2);
 
         let records = WorkRecord::chat_turns(AgentProvider::Claude, &session);
         assert_eq!(records.len(), 1);

--- a/docs-site/src/content/docs/explanation/local-first-privacy.md
+++ b/docs-site/src/content/docs/explanation/local-first-privacy.md
@@ -18,7 +18,7 @@ It does not provide a hosted transcript service by default.
 
 ## The local archive
 
-Terminal captures and agent sessions live in one local SQLite archive (`archive.db`) under sivtr's data directory. Nothing leaves the machine in the process: native session files remain the source of truth: the sync engine reads them, and session-addressed loads self-heal by parsing the native file when the archive copy is missing or stale.
+Terminal captures and agent sessions live in one local SQLite archive (`archive.db`) under sivtr's data directory. Nothing leaves the machine in the process. Native session files remain the source of truth: the sync engine reads them locally, and session-addressed loads self-heal by parsing the native file when the archive copy is missing or stale.
 ## Explicit remote share
 
 Cross-device memory access is also opt-in. Nothing leaves the machine until you create a share (`sivtr share` / `share add`), issue an invite (`share invite`), and a peer redeems it:

--- a/src/commands/browse/perf.rs
+++ b/src/commands/browse/perf.rs
@@ -6,7 +6,8 @@ use crate::pane::{Pane, PaneInput, Viewport};
 use crate::tui::workspace::{WorkspaceDialogue, WorkspaceSession, WorkspaceSource};
 use sivtr_core::agents::AgentProvider;
 use sivtr_core::record::{
-    WorkPart, WorkRecord, WorkRef, WorkSessionRef, WorkTime, RECORD_SCHEMA_VERSION,
+    MessageRole, WorkContent, WorkPart, WorkPartBody, WorkRecord, WorkRef, WorkSessionRef,
+    WorkTime, RECORD_SCHEMA_VERSION,
 };
 use std::cell::RefCell;
 use std::time::UNIX_EPOCH;
@@ -30,7 +31,14 @@ fn fat_record(session: &str, index: usize, title: &str) -> WorkRecord {
         parts: vec![WorkPart {
             seq: 0,
             occurred_at: None,
-            data: sivtr_core::record::WorkPartData::Assistant { content: blob },
+            body: WorkPartBody::Message {
+                role: MessageRole::Assistant,
+                label: None,
+                content: WorkContent::Text {
+                    content: blob,
+                    ansi: None,
+                },
+            },
         }],
     }
 }


### PR DESCRIPTION
## What

Machine-injected user-role text (Codex goal context, turn aborts, subagent/task notifications, Claude system reminders, bash and slash-command transcripts, image envelopes) leaked into dialogue records. One prefix predicate in `push_block` now guards every provider parser, replacing the record-layer startup list and grok's private copy. Bare Codex `<skill>` wrappers become labeled skill blocks. Archive schema bumps to v7 so stored blobs rebuild from native sources.

## Depends on

- #282 (TUI colors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Session history now excludes machine-injected envelopes while preserving genuine user messages and assistant responses.
  * Codex skill wrappers appear as labeled skill blocks; incomplete wrappers remain regular user messages.
  * Added recognition for sessions from additional AI providers.
  * Improved chat history and turn tracking accuracy.

* **Documentation**
  * Clarified how local session files, archives, and recovery from stale or missing archive data work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->